### PR TITLE
polish: add agent registry

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,9 +1,9 @@
 mod operations;
 
-pub use operations::{AgentOperations, CodingAgent};
+pub use operations::{AgentOperations, AgentRegistry, CodingAgent, RealAgentRegistry};
 
 #[cfg(feature = "test-mocks")]
-pub use operations::MockAgentOperations;
+pub use operations::{MockAgentOperations, MockAgentRegistry};
 
 use serde::{Deserialize, Serialize};
 

--- a/src/agent/operations.rs
+++ b/src/agent/operations.rs
@@ -4,7 +4,9 @@
 //! like Claude Code, Aider, Codex, etc.
 
 use anyhow::Result;
+use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
 
 #[cfg(feature = "test-mocks")]
 use mockall::automock;
@@ -21,6 +23,9 @@ pub trait AgentOperations: Send + Sync {
     /// Get the co-author string for git commits
     /// e.g., "Claude <noreply@anthropic.com>"
     fn co_author_string(&self) -> &str;
+
+    /// Build the shell command to start the agent interactively with a prompt
+    fn build_interactive_command(&self, prompt: &str) -> String;
 }
 
 /// Generic agent implementation that works with any Agent config
@@ -70,5 +75,66 @@ impl AgentOperations for CodingAgent {
 
     fn co_author_string(&self) -> &str {
         &self.agent.co_author
+    }
+
+    fn build_interactive_command(&self, prompt: &str) -> String {
+        self.agent.build_interactive_command(prompt)
+    }
+}
+
+/// Registry that maps agent names to AgentOperations instances.
+/// Enables per-stage agent selection (e.g., different agents for planning, running, review).
+#[cfg_attr(feature = "test-mocks", automock)]
+pub trait AgentRegistry: Send + Sync {
+    /// Get the AgentOperations instance for a given agent name.
+    /// Falls back to the default agent if the name is unknown or unavailable.
+    fn get(&self, agent_name: &str) -> Arc<dyn AgentOperations>;
+}
+
+/// Production implementation of AgentRegistry.
+/// Holds all available agents, keyed by name.
+pub struct RealAgentRegistry {
+    agents: HashMap<String, Arc<dyn AgentOperations>>,
+    default_name: String,
+}
+
+impl RealAgentRegistry {
+    /// Create a new registry populated with all available agents.
+    /// `default_name` is used as the fallback when a requested name isn't found.
+    pub fn new(default_name: &str) -> Self {
+        let mut agents: HashMap<String, Arc<dyn AgentOperations>> = HashMap::new();
+
+        for agent in super::known_agents() {
+            if agent.is_available() {
+                let name = agent.name.clone();
+                agents.insert(name, Arc::new(CodingAgent::new(agent)));
+            }
+        }
+
+        // Ensure we have the default agent even if not detected as available
+        if !agents.contains_key(default_name) {
+            if let Some(agent) = super::get_agent(default_name) {
+                agents.insert(default_name.to_string(), Arc::new(CodingAgent::new(agent)));
+            }
+        }
+
+        Self {
+            agents,
+            default_name: default_name.to_string(),
+        }
+    }
+}
+
+impl AgentRegistry for RealAgentRegistry {
+    fn get(&self, agent_name: &str) -> Arc<dyn AgentOperations> {
+        self.agents
+            .get(agent_name)
+            .cloned()
+            .unwrap_or_else(|| {
+                self.agents
+                    .get(&self.default_name)
+                    .cloned()
+                    .expect("Default agent must exist in registry")
+            })
     }
 }

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -1323,6 +1323,7 @@ fn test_setup_task_worktree_success() {
 
     let mut mock_tmux = MockTmuxOperations::new();
     let mut mock_git = MockGitOperations::new();
+    let mut mock_agent = MockAgentOperations::new();
 
     // Expect worktree creation
     mock_git
@@ -1333,6 +1334,11 @@ fn test_setup_task_worktree_success() {
     mock_git
         .expect_initialize_worktree()
         .returning(|_, _, _, _| vec![]);
+
+    // Expect agent command building
+    mock_agent
+        .expect_build_interactive_command()
+        .returning(|prompt| format!("claude --dangerously-skip-permissions '{}'", prompt));
 
     // Expect tmux session check and window creation
     mock_tmux
@@ -1355,6 +1361,7 @@ fn test_setup_task_worktree_success() {
         None,
         &mock_tmux,
         &mock_git,
+        &mock_agent,
     );
 
     assert!(result.is_ok());
@@ -1374,6 +1381,7 @@ fn test_setup_task_worktree_sets_task_fields() {
 
     let mut mock_tmux = MockTmuxOperations::new();
     let mut mock_git = MockGitOperations::new();
+    let mut mock_agent = MockAgentOperations::new();
 
     mock_git
         .expect_create_worktree()
@@ -1381,6 +1389,9 @@ fn test_setup_task_worktree_sets_task_fields() {
     mock_git
         .expect_initialize_worktree()
         .returning(|_, _, _, _| vec![]);
+    mock_agent
+        .expect_build_interactive_command()
+        .returning(|prompt| format!("claude '{}'", prompt));
     mock_tmux.expect_has_session().returning(|_| true);
     mock_tmux.expect_create_window().returning(|_, _, _, _| Ok(()));
 
@@ -1395,6 +1406,7 @@ fn test_setup_task_worktree_sets_task_fields() {
         Some("./init.sh".to_string()),
         &mock_tmux,
         &mock_git,
+        &mock_agent,
     ).unwrap();
 
     // session_name should be the returned target
@@ -1414,6 +1426,7 @@ fn test_setup_task_worktree_worktree_creation_fails() {
 
     let mut mock_tmux = MockTmuxOperations::new();
     let mut mock_git = MockGitOperations::new();
+    let mut mock_agent = MockAgentOperations::new();
 
     // Worktree creation fails
     mock_git
@@ -1424,6 +1437,9 @@ fn test_setup_task_worktree_worktree_creation_fails() {
     mock_git
         .expect_initialize_worktree()
         .returning(|_, _, _, _| vec![]);
+    mock_agent
+        .expect_build_interactive_command()
+        .returning(|prompt| format!("claude '{}'", prompt));
     mock_tmux.expect_has_session().returning(|_| true);
     mock_tmux.expect_create_window().returning(|_, _, _, _| Ok(()));
 
@@ -1438,6 +1454,7 @@ fn test_setup_task_worktree_worktree_creation_fails() {
         None,
         &mock_tmux,
         &mock_git,
+        &mock_agent,
     );
 
     // Should succeed despite worktree creation failure (uses fallback path)
@@ -1454,6 +1471,7 @@ fn test_setup_task_worktree_tmux_window_fails() {
 
     let mut mock_tmux = MockTmuxOperations::new();
     let mut mock_git = MockGitOperations::new();
+    let mut mock_agent = MockAgentOperations::new();
 
     mock_git
         .expect_create_worktree()
@@ -1461,6 +1479,9 @@ fn test_setup_task_worktree_tmux_window_fails() {
     mock_git
         .expect_initialize_worktree()
         .returning(|_, _, _, _| vec![]);
+    mock_agent
+        .expect_build_interactive_command()
+        .returning(|prompt| format!("claude '{}'", prompt));
     mock_tmux.expect_has_session().returning(|_| true);
 
     // Tmux window creation fails
@@ -1479,6 +1500,7 @@ fn test_setup_task_worktree_tmux_window_fails() {
         None,
         &mock_tmux,
         &mock_git,
+        &mock_agent,
     );
 
     // Should propagate the error
@@ -1494,6 +1516,7 @@ fn test_setup_task_worktree_creates_session_when_missing() {
 
     let mut mock_tmux = MockTmuxOperations::new();
     let mut mock_git = MockGitOperations::new();
+    let mut mock_agent = MockAgentOperations::new();
 
     mock_git
         .expect_create_worktree()
@@ -1501,6 +1524,9 @@ fn test_setup_task_worktree_creates_session_when_missing() {
     mock_git
         .expect_initialize_worktree()
         .returning(|_, _, _, _| vec![]);
+    mock_agent
+        .expect_build_interactive_command()
+        .returning(|prompt| format!("claude '{}'", prompt));
 
     // Session doesn't exist yet
     mock_tmux
@@ -1524,6 +1550,7 @@ fn test_setup_task_worktree_creates_session_when_missing() {
         None,
         &mock_tmux,
         &mock_git,
+        &mock_agent,
     );
 
     assert!(result.is_ok());
@@ -1537,6 +1564,7 @@ fn test_setup_task_worktree_passes_init_config() {
 
     let mut mock_tmux = MockTmuxOperations::new();
     let mut mock_git = MockGitOperations::new();
+    let mut mock_agent = MockAgentOperations::new();
 
     mock_git
         .expect_create_worktree()
@@ -1551,6 +1579,9 @@ fn test_setup_task_worktree_passes_init_config() {
         })
         .returning(|_, _, _, _| vec!["warning: .env not found".to_string()]);
 
+    mock_agent
+        .expect_build_interactive_command()
+        .returning(|prompt| format!("claude '{}'", prompt));
     mock_tmux.expect_has_session().returning(|_| true);
     mock_tmux.expect_create_window().returning(|_, _, _, _| Ok(()));
 
@@ -1565,6 +1596,7 @@ fn test_setup_task_worktree_passes_init_config() {
         Some("./setup.sh".to_string()),
         &mock_tmux,
         &mock_git,
+        &mock_agent,
     );
 
     assert!(result.is_ok());


### PR DESCRIPTION
## Changes

  `src/agent/operations.rs` — New trait + implementation:
  - AgentRegistry trait with fn get(&self, agent_name: &str) -> Arc<dyn AgentOperations> (mockall-compatible)
  - RealAgentRegistry struct — holds a HashMap<String, Arc<dyn AgentOperations>> of all available agents, falls back to default name for unknown lookups

  `src/agent/mod.rs` — Exports AgentRegistry, RealAgentRegistry, MockAgentRegistry

  src/tui/app.rs — Replaced single agent with registry:
  - AppState.agent_ops → AppState.agent_registry
  - App::new() creates RealAgentRegistry::new("claude")
  - App::with_ops() accepts Arc<dyn AgentRegistry>
  - All 5 call sites resolve via agent_registry.get(&config.default_agent) — ready to be switched to per-stage config keys later

  `tests/mock_infrastructure_tests.rs` — Added test_agent_registry_mock test

##  What this enables

  When you add per-stage config fields later (planning_agent, running_agent, review_agent), each call site just needs to change from config.default_agent to
   the appropriate stage-specific config key. The infrastructure is ready.