### PR TITLE
feat: add plugin framework with builtin gsd and spec-kit

### DIFF
--- a/plugins/gsd/plugin.toml
+++ b/plugins/gsd/plugin.toml
@@ -1,0 +1,25 @@
+name = "gsd"
+description = "Get Shit Done - structured spec-driven development framework"
+init_script = "npx get-shit-done-cc@latest --{agent} --local --non-interactive"
+supported_agents = ["claude", "codex", "gemini", "opencode"]
+
+[artifacts]
+research = ".planning/ROADMAP.md"
+planning = ".planning/1/1-PLAN.md"
+running = ".planning/1/1-SUMMARY.md"
+review = ".planning/1/UAT.md"
+
+[commands]
+research = "/gsd:new-project"
+planning = "/gsd:plan-phase 1"
+running = "/gsd:execute-phase 1"
+review = "/gsd:verify-work 1"
+
+[prompts]
+research = "Task: {task}"
+planning = ""
+running = ""
+review = ""
+
+[prompt_triggers]
+research = "What do you want to build?"

--- a/plugins/spec-kit/plugin.toml
+++ b/plugins/spec-kit/plugin.toml
@@ -1,0 +1,24 @@
+name = "spec-kit"
+description = "Spec-Driven Development by GitHub - specifications become executable artifacts"
+# No init_script — spec-kit must be installed in the project root first (specify init).
+# The .claude/ directory (containing spec-kit commands) is copied to worktrees automatically.
+copy_dirs = [".specify"]
+
+# Artifact files that signal phase completion.
+# Paths with * match any single directory level (e.g. specs/{branch-name}/plan.md).
+# Omitted phases fall back to agtx defaults (.agtx/execute.md, .agtx/review.md).
+[artifacts]
+research = "specs/*/spec.md"
+planning = "specs/*/plan.md"
+
+[commands]
+research = "/speckit.specify {task}"
+planning = "/speckit.plan {task}"
+running = "/speckit.implement"
+review = "/speckit.analyze"
+
+[prompts]
+research = ""
+planning = ""
+running = ""
+review = ""

--- a/plugins/void/plugin.toml
+++ b/plugins/void/plugin.toml
@@ -1,0 +1,14 @@
+name = "void"
+description = "Plain coding agent session without any prompting or skills"
+
+[commands]
+research = ""
+planning = ""
+running = ""
+review = ""
+
+[prompts]
+research = ""
+planning = ""
+running = ""
+review = ""

--- a/skills/execute.md
+++ b/skills/execute.md
@@ -1,0 +1,32 @@
+---
+name: agtx-execute
+description: Execute an approved implementation plan. Implement the changes, then write a summary to .agtx/execute.md and stop.
+---
+
+# Execution Phase
+
+You are in the **execution phase** of an agtx-managed task. Your plan has been approved.
+
+## Instructions
+
+1. Read your plan from `.agtx/plan.md`
+2. Implement the changes described in the plan
+3. Run relevant tests to verify your changes
+4. Fix any issues found during testing
+
+## Output
+
+When implementation is complete, write a summary to `.agtx/execute.md` with these sections:
+
+## Changes
+What files were modified/created and what was changed in each.
+
+## Testing
+How you verified the changes — tests run, results, manual checks.
+
+## CRITICAL: Stop After Writing
+
+After writing `.agtx/execute.md`:
+- Do NOT start new work beyond the plan
+- Say: "Implementation complete. Summary written to `.agtx/execute.md`."
+- Wait for further instructions

--- a/skills/plan.md
+++ b/skills/plan.md
@@ -1,0 +1,36 @@
+---
+name: agtx-plan
+description: Plan a task implementation. Analyze the codebase, create a detailed plan, write it to .agtx/plan.md, then stop and wait for user approval before making any changes.
+---
+
+# Planning Phase
+
+You are in the **planning phase** of an agtx-managed task.
+
+## Instructions
+
+1. Read and understand the task description
+2. Explore the codebase to understand relevant files, patterns, and architecture
+3. Identify all files that need to be created or modified
+4. Create a detailed implementation plan
+
+## Output
+
+Write your plan to `.agtx/plan.md` with these sections:
+
+## Analysis
+What you found in the codebase — relevant files, patterns, dependencies.
+
+## Plan
+Step-by-step implementation plan — files to modify, approach, order of changes.
+
+## Risks
+What could go wrong — edge cases, breaking changes, areas needing extra care.
+
+## CRITICAL: Stop After Writing
+
+After writing `.agtx/plan.md`:
+- Do NOT start implementing
+- Do NOT modify any source files
+- Say: "Plan written to `.agtx/plan.md`. Waiting for approval."
+- Wait for explicit instructions to proceed

--- a/skills/research.md
+++ b/skills/research.md
@@ -1,0 +1,40 @@
+---
+name: agtx-research
+description: Explore the codebase to understand a task before planning. Write findings to .agtx/research/{task-id}.md and stop. This is a read-only exploration — do not modify any files.
+---
+
+# Research Phase
+
+You are in the **research phase** of an agtx-managed task. This is a read-only exploration.
+
+## Instructions
+
+1. Read and understand the task description
+2. Explore the codebase to find relevant files, patterns, and architecture
+3. Identify dependencies, related code, and potential complexity
+4. Assess feasibility and estimate scope
+
+## Output
+
+Write your findings to the research artifact path provided in the task prompt. Include:
+
+## Relevant Files
+Key files and their roles — what exists, what needs changing.
+
+## Architecture
+How the relevant parts of the codebase fit together.
+
+## Complexity
+Assessment of scope — simple change, moderate refactor, or major undertaking.
+
+## Open Questions
+Things that need clarification before planning can begin.
+
+## CRITICAL: Do Not Modify Code
+
+This is a **read-only** exploration:
+- Do NOT modify any source files
+- Do NOT create branches or worktrees
+- Do NOT start planning or implementing
+- Say: "Research complete. Findings written to {artifact_path}."
+- Wait for further instructions

--- a/skills/review.md
+++ b/skills/review.md
@@ -1,0 +1,35 @@
+---
+name: agtx-review
+description: Self-review completed work. Check for correctness, edge cases, and code quality. Write review to .agtx/review.md and stop.
+---
+
+# Review Phase
+
+You are in the **review phase** of an agtx-managed task.
+
+## Instructions
+
+1. Review all changes made during execution (use git diff)
+2. Check for:
+   - Correctness and edge cases
+   - Error handling
+   - Code style consistency with the existing codebase
+   - Test coverage
+   - Security issues (injection, XSS, etc.)
+3. Fix any issues you find
+
+## Output
+
+Write your review to `.agtx/review.md` with these sections:
+
+## Review
+Findings from your review — what looks good, what was fixed, any concerns.
+
+## Status
+Either `READY` (good to merge) or `NEEDS_WORK` (with explanation of remaining issues).
+
+## CRITICAL: Stop After Writing
+
+After writing `.agtx/review.md`:
+- Say: "Review written to `.agtx/review.md`."
+- Wait for further instructions

--- a/src/agent/operations.rs
+++ b/src/agent/operations.rs
@@ -24,7 +24,8 @@ pub trait AgentOperations: Send + Sync {
     /// e.g., "Claude <noreply@anthropic.com>"
     fn co_author_string(&self) -> &str;
 
-    /// Build the shell command to start the agent interactively with a prompt
+    /// Build the shell command to start the agent interactively.
+    /// When prompt is empty, the agent starts with no initial message.
     fn build_interactive_command(&self, prompt: &str) -> String;
 }
 

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -58,6 +58,7 @@ pub struct Task {
     pub branch_name: Option<String>,
     pub pr_number: Option<i32>,
     pub pr_url: Option<String>,
+    pub plugin: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -78,6 +79,7 @@ impl Task {
             branch_name: None,
             pr_number: None,
             pr_url: None,
+            plugin: None,
             created_at: now,
             updated_at: now,
         }
@@ -148,4 +150,15 @@ impl AgentStatus {
             AgentStatus::Completed => "completed",
         }
     }
+}
+
+/// Phase completion status (runtime-only, not persisted to DB)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhaseStatus {
+    /// Agent is still working, no artifact yet
+    Working,
+    /// Phase artifact detected, ready to advance
+    Ready,
+    /// Tmux window gone (process exited)
+    Exited,
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -81,6 +81,7 @@ impl Database {
                 branch_name TEXT,
                 pr_number INTEGER,
                 pr_url TEXT,
+                plugin TEXT,
                 created_at TEXT NOT NULL,
                 updated_at TEXT NOT NULL
             );
@@ -94,6 +95,7 @@ impl Database {
         let _ = self.conn.execute("ALTER TABLE tasks ADD COLUMN branch_name TEXT", []);
         let _ = self.conn.execute("ALTER TABLE tasks ADD COLUMN pr_number INTEGER", []);
         let _ = self.conn.execute("ALTER TABLE tasks ADD COLUMN pr_url TEXT", []);
+        let _ = self.conn.execute("ALTER TABLE tasks ADD COLUMN plugin TEXT", []);
 
         Ok(())
     }
@@ -131,8 +133,8 @@ impl Database {
     pub fn create_task(&self, task: &Task) -> Result<()> {
         self.conn.execute(
             r#"
-            INSERT INTO tasks (id, title, description, status, agent, project_id, session_name, worktree_path, branch_name, pr_number, pr_url, created_at, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            INSERT INTO tasks (id, title, description, status, agent, project_id, session_name, worktree_path, branch_name, pr_number, pr_url, plugin, created_at, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
             "#,
             params![
                 task.id,
@@ -146,6 +148,7 @@ impl Database {
                 task.branch_name,
                 task.pr_number,
                 task.pr_url,
+                task.plugin,
                 task.created_at.to_rfc3339(),
                 task.updated_at.to_rfc3339(),
             ],
@@ -166,7 +169,8 @@ impl Database {
                 branch_name = ?8,
                 pr_number = ?9,
                 pr_url = ?10,
-                updated_at = ?11
+                plugin = ?11,
+                updated_at = ?12
             WHERE id = ?1
             "#,
             params![
@@ -180,6 +184,7 @@ impl Database {
                 task.branch_name,
                 task.pr_number,
                 task.pr_url,
+                task.plugin,
                 task.updated_at.to_rfc3339(),
             ],
         )?;
@@ -206,6 +211,7 @@ impl Database {
             branch_name: row.get("branch_name").ok().flatten(),
             pr_number: row.get("pr_number").ok().flatten(),
             pr_url: row.get("pr_url").ok().flatten(),
+            plugin: row.get("plugin").ok().flatten(),
             created_at: chrono::DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at")?)
                 .map(|dt| dt.with_timezone(&chrono::Utc))
                 .unwrap_or_else(|_| chrono::Utc::now()),

--- a/src/git/operations.rs
+++ b/src/git/operations.rs
@@ -59,6 +59,7 @@ pub trait GitOperations: Send + Sync {
         worktree_path: &Path,
         copy_files: Option<String>,
         init_script: Option<String>,
+        copy_dirs: Vec<String>,
     ) -> Vec<String>;
 }
 
@@ -209,7 +210,8 @@ impl GitOperations for RealGitOps {
         worktree_path: &Path,
         copy_files: Option<String>,
         init_script: Option<String>,
+        copy_dirs: Vec<String>,
     ) -> Vec<String> {
-        super::initialize_worktree(project_path, worktree_path, copy_files.as_deref(), init_script.as_deref())
+        super::initialize_worktree(project_path, worktree_path, copy_files.as_deref(), init_script.as_deref(), &copy_dirs)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod config;
 pub mod db;
 pub mod git;
+pub mod skills;
 pub mod tmux;
 pub mod tui;
 

--- a/src/tmux/operations.rs
+++ b/src/tmux/operations.rs
@@ -65,7 +65,9 @@ impl TmuxOperations for RealTmuxOps {
             .args(["-c", working_dir]);
 
         if let Some(ref shell_cmd) = command {
-            cmd.args(["sh", "-c", shell_cmd]);
+            // Wrap command so it drops to a shell after the agent exits
+            let wrapped = format!("{}; exec $SHELL", shell_cmd);
+            cmd.args(["sh", "-c", &wrapped]);
         }
 
         let output = cmd.output()?;

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -107,6 +107,7 @@ fn test_merged_config_project_overrides() {
         github_url: Some("https://github.com/user/repo".to_string()),
         copy_files: Some(".env, .env.local".to_string()),
         init_script: Some("npm install".to_string()),
+        workflow_plugin: None,
     };
 
     let merged = MergedConfig::merge(&global, &project);


### PR DESCRIPTION
### Summary

  - Optimize phase status polling by removing per-task window_exists tmux subprocess calls
  - Fix slow git diff popup by filtering copied directories (.claude/, .specify/, etc.) from untracked file iteration
  - Add workflow plugin system: header display, void plugin, per-task plugin persistence
  - Prefill task content in agent input buffer for void plugin sessions
  - Add plugin documentation to README with creation guide

### Changes

#### Performance
  - Remove window_exists tmux check from refresh_sessions() polling loop — eliminates N subprocess spawns per tick
  - Filter agent config dirs and plugin copy_dirs from collect_task_diff() untracked file list — prevents N git diff --no-index calls for copied directories

  #### Plugin system
  - Show active plugin name in header bar (agtx [P] Plugins by default)
  - Add void plugin — plain agent session with no commands or prompts, task content prefilled in input via send_keys_literal
  - Handle empty command/prompt strings: resolve_skill_command returns None, resolve_prompt returns empty, callers guard with !msg.is_empty()
  - Persist plugin per task (task.plugin field in DB) — tasks keep the plugin they were started with, unaffected by later plugin switches
  - Replace global effective_plugin() with per-task load_task_plugin() across all phase transitions and artifact detection
  - Cache plugin lookups in refresh_sessions() via HashMap<Option<String>, Option<WorkflowPlugin>>

  #### Documentation
  - Add workflow plugins section to README: plugin table, agent compatibility matrix
  - Add "Creating a Plugin" guide with minimal example, full field reference, phase transition flow, and custom skills