### PR TITLE
feat: improve task creation wizard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,10 +217,25 @@ color_popup_header = "#69fae7"  # Popup headers (light cyan)
 | `Ctrl+s` | Create PR and move to Review |
 | `Esc` | Cancel |
 
+### Task Creation Wizard
+The wizard flow is: **Title → Plugin → Prompt** (plugin step auto-skipped if ≤1 option or no agents detected).
+
+| Key | Action |
+|-----|--------|
+| `j/k` or arrows | Navigate plugin list |
+| `Tab` | Cycle through options |
+| `Enter` | Advance to next step / save |
+| `Esc` | Cancel wizard |
+
+Agent is determined by `config.default_agent` (set via config file), not selected per-task.
+Plugin defaults to the project's active plugin (set via `P` on the board).
+
 ### Task Edit (Description)
 | Key | Action |
 |-----|--------|
 | `#` or `@` | Start file search (fuzzy find) |
+| `/` | Start skill search (at start of line or after space) |
+| `!` | Start task reference search (at start of line or after space) |
 | `\` + Enter | Line continuation (multi-line) |
 | Arrow keys | Move cursor |
 | `Alt+Left/Right` or `Alt+b/f` | Word-by-word navigation |
@@ -247,14 +262,27 @@ color_popup_header = "#69fae7"  # Popup headers (light cyan)
 ### Background Operations
 - PR description generation runs in background thread
 - PR creation runs in background thread
-- Uses `mpsc` channels to communicate results back to main thread
+- Phase status polling runs in background thread (`maybe_spawn_session_refresh`)
+- Uses `mpsc` channels to communicate results back to main thread via `try_recv()` (non-blocking)
 - Loading spinners shown during async operations
 
 ### Phase Status Polling
-- `refresh_sessions()` runs every 100ms, checks artifact files with 2-second cache TTL
+- `maybe_spawn_session_refresh()` spawns a background thread with 2-second cache TTL per task
+- Overlap guard: only one refresh thread runs at a time (`session_refresh_rx.is_some()`)
+- Thread does all expensive work: plugin TOML loading, artifact file checks, `tmux capture-pane`, copy-back side effects
+- `apply_session_refresh()` applies results on main thread (non-blocking `try_recv`)
+- Idle detection (Working → Idle) handled on main thread using `pane_content_hashes` timestamps
 - Four states: Working (spinner), Idle (pause icon, 15s no output), Ready (checkmark), Exited (no window)
 - Phase artifact paths come from the task's plugin or agtx defaults
 - Plugin instances cached per task in `HashMap<Option<String>, Option<WorkflowPlugin>>` to avoid repeated disk reads
+
+### Task References
+- In description input, type `!` (at start of line or after space) to search existing tasks
+- Selecting a task inserts `![task-title]` and tracks the reference ID
+- Referenced task IDs stored as comma-separated string in `task.referenced_tasks`
+- At worktree setup, referenced tasks' artifacts are copied to `.agtx/references/`:
+  - Git diffs (`{slug}.diff`) from `git diff main..{branch}`
+  - Worktree files (`.agtx/skills/`, `.planning/`) if the referenced worktree still exists
 
 ### Agent Integration
 - Agents spawned via `build_interactive_command()` in `src/agent/mod.rs`

--- a/README.md
+++ b/README.md
@@ -91,14 +91,24 @@ agtx -g
 | `e` | Toggle project sidebar |
 | `q` | Quit |
 
+### Task Creation Wizard
+
+Press `o` to create a new task. The wizard guides you through:
+1. **Title** — enter a short task name
+2. **Plugin** — select a workflow plugin (auto-skipped if only one option)
+3. **Prompt** — write a detailed task description with inline references
+
+The agent is configured at the project level via `config.toml` (not per-task).
+
 ### Task Description Editor
 
-When writing a task description, you can reference files and agent skills inline:
+When writing a task description, you can reference files, skills, and other tasks inline:
 
 | Key | Action |
 |-----|--------|
 | `#` or `@` | Fuzzy search and insert a file path |
-| `!` | Fuzzy search and insert an agent skill/command |
+| `/` | Fuzzy search and insert an agent skill/command (at line start or after space) |
+| `!` | Fuzzy search and insert a task reference (at line start or after space) |
 
 
 ### Agent Session Features

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -70,6 +70,7 @@ pub struct Task {
     pub pr_url: Option<String>,
     pub plugin: Option<String>,
     pub cycle: i32,
+    pub referenced_tasks: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -92,6 +93,7 @@ impl Task {
             pr_url: None,
             plugin: None,
             cycle: 1,
+            referenced_tasks: None,
             created_at: now,
             updated_at: now,
         }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -115,6 +115,7 @@ impl Database {
         let _ = self.conn.execute("ALTER TABLE tasks ADD COLUMN pr_url TEXT", []);
         let _ = self.conn.execute("ALTER TABLE tasks ADD COLUMN plugin TEXT", []);
         let _ = self.conn.execute("ALTER TABLE tasks ADD COLUMN cycle INTEGER NOT NULL DEFAULT 1", []);
+        let _ = self.conn.execute("ALTER TABLE tasks ADD COLUMN referenced_tasks TEXT", []);
 
         Ok(())
     }
@@ -152,8 +153,8 @@ impl Database {
     pub fn create_task(&self, task: &Task) -> Result<()> {
         self.conn.execute(
             r#"
-            INSERT INTO tasks (id, title, description, status, agent, project_id, session_name, worktree_path, branch_name, pr_number, pr_url, plugin, cycle, created_at, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+            INSERT INTO tasks (id, title, description, status, agent, project_id, session_name, worktree_path, branch_name, pr_number, pr_url, plugin, cycle, referenced_tasks, created_at, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
             "#,
             params![
                 task.id,
@@ -169,6 +170,7 @@ impl Database {
                 task.pr_url,
                 task.plugin,
                 task.cycle,
+                task.referenced_tasks,
                 task.created_at.to_rfc3339(),
                 task.updated_at.to_rfc3339(),
             ],
@@ -191,7 +193,8 @@ impl Database {
                 pr_url = ?10,
                 plugin = ?11,
                 cycle = ?12,
-                updated_at = ?13
+                referenced_tasks = ?13,
+                updated_at = ?14
             WHERE id = ?1
             "#,
             params![
@@ -207,6 +210,7 @@ impl Database {
                 task.pr_url,
                 task.plugin,
                 task.cycle,
+                task.referenced_tasks,
                 task.updated_at.to_rfc3339(),
             ],
         )?;
@@ -235,6 +239,7 @@ impl Database {
             pr_url: row.get("pr_url").ok().flatten(),
             plugin: row.get("plugin").ok().flatten(),
             cycle: row.get("cycle").unwrap_or(1),
+            referenced_tasks: row.get("referenced_tasks").ok().flatten(),
             created_at: chrono::DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at")?)
                 .map(|dt| dt.with_timezone(&chrono::Utc))
                 .unwrap_or_else(|_| chrono::Utc::now()),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -48,7 +48,8 @@ fn build_footer_text(input_mode: InputMode, sidebar_focused: bool, selected_colu
             }
         }
         InputMode::InputTitle => " Enter task title... [Esc] cancel [Enter] next ".to_string(),
-        InputMode::InputDescription => " Enter prompt for agent... [#] file search [!] skills [Esc] cancel [\\+Enter] newline [Enter] save ".to_string(),
+        InputMode::SelectPlugin => " [j/k] select plugin  [Tab] cycle  [Enter] next  [Esc] cancel ".to_string(),
+        InputMode::InputDescription => " [#] files  [/] skills  [!] tasks  [Esc] cancel  [\\+Enter] newline  [Enter] save ".to_string(),
     }
 }
 
@@ -162,9 +163,12 @@ struct AppState {
     input_mode: InputMode,
     input_buffer: String,
     input_cursor: usize, // Cursor position in input_buffer
-    // For task creation/editing
+    // For task creation/editing wizard
     pending_task_title: String,
     editing_task_id: Option<String>, // Some(id) when editing, None when creating
+    wizard_selected_plugin: usize,
+    wizard_plugin_options: Vec<PluginOption>,
+    wizard_referenced_task_ids: HashSet<String>,
     db: Option<Database>,
     #[allow(dead_code)]
     global_db: Database,
@@ -193,7 +197,9 @@ struct AppState {
     file_search: Option<FileSearchState>,
     // Skill search dropdown
     skill_search: Option<SkillSearchState>,
-    // References inserted via file search or skill search (for highlighting)
+    // Task reference search dropdown
+    task_ref_search: Option<TaskRefSearchState>,
+    // References inserted via file search, skill search, or task search (for highlighting)
     highlighted_references: HashSet<String>,
     // Task search popup
     task_search: Option<TaskSearchState>,
@@ -231,6 +237,8 @@ struct AppState {
     warning_message: Option<(String, Instant)>,
     // Plugin selection popup
     plugin_select_popup: Option<PluginSelectPopup>,
+    // Background session refresh channel (non-blocking phase status polling)
+    session_refresh_rx: Option<mpsc::Receiver<SessionRefreshResult>>,
 }
 
 /// State for confirming move to Done
@@ -268,6 +276,27 @@ struct SetupResult {
     agent: String,
     plugin: Option<String>,
     error: Option<String>,
+}
+
+/// Pre-fetched info about a referenced task for worktree setup (avoids DB access in thread).
+#[derive(Debug, Clone)]
+struct ReferencedTaskInfo {
+    slug: String,
+    branch_name: Option<String>,
+    worktree_path: Option<String>,
+}
+
+/// Per-task result from the background session refresh thread.
+struct SessionTaskStatus {
+    task_id: String,
+    phase_status: PhaseStatus,
+    /// Content hash from tmux capture (for idle detection on main thread).
+    content_hash: Option<u64>,
+}
+
+/// Results sent back from the background session refresh thread.
+struct SessionRefreshResult {
+    statuses: Vec<SessionTaskStatus>,
 }
 
 /// State for PR creation status popup (loading/success/error)
@@ -336,12 +365,21 @@ struct SkillEntry {
     description: String,  // from frontmatter or file stem
 }
 
-/// State for skill search dropdown (triggered by `!`)
+/// State for skill search dropdown (triggered by `/`)
 #[derive(Debug, Clone)]
 struct SkillSearchState {
     pattern: String,
     matches: Vec<SkillEntry>,
     all_skills: Vec<SkillEntry>, // cached full list for re-filtering
+    selected: usize,
+    start_pos: usize, // cursor position where `/` was typed
+}
+
+/// State for task reference search dropdown (triggered by `!`)
+#[derive(Debug, Clone)]
+struct TaskRefSearchState {
+    pattern: String,
+    matches: Vec<(String, String, TaskStatus)>, // (id, title, status)
     selected: usize,
     start_pos: usize, // cursor position where `!` was typed
 }
@@ -449,6 +487,9 @@ impl App {
                 input_cursor: 0,
                 pending_task_title: String::new(),
                 editing_task_id: None,
+                wizard_selected_plugin: 0,
+                wizard_plugin_options: vec![],
+                wizard_referenced_task_ids: HashSet::new(),
                 db,
                 global_db,
                 config,
@@ -467,6 +508,7 @@ impl App {
                 shell_popup: None,
                 file_search: None,
                 skill_search: None,
+                task_ref_search: None,
                 highlighted_references: HashSet::new(),
                 task_search: None,
                 pr_confirm_popup: None,
@@ -487,6 +529,7 @@ impl App {
                 cached_plugin: None,
                 warning_message: None,
                 plugin_select_popup: None,
+                session_refresh_rx: None,
             },
         };
 
@@ -543,6 +586,9 @@ impl App {
                 input_cursor: 0,
                 pending_task_title: String::new(),
                 editing_task_id: None,
+                wizard_selected_plugin: 0,
+                wizard_plugin_options: vec![],
+                wizard_referenced_task_ids: HashSet::new(),
                 db,
                 global_db,
                 config,
@@ -561,6 +607,7 @@ impl App {
                 shell_popup: None,
                 file_search: None,
                 skill_search: None,
+                task_ref_search: None,
                 highlighted_references: HashSet::new(),
                 task_search: None,
                 pr_confirm_popup: None,
@@ -581,6 +628,7 @@ impl App {
                 cached_plugin: None,
                 warning_message: None,
                 plugin_select_popup: None,
+                session_refresh_rx: None,
             },
         })
     }
@@ -665,8 +713,22 @@ impl App {
                 popup.cached_content = capture_tmux_pane_with_history(&popup.window_name, 500, self.state.tmux_ops.as_ref());
             }
 
-            // Periodically refresh session status
-            self.refresh_sessions()?;
+            // Apply results from background session refresh (non-blocking)
+            if let Some(ref rx) = self.state.session_refresh_rx {
+                match rx.try_recv() {
+                    Ok(result) => {
+                        self.state.session_refresh_rx = None;
+                        self.apply_session_refresh(result);
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        // Thread panicked or dropped sender — clear to allow future spawns
+                        self.state.session_refresh_rx = None;
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                }
+            }
+            // Spawn background refresh if not already running and cache expired
+            self.maybe_spawn_session_refresh();
 
             // Clear expired warning messages
             if let Some((_, created)) = &self.state.warning_message {
@@ -889,167 +951,261 @@ impl App {
         frame.render_widget(footer, chunks[2]);
 
         // Input overlay if in input mode
-        if state.input_mode == InputMode::InputTitle || state.input_mode == InputMode::InputDescription {
-            let input_area = centered_rect(50, 40, area);
+        if matches!(state.input_mode, InputMode::InputTitle | InputMode::SelectPlugin | InputMode::InputDescription) {
+            let input_area = centered_rect(55, 55, area);
             frame.render_widget(Clear, input_area);
 
             let is_editing = state.editing_task_id.is_some();
-            let (title, label) = match state.input_mode {
-                InputMode::InputTitle => {
-                    if is_editing { (" Edit Task ", "Title: ") } else { (" New Task ", "Title: ") }
-                }
-                InputMode::InputDescription => {
-                    if is_editing { (" Edit Task ", "Prompt: ") } else { (" New Task ", "Prompt: ") }
-                }
-                _ => ("", ""),
-            };
-
-            // Show title if we're on description step
-            // Insert cursor (█) at the correct position
-            let (before_cursor, after_cursor) = state.input_buffer.split_at(
-                state.input_cursor.min(state.input_buffer.len())
-            );
+            let block_title = if is_editing { " Edit Task " } else { " New Task " };
             let text_color = hex_to_color(&state.config.theme.color_text);
             let highlight_color = hex_to_color(&state.config.theme.color_accent);
-            let full_text = if state.input_mode == InputMode::InputDescription {
-                format!(
-                    "Title: {}\n\n{}{}█{}",
-                    state.pending_task_title,
-                    label,
-                    before_cursor,
-                    after_cursor
-                )
-            } else {
-                format!("{}{}█{}", label, before_cursor, after_cursor)
-            };
+            let dimmed_color = hex_to_color(&state.config.theme.color_dimmed);
+            let selected_color = hex_to_color(&state.config.theme.color_selected);
+            let desc_color = hex_to_color(&state.config.theme.color_description);
 
-            let styled_text = if state.input_mode == InputMode::InputDescription && !state.highlighted_references.is_empty() {
-                build_highlighted_text(&full_text, &state.highlighted_references, text_color, highlight_color)
-            } else {
-                Text::raw(full_text)
+            // Determine current step index: Title=0, Plugin=1, Prompt=2
+            let step = match state.input_mode {
+                InputMode::InputTitle => 0,
+                InputMode::SelectPlugin => 1,
+                InputMode::InputDescription => 2,
+                _ => 0,
             };
+            let step_labels = ["Title", "Plugin", "Prompt"];
 
-            let input = Paragraph::new(styled_text)
+            let mut lines: Vec<Line> = Vec::new();
+
+            // Step indicator breadcrumb
+            let mut breadcrumb_spans: Vec<Span> = Vec::new();
+            breadcrumb_spans.push(Span::raw("  "));
+            for (i, label) in step_labels.iter().enumerate() {
+                let style = if i == step {
+                    Style::default().fg(selected_color).add_modifier(Modifier::BOLD)
+                } else if i < step {
+                    Style::default().fg(highlight_color)
+                } else {
+                    Style::default().fg(dimmed_color)
+                };
+                breadcrumb_spans.push(Span::styled(*label, style));
+                if i < step_labels.len() - 1 {
+                    breadcrumb_spans.push(Span::styled("  ›  ", Style::default().fg(dimmed_color)));
+                }
+            }
+            lines.push(Line::from(breadcrumb_spans));
+
+            // Separator
+            let inner_width = input_area.width.saturating_sub(4) as usize;
+            lines.push(Line::from(Span::styled(
+                format!("  {}", "─".repeat(inner_width.saturating_sub(2))),
+                Style::default().fg(dimmed_color),
+            )));
+            lines.push(Line::from(""));
+
+            // Completed fields shown as read-only context
+            if step >= 1 {
+                lines.push(Line::from(vec![
+                    Span::styled("  Title: ", Style::default().fg(dimmed_color)),
+                    Span::styled(&state.pending_task_title, Style::default().fg(text_color)),
+                ]));
+            }
+            if step >= 2 {
+                let plugin_name = state.wizard_plugin_options
+                    .get(state.wizard_selected_plugin)
+                    .map(|o| o.label.as_str())
+                    .unwrap_or("agtx");
+                lines.push(Line::from(vec![
+                    Span::styled("  Plugin: ", Style::default().fg(dimmed_color)),
+                    Span::styled(plugin_name, Style::default().fg(text_color)),
+                ]));
+            }
+            if step >= 1 { lines.push(Line::from("")); }
+
+            // Active area content
+            match state.input_mode {
+                InputMode::InputTitle => {
+                    let (before_cursor, after_cursor) = state.input_buffer.split_at(
+                        state.input_cursor.min(state.input_buffer.len())
+                    );
+                    lines.push(Line::from(vec![
+                        Span::styled("  Title: ", Style::default().fg(selected_color).add_modifier(Modifier::BOLD)),
+                        Span::styled(before_cursor, Style::default().fg(text_color)),
+                        Span::styled("█", Style::default().fg(selected_color)),
+                        Span::styled(after_cursor, Style::default().fg(text_color)),
+                    ]));
+                }
+                InputMode::SelectPlugin => {
+                    let active_plugin = state.config.workflow_plugin.as_deref().unwrap_or("");
+                    for (i, opt) in state.wizard_plugin_options.iter().enumerate() {
+                        let is_sel = i == state.wizard_selected_plugin;
+                        let marker = if is_sel { "  > " } else { "    " };
+                        let is_project_default = (opt.name.is_empty() && active_plugin.is_empty())
+                            || opt.name == active_plugin;
+                        let check = if is_project_default { " ✓" } else { "" };
+                        let name_style = if is_sel {
+                            Style::default().fg(selected_color).add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default().fg(text_color)
+                        };
+                        lines.push(Line::from(vec![
+                            Span::styled(marker, name_style),
+                            Span::styled(format!("{:<14}", &opt.label), name_style),
+                            Span::styled(&opt.description, Style::default().fg(desc_color)),
+                            Span::styled(check, Style::default().fg(Color::Green)),
+                        ]));
+                    }
+                }
+                InputMode::InputDescription => {
+                    let (before_cursor, after_cursor) = state.input_buffer.split_at(
+                        state.input_cursor.min(state.input_buffer.len())
+                    );
+                    let full_text = format!("  Prompt: {}█{}", before_cursor, after_cursor);
+                    // Split on newlines to handle multi-line descriptions
+                    for part in full_text.split('\n') {
+                        if !state.highlighted_references.is_empty() {
+                            let styled = build_highlighted_text(part, &state.highlighted_references, text_color, highlight_color);
+                            for line in styled.lines {
+                                let owned_spans: Vec<Span<'static>> = line.spans.into_iter()
+                                    .map(|s| Span::styled(s.content.into_owned(), s.style))
+                                    .collect();
+                                lines.push(Line::from(owned_spans));
+                            }
+                        } else {
+                            lines.push(Line::from(Span::styled(part.to_string(), Style::default().fg(text_color))));
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            let content = Paragraph::new(Text::from(lines))
                 .style(Style::default().fg(text_color))
                 .wrap(Wrap { trim: false })
                 .block(
                     Block::default()
-                        .title(title)
+                        .title(block_title)
                         .borders(Borders::ALL)
-                        .border_style(Style::default().fg(hex_to_color(&state.config.theme.color_selected))),
+                        .border_style(Style::default().fg(selected_color)),
                 );
-            frame.render_widget(input, input_area);
+            frame.render_widget(content, input_area);
 
-            // File search dropdown
-            if let Some(ref search) = state.file_search {
-                if !search.matches.is_empty() {
-                    let dropdown_height = (search.matches.len() as u16 + 2).min(12);
-                    let dropdown_area = Rect {
-                        x: input_area.x + 2,
-                        y: input_area.y + input_area.height,
-                        width: input_area.width.saturating_sub(4),
-                        height: dropdown_height,
-                    };
+            // Search dropdowns (only in InputDescription mode)
+            if state.input_mode == InputMode::InputDescription {
+                // File search dropdown
+                if let Some(ref search) = state.file_search {
+                    if !search.matches.is_empty() {
+                        let dropdown_height = (search.matches.len() as u16 + 2).min(12);
+                        let dropdown_area = Rect {
+                            x: input_area.x + 2,
+                            y: input_area.y + input_area.height,
+                            width: input_area.width.saturating_sub(4),
+                            height: dropdown_height,
+                        };
+                        let dropdown_area = if dropdown_area.y + dropdown_area.height > area.height {
+                            Rect { y: input_area.y.saturating_sub(dropdown_height), ..dropdown_area }
+                        } else { dropdown_area };
 
-                    // Make sure dropdown doesn't go off screen
-                    let dropdown_area = if dropdown_area.y + dropdown_area.height > area.height {
-                        Rect {
-                            y: input_area.y.saturating_sub(dropdown_height),
-                            ..dropdown_area
-                        }
-                    } else {
-                        dropdown_area
-                    };
-
-                    frame.render_widget(Clear, dropdown_area);
-
-                    let file_selected_color = hex_to_color(&state.config.theme.color_selected);
-                    let items: Vec<ListItem> = search.matches
-                        .iter()
-                        .enumerate()
-                        .map(|(i, path)| {
-                            let style = if i == search.selected {
-                                Style::default().bg(file_selected_color).fg(Color::Black)
-                            } else {
-                                Style::default().fg(Color::White)
-                            };
-                            ListItem::new(format!(" {} ", path)).style(style)
-                        })
-                        .collect();
-
-                    let list = List::new(items)
-                        .block(
+                        frame.render_widget(Clear, dropdown_area);
+                        let file_selected_color = hex_to_color(&state.config.theme.color_selected);
+                        let items: Vec<ListItem> = search.matches.iter().enumerate()
+                            .map(|(i, path)| {
+                                let style = if i == search.selected {
+                                    Style::default().bg(file_selected_color).fg(Color::Black)
+                                } else {
+                                    Style::default().fg(Color::White)
+                                };
+                                ListItem::new(format!(" {} ", path)).style(style)
+                            }).collect();
+                        let list = List::new(items).block(
                             Block::default()
                                 .title(" Files [↑↓] select [Tab/Enter] insert [Esc] cancel ")
                                 .borders(Borders::ALL)
                                 .border_style(Style::default().fg(Color::Cyan)),
                         );
-                    frame.render_widget(list, dropdown_area);
+                        frame.render_widget(list, dropdown_area);
+                    }
                 }
-            }
 
-            // Skill search dropdown
-            if let Some(ref search) = state.skill_search {
-                if !search.matches.is_empty() {
-                    let dropdown_height = (search.matches.len() as u16 + 2).min(12);
-                    let dropdown_area = Rect {
-                        x: input_area.x + 2,
-                        y: input_area.y + input_area.height,
-                        width: input_area.width.saturating_sub(4),
-                        height: dropdown_height,
-                    };
+                // Skill search dropdown
+                if let Some(ref search) = state.skill_search {
+                    if !search.matches.is_empty() {
+                        let dropdown_height = (search.matches.len() as u16 + 2).min(12);
+                        let dropdown_area = Rect {
+                            x: input_area.x + 2,
+                            y: input_area.y + input_area.height,
+                            width: input_area.width.saturating_sub(4),
+                            height: dropdown_height,
+                        };
+                        let dropdown_area = if dropdown_area.y + dropdown_area.height > area.height {
+                            Rect { y: input_area.y.saturating_sub(dropdown_height), ..dropdown_area }
+                        } else { dropdown_area };
 
-                    let dropdown_area = if dropdown_area.y + dropdown_area.height > area.height {
-                        Rect {
-                            y: input_area.y.saturating_sub(dropdown_height),
-                            ..dropdown_area
-                        }
-                    } else {
-                        dropdown_area
-                    };
-
-                    frame.render_widget(Clear, dropdown_area);
-
-                    let skill_selected_color = hex_to_color(&state.config.theme.color_selected);
-                    let accent_color = hex_to_color(&state.config.theme.color_accent);
-                    let dimmed_color = hex_to_color(&state.config.theme.color_dimmed);
-                    let items: Vec<ListItem> = search.matches
-                        .iter()
-                        .enumerate()
-                        .map(|(i, entry)| {
-                            let style = if i == search.selected {
-                                Style::default().bg(skill_selected_color).fg(Color::Black)
-                            } else {
-                                Style::default()
-                            };
-                            let cmd_style = if i == search.selected {
-                                Style::default().bg(skill_selected_color).fg(Color::Black)
-                            } else {
-                                Style::default().fg(accent_color)
-                            };
-                            let desc_style = if i == search.selected {
-                                Style::default().bg(skill_selected_color).fg(Color::Black)
-                            } else {
-                                Style::default().fg(dimmed_color)
-                            };
-                            // Pad command to align descriptions
-                            let cmd_padded = format!(" {:<24}", entry.command);
-                            let line = Line::from(vec![
-                                Span::styled(cmd_padded, cmd_style),
-                                Span::styled(&entry.description, desc_style),
-                            ]);
-                            ListItem::new(line).style(style)
-                        })
-                        .collect();
-
-                    let list = List::new(items)
-                        .block(
+                        frame.render_widget(Clear, dropdown_area);
+                        let skill_sel_color = hex_to_color(&state.config.theme.color_selected);
+                        let accent = hex_to_color(&state.config.theme.color_accent);
+                        let dim = hex_to_color(&state.config.theme.color_dimmed);
+                        let items: Vec<ListItem> = search.matches.iter().enumerate()
+                            .map(|(i, entry)| {
+                                let (style, cmd_style, dsc_style) = if i == search.selected {
+                                    let s = Style::default().bg(skill_sel_color).fg(Color::Black);
+                                    (s, s, s)
+                                } else {
+                                    (Style::default(), Style::default().fg(accent), Style::default().fg(dim))
+                                };
+                                let cmd_padded = format!(" {:<24}", entry.command);
+                                ListItem::new(Line::from(vec![
+                                    Span::styled(cmd_padded, cmd_style),
+                                    Span::styled(&entry.description, dsc_style),
+                                ])).style(style)
+                            }).collect();
+                        let list = List::new(items).block(
                             Block::default()
                                 .title(" Skills [↑↓] select [Tab/Enter] insert [Esc] cancel ")
                                 .borders(Borders::ALL)
                                 .border_style(Style::default().fg(Color::Cyan)),
                         );
-                    frame.render_widget(list, dropdown_area);
+                        frame.render_widget(list, dropdown_area);
+                    }
+                }
+
+                // Task reference search dropdown
+                if let Some(ref search) = state.task_ref_search {
+                    if !search.matches.is_empty() {
+                        let dropdown_height = (search.matches.len() as u16 + 2).min(12);
+                        let dropdown_area = Rect {
+                            x: input_area.x + 2,
+                            y: input_area.y + input_area.height,
+                            width: input_area.width.saturating_sub(4),
+                            height: dropdown_height,
+                        };
+                        let dropdown_area = if dropdown_area.y + dropdown_area.height > area.height {
+                            Rect { y: input_area.y.saturating_sub(dropdown_height), ..dropdown_area }
+                        } else { dropdown_area };
+
+                        frame.render_widget(Clear, dropdown_area);
+                        let task_sel_color = hex_to_color(&state.config.theme.color_selected);
+                        let accent = hex_to_color(&state.config.theme.color_accent);
+                        let dim = hex_to_color(&state.config.theme.color_dimmed);
+                        let items: Vec<ListItem> = search.matches.iter().enumerate()
+                            .map(|(i, (_, title, status))| {
+                                let (style, title_style, status_style) = if i == search.selected {
+                                    let s = Style::default().bg(task_sel_color).fg(Color::Black);
+                                    (s, s, s)
+                                } else {
+                                    (Style::default(), Style::default().fg(accent), Style::default().fg(dim))
+                                };
+                                let status_badge = format!("  [{}]", status.as_str());
+                                ListItem::new(Line::from(vec![
+                                    Span::styled(format!(" {}", title), title_style),
+                                    Span::styled(status_badge, status_style),
+                                ])).style(style)
+                            }).collect();
+                        let list = List::new(items).block(
+                            Block::default()
+                                .title(" Tasks [↑↓] select [Tab/Enter] insert [Esc] cancel ")
+                                .borders(Borders::ALL)
+                                .border_style(Style::default().fg(Color::Cyan)),
+                        );
+                        frame.render_widget(list, dropdown_area);
+                    }
                 }
             }
         }
@@ -1834,6 +1990,7 @@ impl App {
                 match self.state.input_mode {
                     InputMode::Normal => self.handle_normal_key(key.code),
                     InputMode::InputTitle => self.handle_title_input(key),
+                    InputMode::SelectPlugin => self.handle_plugin_select_wizard(key),
                     InputMode::InputDescription => self.handle_description_input(key),
                 }
             }
@@ -2605,34 +2762,14 @@ impl App {
         let has_alt = key.modifiers.contains(crossterm::event::KeyModifiers::ALT);
         match key.code {
             KeyCode::Esc => {
-                self.state.input_mode = InputMode::Normal;
-                self.state.input_buffer.clear();
-                self.state.input_cursor = 0;
-                self.state.pending_task_title.clear();
-                self.state.editing_task_id = None;
+                self.cancel_wizard();
             }
             KeyCode::Enter => {
                 if !self.state.input_buffer.is_empty() {
-                    // Save title and move to description input
                     self.state.pending_task_title = self.state.input_buffer.clone();
-
-                    // If editing, pre-fill description
-                    if let Some(task_id) = &self.state.editing_task_id {
-                        if let Some(db) = &self.state.db {
-                            if let Ok(Some(task)) = db.get_task(task_id) {
-                                self.state.input_buffer = task.description.unwrap_or_default();
-                            } else {
-                                self.state.input_buffer.clear();
-                            }
-                        } else {
-                            self.state.input_buffer.clear();
-                        }
-                    } else {
-                        self.state.input_buffer.clear();
-                    }
-
-                    self.state.input_cursor = self.state.input_buffer.len();
-                    self.state.input_mode = InputMode::InputDescription;
+                    self.state.input_buffer.clear();
+                    self.state.input_cursor = 0;
+                    self.advance_from_title();
                 }
             }
             KeyCode::Left if has_alt => {
@@ -2690,12 +2827,117 @@ impl App {
         Ok(())
     }
 
+    fn handle_plugin_select_wizard(&mut self, key: crossterm::event::KeyEvent) -> Result<()> {
+        match key.code {
+            KeyCode::Esc => { self.cancel_wizard(); }
+            KeyCode::Char('j') | KeyCode::Down => {
+                let max = self.state.wizard_plugin_options.len().saturating_sub(1);
+                if self.state.wizard_selected_plugin < max {
+                    self.state.wizard_selected_plugin += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if self.state.wizard_selected_plugin > 0 {
+                    self.state.wizard_selected_plugin -= 1;
+                }
+            }
+            KeyCode::Tab => {
+                let len = self.state.wizard_plugin_options.len();
+                if len > 0 {
+                    self.state.wizard_selected_plugin = (self.state.wizard_selected_plugin + 1) % len;
+                }
+            }
+            KeyCode::Enter => {
+                self.init_description_input();
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
     fn handle_description_input(&mut self, key: crossterm::event::KeyEvent) -> Result<()> {
+        // Handle task reference search mode if active
+        if let Some(ref mut search) = self.state.task_ref_search {
+            match key.code {
+                KeyCode::Esc => {
+                    // Cancel task ref search, remove `!` + pattern from buffer
+                    let remove_end = search.start_pos + 1 + search.pattern.len();
+                    let suffix = self.state.input_buffer[remove_end..].to_string();
+                    self.state.input_buffer.truncate(search.start_pos);
+                    self.state.input_buffer.push_str(&suffix);
+                    self.state.input_cursor = search.start_pos;
+                    self.state.task_ref_search = None;
+                }
+                KeyCode::Enter | KeyCode::Tab => {
+                    if let Some((task_id, title, _status)) = search.matches.get(search.selected).cloned() {
+                        // Replace `!` + pattern with ![task-title]
+                        let pattern_end = search.start_pos + 1 + search.pattern.len();
+                        let suffix = self.state.input_buffer[pattern_end..].to_string();
+                        self.state.input_buffer.truncate(search.start_pos);
+                        let ref_text = format!("![{}]", title);
+                        self.state.input_buffer.push_str(&ref_text);
+                        self.state.input_cursor = self.state.input_buffer.len();
+                        self.state.input_buffer.push_str(&suffix);
+                        self.state.highlighted_references.insert(ref_text);
+                        self.state.wizard_referenced_task_ids.insert(task_id);
+                    }
+                    self.state.task_ref_search = None;
+                }
+                KeyCode::Up => {
+                    if search.selected > 0 {
+                        search.selected -= 1;
+                    }
+                }
+                KeyCode::Down => {
+                    if search.selected < search.matches.len().saturating_sub(1) {
+                        search.selected += 1;
+                    }
+                }
+                KeyCode::Backspace => {
+                    if search.pattern.is_empty() {
+                        // Remove the `!` trigger character
+                        if self.state.input_cursor > 0 {
+                            self.state.input_cursor -= 1;
+                            self.state.input_buffer.remove(self.state.input_cursor);
+                        }
+                        self.state.task_ref_search = None;
+                    } else {
+                        search.pattern.pop();
+                        if self.state.input_cursor > 0 {
+                            self.state.input_cursor -= 1;
+                            self.state.input_buffer.remove(self.state.input_cursor);
+                        }
+                        let query = search.pattern.clone();
+                        let matches = self.get_all_task_matches(&query);
+                        if let Some(ref mut search) = self.state.task_ref_search {
+                            search.matches = matches;
+                            search.selected = 0;
+                        }
+                    }
+                }
+                KeyCode::Char(c) => {
+                    if let Some(ref mut search) = self.state.task_ref_search {
+                        search.pattern.push(c);
+                    }
+                    self.state.input_buffer.insert(self.state.input_cursor, c);
+                    self.state.input_cursor += 1;
+                    let query = self.state.task_ref_search.as_ref().map(|s| s.pattern.clone()).unwrap_or_default();
+                    let matches = self.get_all_task_matches(&query);
+                    if let Some(ref mut search) = self.state.task_ref_search {
+                        search.matches = matches;
+                        search.selected = 0;
+                    }
+                }
+                _ => {}
+            }
+            return Ok(());
+        }
+
         // Handle skill search mode if active
         if let Some(ref mut search) = self.state.skill_search {
             match key.code {
                 KeyCode::Esc => {
-                    // Cancel skill search, remove `!` + pattern from buffer
+                    // Cancel skill search, remove `/` + pattern from buffer
                     let remove_end = search.start_pos + 1 + search.pattern.len();
                     let suffix = self.state.input_buffer[remove_end..].to_string();
                     self.state.input_buffer.truncate(search.start_pos);
@@ -2705,7 +2947,7 @@ impl App {
                 }
                 KeyCode::Enter | KeyCode::Tab => {
                     if let Some(entry) = search.matches.get(search.selected).cloned() {
-                        // Replace `!` + pattern with the full command
+                        // Replace `/` + pattern with the full command
                         let pattern_end = search.start_pos + 1 + search.pattern.len();
                         let suffix = self.state.input_buffer[pattern_end..].to_string();
                         self.state.input_buffer.truncate(search.start_pos);
@@ -2827,13 +3069,7 @@ impl App {
 
         match key.code {
             KeyCode::Esc => {
-                self.state.input_mode = InputMode::Normal;
-                self.state.input_buffer.clear();
-                self.state.input_cursor = 0;
-                self.state.pending_task_title.clear();
-                self.state.editing_task_id = None;
-                self.state.highlighted_references.clear();
-                self.state.skill_search = None;
+                self.cancel_wizard();
             }
             KeyCode::Enter => {
                 // Check if line ends with backslash for line continuation
@@ -2845,13 +3081,7 @@ impl App {
                 } else {
                     // Save task (create or update)
                     self.save_task()?;
-                    self.state.input_mode = InputMode::Normal;
-                    self.state.input_buffer.clear();
-                    self.state.input_cursor = 0;
-                    self.state.pending_task_title.clear();
-                    self.state.editing_task_id = None;
-                    self.state.highlighted_references.clear();
-                    self.state.skill_search = None;
+                    self.cancel_wizard();
                 }
             }
             KeyCode::Left if key.modifiers.contains(crossterm::event::KeyModifiers::ALT) => {
@@ -2915,10 +3145,10 @@ impl App {
                 });
                 self.update_file_search_matches();
             }
-            KeyCode::Char('!') => {
-                // Start skill search at cursor position
+            KeyCode::Char('/') if self.state.input_cursor == 0 || matches!(self.state.input_buffer.as_bytes().get(self.state.input_cursor.wrapping_sub(1)), Some(&b'\n') | Some(&b' ')) => {
+                // Start skill search at cursor position (at start of line or after space)
                 let start_pos = self.state.input_cursor;
-                self.state.input_buffer.insert(self.state.input_cursor, '!');
+                self.state.input_buffer.insert(self.state.input_cursor, '/');
                 self.state.input_cursor += 1;
 
                 // Start with bundled skills (always available, no filesystem needed)
@@ -2944,6 +3174,20 @@ impl App {
                     pattern: String::new(),
                     matches: all_skills.clone(),
                     all_skills,
+                    selected: 0,
+                    start_pos,
+                });
+            }
+            KeyCode::Char('!') if self.state.input_cursor == 0 || self.state.input_buffer.as_bytes().get(self.state.input_cursor.wrapping_sub(1)) == Some(&b'\n') || self.state.input_buffer.as_bytes().get(self.state.input_cursor.wrapping_sub(1)) == Some(&b' ') => {
+                // Start task reference search at cursor position (at start of line or after space)
+                let start_pos = self.state.input_cursor;
+                self.state.input_buffer.insert(self.state.input_cursor, '!');
+                self.state.input_cursor += 1;
+
+                let matches = self.get_all_task_matches("");
+                self.state.task_ref_search = Some(TaskRefSearchState {
+                    pattern: String::new(),
+                    matches,
                     selected: 0,
                     start_pos,
                 });
@@ -2988,6 +3232,18 @@ impl App {
 
     fn save_task(&mut self) -> Result<()> {
         if let Some(db) = &self.state.db {
+            let agent = self.state.config.default_agent.clone();
+            let plugin_name = self.state.wizard_plugin_options
+                .get(self.state.wizard_selected_plugin)
+                .map(|o| o.name.clone())
+                .unwrap_or_default();
+            let plugin = if plugin_name.is_empty() { None } else { Some(plugin_name) };
+            let refs = if self.state.wizard_referenced_task_ids.is_empty() {
+                None
+            } else {
+                Some(self.state.wizard_referenced_task_ids.iter().cloned().collect::<Vec<_>>().join(","))
+            };
+
             if let Some(task_id) = &self.state.editing_task_id {
                 // Editing existing task
                 if let Some(mut task) = db.get_task(task_id)? {
@@ -2997,24 +3253,116 @@ impl App {
                     } else {
                         Some(self.state.input_buffer.clone())
                     };
+                    task.agent = agent;
+                    task.plugin = plugin;
+                    task.referenced_tasks = refs;
                     task.updated_at = chrono::Utc::now();
                     db.update_task(&task)?;
                 }
             } else {
                 // Creating new task
                 let project_id = self.state.project_name.clone();
-                let agent = self.state.config.default_agent.clone();
 
                 let mut task = Task::new(&self.state.pending_task_title, agent, project_id);
                 if !self.state.input_buffer.is_empty() {
                     task.description = Some(self.state.input_buffer.clone());
                 }
+                task.plugin = plugin;
+                task.referenced_tasks = refs;
                 // Task starts in Backlog without tmux window
                 db.create_task(&task)?;
             }
             self.refresh_tasks()?;
         }
         Ok(())
+    }
+
+    /// Initialize plugin selection options for the wizard, filtered by selected agent.
+    fn init_plugin_selection(&mut self) {
+        let current = if let Some(task_id) = &self.state.editing_task_id {
+            self.state.db.as_ref()
+                .and_then(|db| db.get_task(task_id).ok().flatten())
+                .and_then(|t| t.plugin.clone())
+                .or_else(|| self.state.config.workflow_plugin.clone())
+                .unwrap_or_default()
+        } else {
+            self.state.config.workflow_plugin.as_deref().unwrap_or("").to_string()
+        };
+
+        let selected_agent_name = &self.state.config.default_agent;
+
+        let mut options = vec![PluginOption {
+            name: String::new(),
+            label: "agtx".to_string(),
+            description: "Built-in workflow with skills and prompts".to_string(),
+            active: current.is_empty(),
+        }];
+        for (name, desc, content) in skills::BUNDLED_PLUGINS {
+            if *name == "agtx" { continue; }
+            // Filter by agent compatibility
+            if let Ok(plugin) = toml::from_str::<WorkflowPlugin>(content) {
+                if !plugin.supports_agent(selected_agent_name) { continue; }
+            }
+            options.push(PluginOption {
+                name: name.to_string(),
+                label: name.to_string(),
+                description: desc.to_string(),
+                active: current == *name,
+            });
+        }
+        let selected = options.iter().position(|o| o.active).unwrap_or(0);
+        self.state.wizard_plugin_options = options;
+        self.state.wizard_selected_plugin = selected;
+    }
+
+    /// Initialize the description input step of the wizard.
+    fn init_description_input(&mut self) {
+        if let Some(task_id) = &self.state.editing_task_id {
+            if let Some(db) = &self.state.db {
+                if let Ok(Some(task)) = db.get_task(task_id) {
+                    self.state.input_buffer = task.description.unwrap_or_default();
+                    // Restore referenced task IDs if editing
+                    self.state.wizard_referenced_task_ids = task.referenced_tasks
+                        .as_deref()
+                        .map(|s| s.split(',').filter(|id| !id.is_empty()).map(String::from).collect())
+                        .unwrap_or_default();
+                } else {
+                    self.state.input_buffer.clear();
+                }
+            } else {
+                self.state.input_buffer.clear();
+            }
+        }
+        self.state.input_cursor = self.state.input_buffer.len();
+        self.state.input_mode = InputMode::InputDescription;
+    }
+
+    /// Cancel the task creation/edit wizard entirely.
+    fn cancel_wizard(&mut self) {
+        self.state.input_mode = InputMode::Normal;
+        self.state.input_buffer.clear();
+        self.state.input_cursor = 0;
+        self.state.pending_task_title.clear();
+        self.state.editing_task_id = None;
+        self.state.highlighted_references.clear();
+        self.state.wizard_plugin_options.clear();
+        self.state.wizard_referenced_task_ids.clear();
+        self.state.task_ref_search = None;
+    }
+
+    /// Advance from title step to plugin selection or description.
+    fn advance_from_title(&mut self) {
+        // Skip plugin selection when no agents detected (e.g. test mode)
+        if self.state.available_agents.is_empty() {
+            self.init_description_input();
+            return;
+        }
+        self.init_plugin_selection();
+        if self.state.wizard_plugin_options.len() <= 1 {
+            self.init_description_input();
+        } else {
+            self.state.input_mode = InputMode::SelectPlugin;
+        }
     }
 
     fn delete_selected_task(&mut self) -> Result<()> {
@@ -3208,6 +3556,21 @@ impl App {
         let auto_dismiss = plugin.as_ref().map_or_else(Vec::new, |p| p.auto_dismiss.clone());
         let project_path = project_path.to_path_buf();
 
+        // Pre-fetch referenced task info (DB isn't Send, so fetch before spawning thread)
+        let referenced_tasks: Vec<ReferencedTaskInfo> = task.referenced_tasks.as_deref()
+            .map(|refs_str| {
+                refs_str.split(',').filter(|s| !s.is_empty()).filter_map(|ref_id| {
+                    self.state.db.as_ref()
+                        .and_then(|db| db.get_task(ref_id).ok().flatten())
+                        .map(|ref_task| ReferencedTaskInfo {
+                            slug: generate_task_slug(&ref_task.id, &ref_task.title),
+                            branch_name: ref_task.branch_name.clone(),
+                            worktree_path: ref_task.worktree_path.clone(),
+                        })
+                }).collect()
+            })
+            .unwrap_or_default();
+
         let (tx, rx) = mpsc::channel();
         self.state.setup_rx = Some(rx);
 
@@ -3220,6 +3583,7 @@ impl App {
                 &mut tmp_task, &project_path, &project_name, &prompt,
                 copy_files, init_script, &plugin, &planning_agent_clone, &all_agents,
                 tmux_ops.as_ref(), git_ops.as_ref(), agent_ops.as_ref(),
+                &referenced_tasks,
             );
 
             match result {
@@ -3466,6 +3830,7 @@ impl App {
                 tmux_ops.as_ref(),
                 git_ops.as_ref(),
                 agent_ops.as_ref(),
+                &[],
             );
 
             match result {
@@ -3601,6 +3966,7 @@ impl App {
                 tmux_ops.as_ref(),
                 git_ops.as_ref(),
                 agent_ops.as_ref(),
+                &[],
             );
 
             match result {
@@ -3828,135 +4194,160 @@ impl App {
         Ok(())
     }
 
-    fn refresh_sessions(&mut self) -> Result<()> {
+    /// Spawn a background thread to check phase statuses if no refresh is already running
+    /// and the cache has expired for at least one task.
+    fn maybe_spawn_session_refresh(&mut self) {
+        // Don't spawn if a refresh is already in flight
+        if self.state.session_refresh_rx.is_some() {
+            self.state.spinner_frame = self.state.spinner_frame.wrapping_add(1);
+            return;
+        }
+
         let now = Instant::now();
         const CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(2);
 
-        let project_path = self.state.project_path.clone();
-
+        // Collect tasks that need checking (cache expired or never checked)
         let tasks_to_check: Vec<_> = self.state.board.tasks.iter()
             .filter(|t| {
                 matches!(t.status, TaskStatus::Planning | TaskStatus::Running | TaskStatus::Review)
                 || (t.status == TaskStatus::Backlog && t.session_name.is_some())
             })
             .filter(|t| t.worktree_path.is_some() || t.session_name.is_some())
-            .map(|t| (t.id.clone(), t.status, t.worktree_path.clone(), t.plugin.clone(), t.session_name.clone(), t.cycle))
+            .filter(|t| {
+                self.state.phase_status_cache.get(&t.id)
+                    .map_or(true, |(_, ts)| now.duration_since(*ts) >= CACHE_TTL)
+            })
+            .map(|t| {
+                let was_ready = self.state.phase_status_cache.get(&t.id)
+                    .map_or(false, |(prev, _)| *prev == PhaseStatus::Ready);
+                (t.id.clone(), t.status, t.worktree_path.clone(), t.plugin.clone(), t.session_name.clone(), t.cycle, was_ready)
+            })
             .collect();
 
-        // Cache loaded plugins by name to avoid reloading from disk for each task
-        let mut plugin_cache: HashMap<Option<String>, Option<WorkflowPlugin>> = HashMap::new();
+        if tasks_to_check.is_empty() {
+            self.state.spinner_frame = self.state.spinner_frame.wrapping_add(1);
+            return;
+        }
 
-        for (task_id, status, worktree_path, task_plugin, session_name, cycle) in tasks_to_check {
-            if let Some((_, timestamp)) = self.state.phase_status_cache.get(&task_id) {
-                if now.duration_since(*timestamp) < CACHE_TTL {
-                    continue;
-                }
-            }
+        let project_path = self.state.project_path.clone();
+        let tmux_ops = Arc::clone(&self.state.tmux_ops);
 
-            let phase_status = if status == TaskStatus::Backlog {
-                // Research artifact: check worktree only (research runs in worktree)
+        let (tx, rx) = mpsc::channel();
+        self.state.session_refresh_rx = Some(rx);
+
+        std::thread::spawn(move || {
+            let mut plugin_cache: HashMap<Option<String>, Option<WorkflowPlugin>> = HashMap::new();
+            let mut statuses = Vec::new();
+
+            for (task_id, status, worktree_path, task_plugin, session_name, cycle, was_ready) in tasks_to_check {
                 let plugin = plugin_cache.entry(task_plugin.clone()).or_insert_with(|| {
                     match &task_plugin {
-                        Some(name) => WorkflowPlugin::load(name, self.state.project_path.as_deref()).ok(),
+                        Some(name) => WorkflowPlugin::load(name, project_path.as_deref()).ok(),
                         None => skills::load_bundled_plugin("agtx"),
                     }
                 });
 
-                // Preresearch artifact: copy back project files when preresearch completes
-                // Only copy if not all files exist at project root yet (avoids repeated copies)
-                if let (Some(ref wt), Some(ref pp)) = (&worktree_path, &project_path) {
-                    if let Some(ref p) = plugin {
-                        if let Some(entries) = p.copy_back.get("preresearch") {
-                            let all_at_root = !entries.is_empty() && entries.iter().all(|e| Path::new(pp).join(e).exists());
-                            if !all_at_root && !p.artifacts.preresearch.is_empty() {
-                                // Check if all preresearch artifacts exist in worktree
-                                let any_artifact = p.artifacts.preresearch.iter().all(|a| {
-                                    let path = Path::new(wt).join(a);
-                                    if a.contains('*') {
-                                        glob_path_exists(&path.to_string_lossy())
-                                    } else {
-                                        path.exists()
+                let phase_status = if status == TaskStatus::Backlog {
+                    // Preresearch copy-back
+                    if let (Some(ref wt), Some(ref pp)) = (&worktree_path, &project_path) {
+                        if let Some(ref p) = plugin {
+                            if let Some(entries) = p.copy_back.get("preresearch") {
+                                let all_at_root = !entries.is_empty() && entries.iter().all(|e| pp.join(e).exists());
+                                if !all_at_root && !p.artifacts.preresearch.is_empty() {
+                                    let any_artifact = p.artifacts.preresearch.iter().all(|a| {
+                                        let path = Path::new(wt).join(a);
+                                        if a.contains('*') {
+                                            glob_path_exists(&path.to_string_lossy())
+                                        } else {
+                                            path.exists()
+                                        }
+                                    });
+                                    if any_artifact {
+                                        copy_back_to_project(Path::new(wt), pp, entries);
                                     }
-                                });
-                                if any_artifact {
-                                    copy_back_to_project(Path::new(wt), Path::new(pp), entries);
                                 }
                             }
                         }
                     }
-                }
 
-                let found = worktree_path.as_ref().map_or(false, |wt| {
-                    research_artifact_exists(wt, &task_id, plugin)
-                });
-                if found { PhaseStatus::Ready } else { PhaseStatus::Working }
-            } else if let Some(ref wt) = worktree_path {
-                let plugin = plugin_cache.entry(task_plugin.clone()).or_insert_with(|| {
-                    match &task_plugin {
-                        Some(name) => WorkflowPlugin::load(name, self.state.project_path.as_deref()).ok(),
-                        None => skills::load_bundled_plugin("agtx"),
+                    let found = worktree_path.as_ref().map_or(false, |wt| {
+                        research_artifact_exists(wt, &task_id, plugin)
+                    });
+                    if found { PhaseStatus::Ready } else { PhaseStatus::Working }
+                } else if let Some(ref wt) = worktree_path {
+                    if phase_artifact_exists(wt, status, plugin, cycle) {
+                        PhaseStatus::Ready
+                    } else {
+                        PhaseStatus::Working
                     }
-                });
-                if phase_artifact_exists(wt, status, plugin, cycle) {
-                    PhaseStatus::Ready
                 } else {
                     PhaseStatus::Working
-                }
-            } else {
-                PhaseStatus::Working
-            };
+                };
 
-            // Idle detection: if Working, check if pane content has been stable for 15s
-            let mut phase_status = phase_status;
-            if phase_status == PhaseStatus::Working {
-                if let Some(ref session_name) = session_name {
-                    if let Ok(content) = self.state.tmux_ops.capture_pane(session_name) {
-                        use std::hash::{Hash, Hasher};
-                        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-                        content.hash(&mut hasher);
-                        let hash = hasher.finish();
-
-                        let entry = self.state.pane_content_hashes
-                            .entry(task_id.clone())
-                            .or_insert((hash, now));
-                        if entry.0 != hash {
-                            *entry = (hash, now);
-                        } else if now.duration_since(entry.1) >= std::time::Duration::from_secs(15) {
-                            phase_status = PhaseStatus::Idle;
-                        }
-                    }
-                }
-
-            } else if phase_status == PhaseStatus::Ready {
-                self.state.pane_content_hashes.remove(&task_id);
-
-                // Copy-back: on Working → Ready transition, copy artifacts from worktree to project root
-                let was_ready = self.state.phase_status_cache.get(&task_id)
-                    .map_or(false, |(prev, _)| *prev == PhaseStatus::Ready);
-                if !was_ready {
+                // Copy-back on Working → Ready transition
+                if phase_status == PhaseStatus::Ready && !was_ready {
                     if let (Some(ref wt), Some(ref pp)) = (&worktree_path, &project_path) {
-                        let plugin = plugin_cache.entry(task_plugin.clone()).or_insert_with(|| {
-                            match &task_plugin {
-                                Some(name) => WorkflowPlugin::load(name, self.state.project_path.as_deref()).ok(),
-                                None => skills::load_bundled_plugin("agtx"),
-                            }
-                        });
-                        // Backlog tasks are in research phase; map to "research" for copy_back lookup
                         let phase_name = if status == TaskStatus::Backlog { "research" } else { status.as_str() };
                         if let Some(ref p) = plugin {
                             if let Some(entries) = p.copy_back.get(phase_name) {
-                                copy_back_to_project(Path::new(wt), Path::new(pp), entries);
+                                copy_back_to_project(Path::new(wt), pp, entries);
                             }
                         }
                     }
                 }
+
+                // Capture tmux content hash for idle detection (only when Working)
+                let content_hash = if phase_status == PhaseStatus::Working {
+                    session_name.as_ref().and_then(|sn| {
+                        tmux_ops.capture_pane(sn).ok().map(|content| {
+                            use std::hash::{Hash, Hasher};
+                            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                            content.hash(&mut hasher);
+                            hasher.finish()
+                        })
+                    })
+                } else {
+                    None
+                };
+
+                statuses.push(SessionTaskStatus {
+                    task_id,
+                    phase_status,
+                    content_hash,
+                });
             }
 
-            self.state.phase_status_cache.insert(task_id, (phase_status, now));
+            let _ = tx.send(SessionRefreshResult { statuses });
+        });
+    }
+
+    /// Apply results from the background session refresh thread.
+    fn apply_session_refresh(&mut self, result: SessionRefreshResult) {
+        let now = Instant::now();
+
+        for task_status in result.statuses {
+            let mut phase = task_status.phase_status;
+
+            if phase == PhaseStatus::Working {
+                // Idle detection: check if content hash has been stable for 15s
+                if let Some(hash) = task_status.content_hash {
+                    let entry = self.state.pane_content_hashes
+                        .entry(task_status.task_id.clone())
+                        .or_insert((hash, now));
+                    if entry.0 != hash {
+                        *entry = (hash, now);
+                    } else if now.duration_since(entry.1) >= std::time::Duration::from_secs(15) {
+                        phase = PhaseStatus::Idle;
+                    }
+                }
+            } else if phase == PhaseStatus::Ready {
+                self.state.pane_content_hashes.remove(&task_status.task_id);
+            }
+
+            self.state.phase_status_cache.insert(task_status.task_id, (phase, now));
         }
 
         self.state.spinner_frame = self.state.spinner_frame.wrapping_add(1);
-        Ok(())
     }
 
     fn switch_to_project(&mut self, project: &ProjectInfo) -> Result<()> {
@@ -4160,6 +4551,7 @@ fn setup_task_worktree(
     tmux_ops: &dyn TmuxOperations,
     git_ops: &dyn GitOperations,
     agent_ops: &dyn AgentOperations,
+    referenced_tasks: &[ReferencedTaskInfo],
 ) -> Result<String> {
     let unique_slug = generate_task_slug(&task.id, &task.title);
     let window_name = format!("task-{}", unique_slug);
@@ -4207,6 +4599,43 @@ fn setup_task_worktree(
     // Deploy for all unique agents configured across phases
     let agent_refs: Vec<&str> = all_phase_agents.iter().map(|s| s.as_str()).collect();
     write_skills_to_worktree(&worktree_path_str, project_path, plugin, &agent_refs);
+
+    // Copy referenced task artifacts into .agtx/references/
+    if !referenced_tasks.is_empty() {
+        let refs_dir = worktree_path.join(".agtx").join("references");
+        for ref_info in referenced_tasks {
+            // 1. Git diff of referenced task's branch
+            if let Some(ref branch) = ref_info.branch_name {
+                if let Ok(output) = std::process::Command::new("git")
+                    .args(["diff", &format!("main..{}", branch)])
+                    .current_dir(project_path)
+                    .output()
+                {
+                    if output.status.success() && !output.stdout.is_empty() {
+                        let _ = std::fs::create_dir_all(&refs_dir);
+                        let diff_path = refs_dir.join(format!("{}.diff", ref_info.slug));
+                        let _ = std::fs::write(&diff_path, &output.stdout);
+                    }
+                }
+            }
+            // 2. Copy artifact files from referenced task's worktree (if it still exists)
+            if let Some(ref wt) = ref_info.worktree_path {
+                let wt_path = Path::new(wt);
+                if wt_path.exists() {
+                    let dest = refs_dir.join(&ref_info.slug);
+                    let _ = std::fs::create_dir_all(&dest);
+                    // Copy common artifact locations
+                    for pattern in &[".agtx/skills", ".planning"] {
+                        let src = wt_path.join(pattern);
+                        if src.exists() {
+                            let target_dir = dest.join(pattern);
+                            let _ = crate::git::copy_dir_recursive(&src, &target_dir);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     // Run plugin init_script (in addition to project init_script)
     // Supports {agent} placeholder for agent-specific initialization

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -206,6 +206,7 @@ fn test_create_pr_with_content_success() {
         pr_url: None,
         plugin: None,
         cycle: 1,
+        referenced_tasks: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -294,6 +295,7 @@ fn test_create_pr_with_content_no_changes() {
         pr_url: None,
         plugin: None,
         cycle: 1,
+        referenced_tasks: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -352,6 +354,7 @@ fn test_create_pr_with_content_push_failure() {
         pr_url: None,
         plugin: None,
         cycle: 1,
+        referenced_tasks: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -407,6 +410,7 @@ fn test_push_changes_to_existing_pr_success() {
         pr_url: Some("https://github.com/org/repo/pull/99".to_string()),
         plugin: None,
         cycle: 1,
+        referenced_tasks: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -459,6 +463,7 @@ fn test_push_changes_to_existing_pr_no_changes() {
         pr_url: Some("https://github.com/org/repo/pull/50".to_string()),
         plugin: None,
         cycle: 1,
+        referenced_tasks: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -494,6 +499,7 @@ fn test_push_changes_to_existing_pr_no_url() {
         pr_url: None, // No PR URL
         plugin: None,
         cycle: 1,
+        referenced_tasks: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -1327,7 +1333,9 @@ fn test_footer_text_input_title() {
 #[test]
 fn test_footer_text_input_description() {
     let text = build_footer_text(InputMode::InputDescription, false, 0, false);
-    assert!(text.contains("[#] file search"));
+    assert!(text.contains("[#] files"));
+    assert!(text.contains("[/] skills"));
+    assert!(text.contains("[!] tasks"));
     assert!(text.contains("[\\+Enter] newline"));
 }
 
@@ -1385,6 +1393,7 @@ fn test_setup_task_worktree_success() {
         &mock_tmux,
         &mock_git,
         &mock_agent,
+        &[],
     );
 
     assert!(result.is_ok());
@@ -1433,6 +1442,7 @@ fn test_setup_task_worktree_sets_task_fields() {
         &mock_tmux,
         &mock_git,
         &mock_agent,
+        &[],
     ).unwrap();
 
     // session_name should be the returned target
@@ -1484,6 +1494,7 @@ fn test_setup_task_worktree_worktree_creation_fails() {
         &mock_tmux,
         &mock_git,
         &mock_agent,
+        &[],
     );
 
     // Should succeed despite worktree creation failure (uses fallback path)
@@ -1533,6 +1544,7 @@ fn test_setup_task_worktree_tmux_window_fails() {
         &mock_tmux,
         &mock_git,
         &mock_agent,
+        &[],
     );
 
     // Should propagate the error
@@ -1586,6 +1598,7 @@ fn test_setup_task_worktree_creates_session_when_missing() {
         &mock_tmux,
         &mock_git,
         &mock_agent,
+        &[],
     );
 
     assert!(result.is_ok());
@@ -1635,6 +1648,7 @@ fn test_setup_task_worktree_passes_init_config() {
         &mock_tmux,
         &mock_git,
         &mock_agent,
+        &[],
     );
 
     assert!(result.is_ok());
@@ -3346,7 +3360,7 @@ fn test_create_task_full_flow() {
     assert!(app.state.input_buffer.is_empty());
 
     // Type a description
-    type_str(&mut app, "Users report 500 error on /login");
+    type_str(&mut app, "Users report 500 error on the login page");
 
     // Press Enter to save
     press_key(&mut app, KeyCode::Enter);
@@ -3356,7 +3370,7 @@ fn test_create_task_full_flow() {
     assert_eq!(app.state.board.tasks.len(), 1);
     let task = &app.state.board.tasks[0];
     assert_eq!(task.title, "Fix login bug");
-    assert_eq!(task.description.as_deref(), Some("Users report 500 error on /login"));
+    assert_eq!(task.description.as_deref(), Some("Users report 500 error on the login page"));
     assert_eq!(task.status, TaskStatus::Backlog);
 }
 
@@ -3474,5 +3488,276 @@ fn test_quit_sets_should_quit() {
     assert!(!app.state.should_quit);
     press_key(&mut app, KeyCode::Char('q'));
     assert!(app.state.should_quit);
+}
+
+// --- Wizard: Agent & Plugin Selection ---
+
+/// Helper: create a test app with multiple agents available.
+#[cfg(feature = "test-mocks")]
+fn make_test_app_with_agents() -> App {
+    let mut mock_tmux = MockTmuxOperations::new();
+    mock_tmux.expect_window_exists().returning(|_| Ok(false));
+    mock_tmux.expect_has_session().returning(|_| false);
+
+    let mut app = App::new_for_test(
+        Some(PathBuf::from("/tmp/test-project")),
+        Arc::new(mock_tmux),
+        Arc::new(MockGitOperations::new()),
+        Arc::new(MockGitProviderOperations::new()),
+        Arc::new(MockAgentRegistry::new()),
+    ).unwrap();
+
+    // Inject 2 agents so wizard doesn't auto-skip
+    app.state.available_agents = vec![
+        crate::agent::Agent::new("claude", "claude", "Anthropic Claude", "Claude <noreply@anthropic.com>"),
+        crate::agent::Agent::new("codex", "codex", "OpenAI Codex", "Codex <noreply@openai.com>"),
+    ];
+    app
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_wizard_plugin_selection() {
+    let mut app = make_test_app_with_agents();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Test task");
+    press_key(&mut app, KeyCode::Enter);
+    // Should go directly to plugin selection (multiple bundled plugins)
+    assert_eq!(app.state.input_mode, InputMode::SelectPlugin);
+    assert!(!app.state.wizard_plugin_options.is_empty());
+
+    // Navigate down
+    let initial = app.state.wizard_selected_plugin;
+    press_key(&mut app, KeyCode::Char('j'));
+    assert_eq!(app.state.wizard_selected_plugin, initial + 1);
+
+    // Advance to description
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_wizard_cancel_at_plugin_step() {
+    let mut app = make_test_app_with_agents();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Cancel me");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::SelectPlugin);
+
+    press_key(&mut app, KeyCode::Esc);
+    assert_eq!(app.state.input_mode, InputMode::Normal);
+    assert!(app.state.pending_task_title.is_empty());
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_wizard_tab_cycles_plugins() {
+    let mut app = make_test_app_with_agents();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Tabbing");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::SelectPlugin);
+
+    let len = app.state.wizard_plugin_options.len();
+    assert!(len > 1);
+    assert_eq!(app.state.wizard_selected_plugin, 0);
+    press_key(&mut app, KeyCode::Tab);
+    assert_eq!(app.state.wizard_selected_plugin, 1);
+    // Tab wraps around
+    for _ in 1..len {
+        press_key(&mut app, KeyCode::Tab);
+    }
+    assert_eq!(app.state.wizard_selected_plugin, 0);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_wizard_saves_with_selected_plugin() {
+    let mut app = make_test_app_with_agents();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Plugin task");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::SelectPlugin);
+
+    // Move to a non-default plugin (index 1 should be gsd or similar)
+    press_key(&mut app, KeyCode::Char('j'));
+    let selected_plugin = app.state.wizard_plugin_options[app.state.wizard_selected_plugin].name.clone();
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+    press_key(&mut app, KeyCode::Enter); // save with no description
+
+    let tasks = app.state.board.tasks.clone();
+    assert_eq!(tasks.len(), 1);
+    if selected_plugin.is_empty() {
+        assert!(tasks[0].plugin.is_none());
+    } else {
+        assert_eq!(tasks[0].plugin.as_deref(), Some(selected_plugin.as_str()));
+    }
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_wizard_uses_config_default_agent() {
+    let mut app = make_test_app_with_agents();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Config agent task");
+    press_key(&mut app, KeyCode::Enter);
+    // Advance through plugin
+    if app.state.input_mode == InputMode::SelectPlugin {
+        press_key(&mut app, KeyCode::Enter);
+    }
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+    press_key(&mut app, KeyCode::Enter);
+
+    let tasks = app.state.board.tasks.clone();
+    assert_eq!(tasks.len(), 1);
+    // Should use config default_agent, not a wizard selection
+    assert_eq!(tasks[0].agent, app.state.config.default_agent);
+}
+
+// --- Trigger Swap: / for skills, ! for task refs ---
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_skill_search_slash_trigger() {
+    let mut app = make_test_app();
+    // Enter description mode (no agents = skip to description)
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Test");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+
+    // Type `/` at start of buffer — should trigger skill search
+    press_key(&mut app, KeyCode::Char('/'));
+    assert!(app.state.skill_search.is_some());
+    assert_eq!(app.state.input_buffer, "/");
+
+    // Cancel skill search
+    press_key(&mut app, KeyCode::Esc);
+    assert!(app.state.skill_search.is_none());
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_slash_no_trigger_mid_word() {
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Test");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+
+    // `/` after a letter (no space) — should NOT trigger skill search
+    type_str(&mut app, "http:/");
+    assert!(app.state.skill_search.is_none());
+    assert!(app.state.input_buffer.contains("http:/"));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_slash_triggers_after_space() {
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Test");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+
+    // `/` after a space — should trigger skill search
+    type_str(&mut app, "run ");
+    press_key(&mut app, KeyCode::Char('/'));
+    assert!(app.state.skill_search.is_some());
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_task_ref_search_exclamation_trigger() {
+    let mut app = make_test_app();
+    // Add a task to the board so search has results
+    let db = app.state.db.as_ref().unwrap();
+    db.create_task(&Task::new("Setup auth", "claude", "test-project")).unwrap();
+    app.refresh_tasks().unwrap();
+    assert_eq!(app.state.board.tasks.len(), 1);
+
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "New task");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+
+    // Type `!` at start of buffer — should trigger task ref search
+    press_key(&mut app, KeyCode::Char('!'));
+    assert!(app.state.task_ref_search.is_some());
+    let search = app.state.task_ref_search.as_ref().unwrap();
+    assert_eq!(search.pattern, "");
+    assert!(!search.matches.is_empty()); // Should find "Setup auth"
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_task_ref_inserts_reference() {
+    let mut app = make_test_app();
+    // Add a task to the board
+    let db = app.state.db.as_ref().unwrap();
+    db.create_task(&Task::new("Setup auth", "claude", "test-project")).unwrap();
+    app.refresh_tasks().unwrap();
+
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Uses auth");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+
+    // Trigger task ref search
+    press_key(&mut app, KeyCode::Char('!'));
+    assert!(app.state.task_ref_search.is_some());
+
+    // Select the first match
+    press_key(&mut app, KeyCode::Enter);
+    assert!(app.state.task_ref_search.is_none()); // search closed
+
+    // Buffer should contain ![Setup auth]
+    assert!(app.state.input_buffer.contains("![Setup auth]"), "Buffer: {}", app.state.input_buffer);
+    // Referenced task ID should be tracked
+    assert!(!app.state.wizard_referenced_task_ids.is_empty());
+    // Highlighted references should contain the reference text
+    assert!(app.state.highlighted_references.contains("![Setup auth]"));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_task_ref_after_space() {
+    let mut app = make_test_app();
+    let db = app.state.db.as_ref().unwrap();
+    db.create_task(&Task::new("Other task", "claude", "test-project")).unwrap();
+    app.refresh_tasks().unwrap();
+
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Ref test");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+
+    // Type some text, then space + `!` — should trigger
+    type_str(&mut app, "depends on ");
+    press_key(&mut app, KeyCode::Char('!'));
+    assert!(app.state.task_ref_search.is_some());
+}
+
+// --- Footer text ---
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_footer_text_select_plugin() {
+    let text = build_footer_text(InputMode::SelectPlugin, false, 0, false);
+    assert!(text.contains("select plugin"));
+    assert!(text.contains("Tab"));
+    assert!(text.contains("Enter"));
+    assert!(text.contains("Esc"));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_footer_text_description_shows_all_triggers() {
+    let text = build_footer_text(InputMode::InputDescription, false, 0, false);
+    assert!(text.contains("[#] files"), "Missing files trigger: {}", text);
+    assert!(text.contains("[/] skills"), "Missing skills trigger: {}", text);
+    assert!(text.contains("[!] tasks"), "Missing tasks trigger: {}", text);
 }
 

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -5,6 +5,8 @@ pub enum InputMode {
     Normal,
     /// Entering task title
     InputTitle,
+    /// Selecting workflow plugin for the task
+    SelectPlugin,
     /// Entering task description/prompt
     InputDescription,
 }


### PR DESCRIPTION
### Summary

  - Task creation wizard: New multi-step flow (Title → Plugin → Prompt) for creating tasks with inline file references (#/@), skill search (/), and task references (!)
  - Background session refresh: Moved refresh_sessions from synchronous main-thread execution to a background thread via mpsc channel, eliminating ~2s UI lag during typing
  - Simplified agent selection: Removed per-task agent selection from the wizard — agent is now purely config-driven (default_agent / [agents] per-phase), matching how it's actually used during phase transitions
  - Task references: Tasks can reference other tasks via ! trigger in descriptions, stored as referenced_tasks in the database and copied into worktrees as context files