### PR TITLE
Add support for jujutsu to agtx

### DIFF
--- a/plugins/agtx/skills/review.md
+++ b/plugins/agtx/skills/review.md
@@ -9,7 +9,9 @@ You are in the **review phase** of an agtx-managed task.
 
 ## Instructions
 
-1. Review all changes made during execution (use git diff)
+1. Review all changes made during execution:
+   - Git: `git log -1 -p` or `git diff HEAD~1`
+   - Jujutsu (jj): `jj show --git` for all local changes in the current commit
 2. Check for:
    - Correctness and edge cases
    - Error handling

--- a/src/git/jj_operations.rs
+++ b/src/git/jj_operations.rs
@@ -1,0 +1,274 @@
+//! Jujutsu (jj) implementation of VCS operations.
+//! Minimum supported jj version: 0.36
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::operations::GitOperations;
+
+const AGTX_DIR: &str = ".agtx";
+const WORKTREES_DIR: &str = "worktrees";
+
+fn worktree_path(project_path: &Path, task_slug: &str) -> PathBuf {
+    project_path.join(AGTX_DIR).join(WORKTREES_DIR).join(task_slug)
+}
+
+pub struct RealJjOps;
+
+impl GitOperations for RealJjOps {
+    fn create_worktree(&self, project_path: &Path, task_slug: &str) -> Result<String> {
+        let path = worktree_path(project_path, task_slug);
+
+        // If workspace already exists, return it
+        if path.exists() {
+            return Ok(path.to_string_lossy().to_string());
+        }
+
+        // Clean up any partial directory
+        if path.exists() {
+            let _ = std::fs::remove_dir_all(&path);
+        }
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Create workspace at trunk() so it starts from the main branch
+        let output = Command::new("jj")
+            .current_dir(project_path)
+            .args(["workspace", "add", "--revision", "trunk()"])
+            .arg(&path)
+            .output()
+            .context("Failed to create jj workspace")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Failed to create jj workspace: {}", stderr);
+        }
+
+        Ok(path.to_string_lossy().to_string())
+    }
+
+    fn remove_worktree(&self, project_path: &Path, worktree_path: &str) -> Result<()> {
+        let path = Path::new(worktree_path);
+        // Derive workspace name from the last path component
+        let workspace_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(worktree_path);
+
+        // Unregister from jj (ignore errors — may already be forgotten)
+        let _ = Command::new("jj")
+            .current_dir(project_path)
+            .args(["workspace", "forget", workspace_name])
+            .output();
+
+        // Remove the directory
+        if path.exists() {
+            std::fs::remove_dir_all(path)?;
+        }
+
+        Ok(())
+    }
+
+    fn worktree_exists(&self, project_path: &Path, task_slug: &str) -> bool {
+        worktree_path(project_path, task_slug).exists()
+    }
+
+    fn delete_branch(&self, project_path: &Path, branch_name: &str) -> Result<()> {
+        // Ignore errors — bookmark may not exist
+        let _ = Command::new("jj")
+            .current_dir(project_path)
+            .args(["bookmark", "delete", branch_name])
+            .output();
+        Ok(())
+    }
+
+    fn diff(&self, worktree_path: &Path) -> String {
+        Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["diff", "--git"])
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+            .unwrap_or_default()
+    }
+
+    fn diff_cached(&self, worktree_path: &Path) -> String {
+        // jj has no staging area — return the full working-copy diff
+        self.diff(worktree_path)
+    }
+
+    fn list_untracked_files(&self, _worktree_path: &Path) -> String {
+        // jj tracks all files automatically; no concept of untracked files
+        String::new()
+    }
+
+    fn diff_untracked_file(&self, worktree_path: &Path, file: &str) -> String {
+        Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["diff", "--git", "--", file])
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+            .unwrap_or_default()
+    }
+
+    fn diff_stat_from_main(&self, worktree_path: &Path) -> String {
+        Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["diff", "--stat", "-r", "trunk()..@"])
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+            .unwrap_or_default()
+    }
+
+    fn add_all(&self, worktree_path: &Path) -> Result<()> {
+        // jj automatically snapshots the working copy; running `jj st` triggers it
+        Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["st"])
+            .output()
+            .context("Failed to snapshot jj working copy")?;
+        Ok(())
+    }
+
+    fn has_changes(&self, worktree_path: &Path) -> bool {
+        Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["diff", "--summary"])
+            .output()
+            .map(|o| !o.stdout.is_empty())
+            .unwrap_or(false)
+    }
+
+    fn commit(&self, worktree_path: &Path, message: &str) -> Result<()> {
+        let output = Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["commit", "-m", message])
+            .output()
+            .context("Failed to commit in jj")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("jj commit failed: {}", stderr);
+        }
+        Ok(())
+    }
+
+    fn push(&self, worktree_path: &Path, branch: &str, _set_upstream: bool) -> Result<()> {
+        // Create the bookmark at @- (the just-committed revision) before pushing
+        let bookmark_output = Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["bookmark", "create", branch, "-r", "@-"])
+            .output()
+            .context("Failed to create jj bookmark")?;
+
+        if !bookmark_output.status.success() {
+            // Bookmark may already exist — try moving it instead
+            let move_output = Command::new("jj")
+                .current_dir(worktree_path)
+                .args(["bookmark", "move", branch, "--to", "@-"])
+                .output()
+                .context("Failed to move jj bookmark")?;
+
+            if !move_output.status.success() {
+                let stderr = String::from_utf8_lossy(&move_output.stderr);
+                anyhow::bail!("Failed to set jj bookmark '{}': {}", branch, stderr);
+            }
+        }
+
+        let push_output = Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["git", "push", "--bookmark", branch])
+            .output()
+            .context("Failed to push jj bookmark")?;
+
+        if !push_output.status.success() {
+            let stderr = String::from_utf8_lossy(&push_output.stderr);
+            anyhow::bail!("jj git push failed: {}", stderr);
+        }
+        Ok(())
+    }
+
+    fn fetch_and_check_conflicts(&self, worktree_path: &Path) -> Result<bool> {
+        // Fetch latest from remote
+        let fetch = Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["git", "fetch"])
+            .output()
+            .context("Failed to run jj git fetch")?;
+
+        if !fetch.status.success() {
+            let stderr = String::from_utf8_lossy(&fetch.stderr);
+            anyhow::bail!("jj git fetch failed: {}", stderr);
+        }
+
+        // Attempt rebase onto trunk() to detect conflicts
+        let rebase = Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["rebase", "-d", "trunk()"])
+            .output()
+            .context("Failed to run jj rebase")?;
+
+        if !rebase.status.success() {
+            // Rebase command itself failed — undo and report as conflicted
+            let _ = Command::new("jj")
+                .current_dir(worktree_path)
+                .args(["undo"])
+                .output();
+            return Ok(true);
+        }
+
+        // Check if any commits now have unresolved conflicts
+        let conflict_check = Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["log", "-r", "conflicts()", "--no-graph", "-T", "commit_id"])
+            .output()
+            .context("Failed to check for jj conflicts")?;
+
+        let has_conflicts =
+            !String::from_utf8_lossy(&conflict_check.stdout).trim().is_empty();
+
+        if !has_conflicts {
+            // Clean rebase — undo it to restore original state (agent hasn't asked for a rebase)
+            let _ = Command::new("jj")
+                .current_dir(worktree_path)
+                .args(["undo"])
+                .output();
+        }
+        // If conflicts exist, leave the rebased state so the agent can resolve them
+
+        Ok(has_conflicts)
+    }
+
+    fn list_files(&self, project_path: &Path) -> Vec<String> {
+        Command::new("jj")
+            .current_dir(project_path)
+            .args(["file", "list"])
+            .output()
+            .map(|o| {
+                String::from_utf8_lossy(&o.stdout)
+                    .lines()
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn initialize_worktree(
+        &self,
+        project_path: &Path,
+        worktree_path: &Path,
+        copy_files: Option<String>,
+        init_script: Option<String>,
+        copy_dirs: Vec<String>,
+    ) -> Vec<String> {
+        super::initialize_worktree(
+            project_path,
+            worktree_path,
+            copy_files.as_deref(),
+            init_script.as_deref(),
+            &copy_dirs,
+        )
+    }
+}

--- a/src/git/jj_operations.rs
+++ b/src/git/jj_operations.rs
@@ -85,18 +85,19 @@ impl GitOperations for RealJjOps {
         Ok(())
     }
 
-    fn diff(&self, worktree_path: &Path) -> String {
+    fn diff(&self, _worktree_path: &Path) -> String {
+        // jj has no staging area — everything is auto-tracked, nothing is "unstaged"
+        String::new()
+    }
+
+    fn diff_cached(&self, worktree_path: &Path) -> String {
+        // jj has no staging area — everything is effectively "staged"
         Command::new("jj")
             .current_dir(worktree_path)
             .args(["diff", "--git"])
             .output()
             .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
             .unwrap_or_default()
-    }
-
-    fn diff_cached(&self, worktree_path: &Path) -> String {
-        // jj has no staging area — return the full working-copy diff
-        self.diff(worktree_path)
     }
 
     fn list_untracked_files(&self, _worktree_path: &Path) -> String {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,7 +1,9 @@
+mod jj_operations;
 mod operations;
 mod provider;
 mod worktree;
 
+pub use jj_operations::RealJjOps;
 pub use operations::*;
 pub use provider::{GitProviderOperations, PullRequestState, RealGitHubOps};
 pub use worktree::*;
@@ -15,11 +17,41 @@ use anyhow::{Context, Result};
 use std::path::Path;
 use std::process::Command;
 
+/// Which VCS backend a repository uses
+#[derive(Debug, Clone, PartialEq)]
+pub enum VcsBackend {
+    Git,
+    Jj,
+    /// jj repo that also has a .git — prefer jj
+    ColocatedJj,
+}
+
+/// Detect which VCS backend is in use at the given path
+pub fn detect_vcs(path: &Path) -> VcsBackend {
+    let jj = is_jj_repo(path);
+    let git = is_git_repo(path);
+    match (jj, git) {
+        (true, true) => VcsBackend::ColocatedJj,
+        (true, false) => VcsBackend::Jj,
+        _ => VcsBackend::Git,
+    }
+}
+
 /// Check if a path is inside a git repository
 pub fn is_git_repo(path: &Path) -> bool {
     Command::new("git")
         .current_dir(path)
         .args(["rev-parse", "--git-dir"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Check if a path is inside a jj repository
+pub fn is_jj_repo(path: &Path) -> bool {
+    Command::new("jj")
+        .current_dir(path)
+        .args(["root"])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,8 @@ async fn main() -> Result<()> {
                 .map(PathBuf::from)
                 .unwrap_or(std::env::current_dir()?);
             let project_path = project_path.canonicalize()?;
-            if !git::is_git_repo(&project_path) {
-                anyhow::bail!("mcp-serve requires a git project directory");
+            if !git::is_git_repo(&project_path) && !git::is_jj_repo(&project_path) {
+                anyhow::bail!("mcp-serve requires a git or jj project directory");
             }
             return agtx::mcp::serve(project_path).await;
         }
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
         None => {
             // Default: if in git repo, use project mode; otherwise dashboard
             let current_dir = std::env::current_dir()?;
-            if git::is_git_repo(&current_dir) {
+            if git::is_git_repo(&current_dir) || git::is_jj_repo(&current_dir) {
                 AppMode::Project(current_dir)
             } else {
                 AppMode::Dashboard

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -485,11 +485,20 @@ pub struct App {
 
 impl App {
     pub fn new(mode: AppMode, flags: crate::FeatureFlags) -> Result<Self> {
+        let git_ops: Arc<dyn GitOperations> = match &mode {
+            AppMode::Project(path) => match crate::git::detect_vcs(path) {
+                crate::git::VcsBackend::Jj | crate::git::VcsBackend::ColocatedJj => {
+                    Arc::new(crate::git::RealJjOps)
+                }
+                _ => Arc::new(RealGitOps),
+            },
+            AppMode::Dashboard => Arc::new(RealGitOps),
+        };
         Self::with_ops(
             mode,
             flags,
             Arc::new(RealTmuxOps),
-            Arc::new(RealGitOps),
+            git_ops,
             Arc::new(RealGitHubOps),
             Arc::new(agent::RealAgentRegistry::new("claude")),
         )
@@ -3120,7 +3129,7 @@ impl App {
                 }
                 KeyCode::Char('n') => {
                     let current_dir = std::env::current_dir()?;
-                    if crate::git::is_git_repo(&current_dir) {
+                    if crate::git::is_git_repo(&current_dir) || crate::git::is_jj_repo(&current_dir) {
                         let canonical = current_dir.canonicalize().unwrap_or(current_dir);
                         let name = canonical
                             .file_name()

--- a/tests/jj_tests.rs
+++ b/tests/jj_tests.rs
@@ -1,0 +1,439 @@
+use agtx::git::{self, GitOperations, RealJjOps};
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn jj_available() -> bool {
+    Command::new("jj")
+        .args(["--version"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Set up a pure jj repo (no-colocate: only `.jj`, no `.git`) with an initial
+/// commit and a `main` bookmark that `trunk()` resolves to.
+fn setup_jj_repo() -> TempDir {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path();
+
+    Command::new("jj")
+        .args(["git", "init", "--no-colocate"])
+        .arg(path)
+        .output()
+        .expect("Failed to init jj repo");
+
+    Command::new("jj")
+        .current_dir(path)
+        .args(["config", "set", "--repo", "user.name", "Test User"])
+        .output()
+        .expect("Failed to set user.name");
+
+    Command::new("jj")
+        .current_dir(path)
+        .args(["config", "set", "--repo", "user.email", "test@test.com"])
+        .output()
+        .expect("Failed to set user.email");
+
+    std::fs::write(path.join("README.md"), "# Test").unwrap();
+
+    // Describe the working copy commit (jj snapshots the file)
+    Command::new("jj")
+        .current_dir(path)
+        .args(["describe", "-m", "Initial commit"])
+        .output()
+        .expect("Failed to describe");
+
+    // Move to a new empty working copy; the described commit becomes immutable
+    Command::new("jj")
+        .current_dir(path)
+        .args(["new"])
+        .output()
+        .expect("Failed to create new commit");
+
+    // Create a `main` bookmark on the initial commit
+    Command::new("jj")
+        .current_dir(path)
+        .args(["bookmark", "create", "main", "-r", "@-"])
+        .output()
+        .expect("Failed to create main bookmark");
+
+    // Point trunk() at `main`
+    Command::new("jj")
+        .current_dir(path)
+        .args(["config", "set", "--repo", "revsets.trunk", "main"])
+        .output()
+        .expect("Failed to set revsets.trunk");
+
+    temp_dir
+}
+
+/// Set up a colocated jj repo (git + jj sharing the same directory).
+fn setup_colocated_jj_repo() -> TempDir {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path();
+
+    Command::new("git")
+        .current_dir(path)
+        .args(["init"])
+        .output()
+        .expect("Failed to git init");
+
+    Command::new("git")
+        .current_dir(path)
+        .args(["config", "user.email", "test@test.com"])
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .current_dir(path)
+        .args(["config", "user.name", "Test User"])
+        .output()
+        .unwrap();
+
+    std::fs::write(path.join("README.md"), "# Test").unwrap();
+    Command::new("git").current_dir(path).args(["add", "."]).output().unwrap();
+    Command::new("git")
+        .current_dir(path)
+        .args(["commit", "-m", "Initial commit"])
+        .output()
+        .unwrap();
+    Command::new("git")
+        .current_dir(path)
+        .args(["branch", "-M", "main"])
+        .output()
+        .unwrap();
+
+    // Colocate jj using the existing git repo
+    Command::new("jj")
+        .current_dir(path)
+        .args(["git", "init", "--git-repo", "."])
+        .output()
+        .expect("Failed to colocate jj");
+
+    temp_dir
+}
+
+// =============================================================================
+// Detection tests
+// =============================================================================
+
+#[test]
+fn test_is_jj_repo_true() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    assert!(git::is_jj_repo(temp_dir.path()));
+}
+
+#[test]
+fn test_is_jj_repo_false_for_plain_dir() {
+    if !jj_available() { return; }
+    let temp_dir = TempDir::new().unwrap();
+    assert!(!git::is_jj_repo(temp_dir.path()));
+}
+
+#[test]
+fn test_is_jj_repo_false_for_git_only() {
+    if !jj_available() { return; }
+    let temp_dir = TempDir::new().unwrap();
+    Command::new("git").current_dir(temp_dir.path()).args(["init"]).output().unwrap();
+    assert!(!git::is_jj_repo(temp_dir.path()));
+}
+
+#[test]
+fn test_detect_vcs_pure_jj() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    // --no-colocate: only .jj present, git can't see the repo
+    assert_eq!(git::detect_vcs(temp_dir.path()), git::VcsBackend::Jj);
+}
+
+#[test]
+fn test_detect_vcs_colocated() {
+    if !jj_available() { return; }
+    let temp_dir = setup_colocated_jj_repo();
+    assert_eq!(git::detect_vcs(temp_dir.path()), git::VcsBackend::ColocatedJj);
+}
+
+#[test]
+fn test_detect_vcs_git_only() {
+    if !jj_available() { return; }
+    let temp_dir = TempDir::new().unwrap();
+    Command::new("git").current_dir(temp_dir.path()).args(["init"]).output().unwrap();
+    assert_eq!(git::detect_vcs(temp_dir.path()), git::VcsBackend::Git);
+}
+
+#[test]
+fn test_detect_vcs_plain_dir_fallback() {
+    let temp_dir = TempDir::new().unwrap();
+    // Neither git nor jj — falls back to Git variant
+    assert_eq!(git::detect_vcs(temp_dir.path()), git::VcsBackend::Git);
+}
+
+// =============================================================================
+// RealJjOps workspace tests
+// =============================================================================
+
+#[test]
+fn test_jj_create_and_remove_workspace() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws = ops.create_worktree(temp_dir.path(), "test-task").unwrap();
+    let ws_path = Path::new(&ws);
+
+    assert!(ws_path.exists());
+    assert!(ops.worktree_exists(temp_dir.path(), "test-task"));
+
+    ops.remove_worktree(temp_dir.path(), &ws).unwrap();
+    assert!(!ops.worktree_exists(temp_dir.path(), "test-task"));
+}
+
+#[test]
+fn test_jj_create_workspace_idempotent() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws1 = ops.create_worktree(temp_dir.path(), "idem-task").unwrap();
+    let ws2 = ops.create_worktree(temp_dir.path(), "idem-task").unwrap();
+    assert_eq!(ws1, ws2);
+    assert!(Path::new(&ws1).exists());
+}
+
+#[test]
+fn test_jj_worktree_exists_false_for_nonexistent() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+    assert!(!ops.worktree_exists(temp_dir.path(), "no-such-task"));
+}
+
+#[test]
+fn test_jj_create_multiple_workspaces() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws1 = ops.create_worktree(temp_dir.path(), "task-1").unwrap();
+    let ws2 = ops.create_worktree(temp_dir.path(), "task-2").unwrap();
+    let ws3 = ops.create_worktree(temp_dir.path(), "task-3").unwrap();
+
+    assert_ne!(ws1, ws2);
+    assert_ne!(ws2, ws3);
+    assert!(Path::new(&ws1).exists());
+    assert!(Path::new(&ws2).exists());
+    assert!(Path::new(&ws3).exists());
+
+    ops.remove_worktree(temp_dir.path(), &ws1).unwrap();
+    ops.remove_worktree(temp_dir.path(), &ws2).unwrap();
+    ops.remove_worktree(temp_dir.path(), &ws3).unwrap();
+
+    assert!(!Path::new(&ws1).exists());
+    assert!(!Path::new(&ws2).exists());
+    assert!(!Path::new(&ws3).exists());
+}
+
+// =============================================================================
+// RealJjOps diff / status tests
+// =============================================================================
+
+#[test]
+fn test_jj_has_changes_false_on_clean_workspace() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws = ops.create_worktree(temp_dir.path(), "clean-task").unwrap();
+    let ws_path = Path::new(&ws);
+
+    assert!(!ops.has_changes(ws_path));
+}
+
+#[test]
+fn test_jj_has_changes_true_after_file_write() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws = ops.create_worktree(temp_dir.path(), "dirty-task").unwrap();
+    let ws_path = Path::new(&ws);
+
+    std::fs::write(ws_path.join("new_file.txt"), "hello").unwrap();
+
+    assert!(ops.has_changes(ws_path));
+}
+
+#[test]
+fn test_jj_diff_empty_on_clean_workspace() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws = ops.create_worktree(temp_dir.path(), "diff-clean").unwrap();
+    let ws_path = Path::new(&ws);
+
+    assert!(ops.diff(ws_path).is_empty());
+}
+
+#[test]
+fn test_jj_diff_shows_changes() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws = ops.create_worktree(temp_dir.path(), "diff-dirty").unwrap();
+    let ws_path = Path::new(&ws);
+
+    std::fs::write(ws_path.join("feature.txt"), "new feature").unwrap();
+
+    let diff = ops.diff(ws_path);
+    assert!(!diff.is_empty());
+    assert!(diff.contains("feature.txt"));
+}
+
+#[test]
+fn test_jj_diff_cached_matches_diff() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws = ops.create_worktree(temp_dir.path(), "diff-cached").unwrap();
+    let ws_path = Path::new(&ws);
+
+    std::fs::write(ws_path.join("staged.txt"), "content").unwrap();
+
+    // jj has no staging area — diff_cached should equal diff
+    assert_eq!(ops.diff(ws_path), ops.diff_cached(ws_path));
+}
+
+#[test]
+fn test_jj_list_untracked_files_empty() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws = ops.create_worktree(temp_dir.path(), "untracked").unwrap();
+    let ws_path = Path::new(&ws);
+
+    // jj tracks all files — untracked list is always empty
+    assert!(ops.list_untracked_files(ws_path).is_empty());
+}
+
+// =============================================================================
+// RealJjOps add_all / commit tests
+// =============================================================================
+
+#[test]
+fn test_jj_add_all_triggers_snapshot() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws = ops.create_worktree(temp_dir.path(), "snapshot").unwrap();
+    let ws_path = Path::new(&ws);
+
+    std::fs::write(ws_path.join("snap.txt"), "data").unwrap();
+    // add_all should complete without error
+    ops.add_all(ws_path).unwrap();
+    // changes should still be visible after snapshot
+    assert!(ops.has_changes(ws_path));
+}
+
+#[test]
+fn test_jj_commit_creates_immutable_change() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws = ops.create_worktree(temp_dir.path(), "commit-task").unwrap();
+    let ws_path = Path::new(&ws);
+
+    std::fs::write(ws_path.join("work.txt"), "some work").unwrap();
+    ops.add_all(ws_path).unwrap();
+    assert!(ops.has_changes(ws_path));
+
+    ops.commit(ws_path, "Do some work").unwrap();
+
+    // After commit, working copy should be clean
+    assert!(!ops.has_changes(ws_path));
+}
+
+#[test]
+fn test_jj_commit_noop_on_clean_workspace() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws = ops.create_worktree(temp_dir.path(), "commit-clean").unwrap();
+    let ws_path = Path::new(&ws);
+
+    // Committing with no changes should not error
+    // jj commit on an empty change is valid (creates an empty commit)
+    let result = ops.commit(ws_path, "Empty commit");
+    assert!(result.is_ok());
+}
+
+// =============================================================================
+// RealJjOps list_files tests
+// =============================================================================
+
+#[test]
+fn test_jj_list_files_includes_tracked_files() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    // The root repo has README.md from initial commit
+    let files = ops.list_files(temp_dir.path());
+    assert!(files.iter().any(|f| f.contains("README.md")));
+}
+
+#[test]
+fn test_jj_list_files_from_workspace() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    let ws = ops.create_worktree(temp_dir.path(), "list-files").unwrap();
+    let ws_path = Path::new(&ws);
+
+    // Add a file so the workspace has something to list
+    std::fs::write(ws_path.join("ws_file.txt"), "content").unwrap();
+
+    let files = ops.list_files(ws_path);
+    assert!(files.iter().any(|f| f.contains("ws_file.txt")));
+}
+
+// =============================================================================
+// RealJjOps delete_branch (bookmark) tests
+// =============================================================================
+
+#[test]
+fn test_jj_delete_nonexistent_bookmark_is_ok() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    // Deleting a bookmark that doesn't exist should not error
+    let result = ops.delete_branch(temp_dir.path(), "no-such-bookmark");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_jj_delete_existing_bookmark() {
+    if !jj_available() { return; }
+    let temp_dir = setup_jj_repo();
+    let ops = RealJjOps;
+
+    // Create a bookmark to delete
+    Command::new("jj")
+        .current_dir(temp_dir.path())
+        .args(["bookmark", "create", "to-delete", "-r", "@-"])
+        .output()
+        .unwrap();
+
+    let result = ops.delete_branch(temp_dir.path(), "to-delete");
+    assert!(result.is_ok());
+}

--- a/tests/jj_tests.rs
+++ b/tests/jj_tests.rs
@@ -266,7 +266,7 @@ fn test_jj_has_changes_true_after_file_write() {
 }
 
 #[test]
-fn test_jj_diff_empty_on_clean_workspace() {
+fn test_jj_diff_always_empty() {
     if !jj_available() { return; }
     let temp_dir = setup_jj_repo();
     let ops = RealJjOps;
@@ -274,27 +274,16 @@ fn test_jj_diff_empty_on_clean_workspace() {
     let ws = ops.create_worktree(temp_dir.path(), "diff-clean").unwrap();
     let ws_path = Path::new(&ws);
 
+    // jj has no staging area — nothing is ever "unstaged"
+    assert!(ops.diff(ws_path).is_empty());
+
+    // still empty even with working-copy changes
+    std::fs::write(ws_path.join("feature.txt"), "new feature").unwrap();
     assert!(ops.diff(ws_path).is_empty());
 }
 
 #[test]
-fn test_jj_diff_shows_changes() {
-    if !jj_available() { return; }
-    let temp_dir = setup_jj_repo();
-    let ops = RealJjOps;
-
-    let ws = ops.create_worktree(temp_dir.path(), "diff-dirty").unwrap();
-    let ws_path = Path::new(&ws);
-
-    std::fs::write(ws_path.join("feature.txt"), "new feature").unwrap();
-
-    let diff = ops.diff(ws_path);
-    assert!(!diff.is_empty());
-    assert!(diff.contains("feature.txt"));
-}
-
-#[test]
-fn test_jj_diff_cached_matches_diff() {
+fn test_jj_diff_cached_shows_changes() {
     if !jj_available() { return; }
     let temp_dir = setup_jj_repo();
     let ops = RealJjOps;
@@ -302,10 +291,14 @@ fn test_jj_diff_cached_matches_diff() {
     let ws = ops.create_worktree(temp_dir.path(), "diff-cached").unwrap();
     let ws_path = Path::new(&ws);
 
-    std::fs::write(ws_path.join("staged.txt"), "content").unwrap();
+    // clean workspace — no staged changes yet
+    assert!(ops.diff_cached(ws_path).is_empty());
 
-    // jj has no staging area — diff_cached should equal diff
-    assert_eq!(ops.diff(ws_path), ops.diff_cached(ws_path));
+    // after a file write, diff_cached shows the full working-copy diff
+    std::fs::write(ws_path.join("staged.txt"), "content").unwrap();
+    let diff = ops.diff_cached(ws_path);
+    assert!(!diff.is_empty());
+    assert!(diff.contains("staged.txt"));
 }
 
 #[test]


### PR DESCRIPTION
I've really been enjoying agtx, but I use [jututsu](https://github.com/jj-vcs/jj) instead of git for my local workflow.

This isn't perfect, but it has been working well enough for the last week so I figured i'd share. :)

-[x] add a JJ implementation of GitOperations
-[x] show tag for jj or git when using looking at projects in the TUI
-[x] update the agtx review skill to use jj's diff command.