### PR TITLE
feat: add agent teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ With the orchestrator, you don't even manage the board yourself. **An AI agent p
 ## Features
 
 - **Orchestrator agent**: A dedicated AI agent that autonomously manages your kanban board via [MCP](https://modelcontextprotocol.io) — delegates to coding agents, advances phases, checks for merge conflicts ([experimental](#orchestrator-agent-experimental))
+- **Agent teams**: Decompose complex tasks into parallel subtasks during planning — each subtask gets its own worktree, agent session, and kanban lifecycle, then merges back automatically ([experimental](#agent-teams-experimental))
 - **Multi-agent task lifecycle**: Configure different agents per workflow phase — e.g. Gemini for research, Claude for implementation, Codex for review — with automatic agent switching
 - **Parallel execution**: Every task gets its own git worktree and tmux window — run as many agents as needed, simultaneously
 - **Spec-driven plugins**: Plug in [GSD](https://github.com/fynnfluegge/get-shit-done-cc), [Spec-kit](https://github.com/github/spec-kit), [OpenSpec](https://github.com/Fission-AI/OpenSpec), [BMAD](https://github.com/bmad-code-org/BMAD-METHOD), [Superpowers](https://github.com/obra/superpowers) — or define your own with a single TOML file
@@ -169,6 +170,19 @@ copy_files = ".env, .env.local, web/.env.local"
 
 # Shell command to run inside the worktree after creation and file copying
 init_script = "scripts/init_worktree.sh"
+
+# Enable agent teams: planning phase decomposes complex tasks into parallel subtasks.
+# Each subtask gets its own worktree, agent session, and kanban lifecycle.
+# Subtasks merge back into the parent branch automatically when done.
+# Defaults to false — opt-in per project.
+enable_agent_teams = true
+
+# Agent to use for subtasks (defaults to default_agent if not set)
+subtask_agent = "claude"
+
+# Model flag passed when spawning subtask agents (optional)
+# Only used if the agent supports --model
+subtask_model = "claude-sonnet-4-6"
 ```
 
 `base_branch` controls which branch new task worktrees are created from. If omitted or empty, agtx
@@ -447,6 +461,7 @@ agtx --experimental   # then press O
 **What it does:**
 - Monitors tasks in Planning and Running
 - Advances tasks automatically as phases complete (Planning → Running → Review)
+- Manages subtask waves: advances individual subtasks through their lifecycle, respects dep-blocking between siblings, and advances the parent when all subtasks are merged
 - Respects plugin phase rules — checks `allowed_actions` before each transition
 - Detects stuck tasks (idle for 1+ minute without a phase artifact) and reads the agent pane to diagnose the cause
 - Nudges stuck agents, answers CLI prompts automatically, or escalates to you with a reason when human input is needed
@@ -489,6 +504,32 @@ The orchestrator communicates with agtx through the [Model Context Protocol (MCP
 5. If a task has been idle for 1+ minute without a phase artifact, the orchestrator is notified — it reads the pane with `read_pane_content`, then either nudges the agent with `send_to_task` or calls `move_task` with `escalate_to_user` to flag it for your attention
 6. Escalated tasks show a `⚠` badge on the kanban board; opening the task popup shows the reason and dismisses the flag
 7. MCP registration is cleaned up when the orchestrator is stopped
+
+## Agent Teams (Experimental)
+
+> One task. Multiple agents. All in parallel.
+
+When `enable_agent_teams = true`, the planning phase uses a decomposition-aware skill (`plan-teams.md`). The planning agent analyses the task, applies a heuristic (3+ directories, sequential layers, or 5+ independent steps), and either decomposes into subtasks or proceeds as a normal single task.
+
+**What happens on decomposition:**
+1. The planning agent writes a plan per subtask to `.agtx/subtasks/{slug}/plan.md`
+2. It calls the `create_subtask` MCP tool for each subtask — child task records appear on the board under the parent
+3. When the parent advances to Running, all subtasks launch in parallel — each gets its own worktree branched off the parent branch, its own tmux window, and its own agent session
+4. Subtasks follow the normal Planning → Running → Review lifecycle, managed by the orchestrator
+5. When a subtask moves to Done, its branch is merged locally into the parent worktree. On conflict, the agent is automatically sent the `/agtx:merge-conflicts` skill
+6. When all subtasks are merged, the orchestrator receives a notification and advances the parent task to Review
+
+**On the board**, subtask cards appear indented under their parent in the parent's column. Blocked subtasks (waiting on a sibling dependency) show a `[blocked]` badge. Opening a parent with active subtasks shows a dashboard listing each subtask's status — press `1`–`9` to jump to that subtask's agent pane.
+
+**Enable per project** in `.agtx/config.toml`:
+
+```toml
+enable_agent_teams = true
+
+# Optional: use a faster/cheaper model for subtasks
+subtask_agent = "claude"
+subtask_model = "claude-haiku-4-5-20251001"
+```
 
 ## Contributing
 

--- a/plugins/agtx/plugin.toml
+++ b/plugins/agtx/plugin.toml
@@ -3,7 +3,7 @@ description = "Built-in workflow with skills and prompts"
 
 [artifacts]
 research = ".agtx/research.md"
-planning = ".agtx/plan.md"
+planning = ".agtx/planning.done"
 running = ".agtx/execute.md"
 review = ".agtx/review.md"
 
@@ -12,3 +12,6 @@ research = "/agtx:research {task}"
 planning = "/agtx:plan {task}"
 running = "/agtx:execute {task}"
 review = "/agtx:review"
+
+[subtask_copy_files]
+".agtx/subtasks/{slug}/plan.md" = ".agtx/plan.md"

--- a/plugins/agtx/skills/orchestrate.md
+++ b/plugins/agtx/skills/orchestrate.md
@@ -76,6 +76,21 @@ Backlog → Research → Planning → Running → Review
    finish processing and have no more pending work — this is how the board
    knows you are ready to receive the next notification.
 
+## Subtask Waves
+
+Tasks may have subtasks (identifiable by `parent_task_id` in `get_task` response).
+
+- **Only advance subtasks where `allowed_actions` includes `move_forward`.**
+  Dep-blocking is automatic — blocked tasks won't have `move_forward` available.
+- **Subtasks follow the same lifecycle as regular tasks:** Planning → Running → Review.
+  Each subtask has its own agent, worktree, and phase progression.
+- **When all children of a parent reach Done** (merged into parent branch), you'll
+  receive a notification: `"All subtasks of \"...\" (...) merged — parent ready for review"`.
+  Advance the parent with `move_forward` at that point.
+- **Never advance a parent independently** while it has children still in
+  Planning or Running. The parent's `allowed_actions` will omit `move_forward` until
+  all children are Done — trust the allowed_actions check.
+
 ## Rules
 
 - **You are a coordinator, not a reviewer.** Your job is to move tasks between phases.

--- a/plugins/agtx/skills/plan-teams.md
+++ b/plugins/agtx/skills/plan-teams.md
@@ -1,0 +1,96 @@
+---
+name: agtx-plan
+description: Analyze the codebase, write a plan, then decide whether to decompose into parallel subtasks.
+---
+
+# Planning Phase
+
+You are in the **planning phase** of an agtx-managed task.
+
+## Input
+
+- **Task description** — provided inline with this command (when entering directly from Backlog)
+- **`.agtx/research.md`** — prior analysis from research phase (when research was completed first)
+
+## Instructions
+
+1. If `.agtx/research.md` exists, read it for prior analysis
+2. Read and understand the task description
+3. Explore the codebase to understand relevant files, patterns, and architecture
+4. Identify all files that need to be created or modified
+5. Create a detailed implementation plan
+
+## Output
+
+Write your plan to `.agtx/plan.md` with these sections:
+
+## Analysis
+What you found in the codebase — relevant files, patterns, dependencies.
+
+## Plan
+Step-by-step implementation plan — files to modify, approach, order of changes.
+
+## Risks
+What could go wrong — edge cases, breaking changes, areas needing extra care.
+
+## CRITICAL: Stop After Writing
+
+Once you have written `.agtx/plan.md`, apply the decomposition heuristic below — do NOT
+start implementing.
+
+## Decomposition Heuristic
+
+**Split into subtasks if 2+ of these signals are present:**
+- Changes span 3+ distinct top-level directories (e.g. `src/db/`, `src/mcp/`, `src/tui/`)
+- Plan has clearly independent layers (schema, API, UI, tests) with minimal cross-dependency
+- 5+ implementation steps that could proceed in parallel or strict sequence
+- Different subtasks would never need to edit the same file
+
+**Proceed as single task if:**
+- Change is focused within 1-2 modules
+- Steps are tightly coupled — each step depends on the previous output
+- 3 or fewer files need to be modified
+
+## Path A: Decompose (complex)
+
+Before calling `create_subtask`, write a focused plan file for each subtask at
+`.agtx/subtasks/{slug}/plan.md`. Each file must be self-contained — no references to the
+global plan or other subtasks.
+
+```markdown
+# {title}
+
+## Scope
+{comma-separated files/dirs this subtask exclusively owns}
+
+## What to implement
+{focused implementation steps — only what this subtask does}
+
+## Context
+{minimal background needed — data structures, interfaces, conventions this subtask depends on}
+```
+
+Then call `create_subtask` via MCP for each subtask:
+- `parent_task_id`: the current task's ID (available from your context as the agtx task ID)
+- `slug`: "subtask-1", "subtask-2", etc. — must match the directory name used above
+- `title`: 3-5 words, imperative, describes the deliverable (e.g. "Add DB schema migrations")
+- `description`: 1-3 sentences max — what to implement and which files to own
+- `scope`: comma-separated files/dirs this subtask exclusively owns
+- `depends_on`: sibling slugs that must complete before this starts ([] if none)
+
+Rules:
+- Each file must appear in exactly one subtask's scope
+- Subtasks with no dependencies can run in parallel — list first
+- Tests/docs subtask always depends_on all implementation subtasks
+- Maximum 5 subtasks
+
+After all `create_subtask` calls:
+1. Write `.agtx/planning.done`
+2. Say: "Decomposition complete — N subtasks created."
+**Stop.**
+
+## Path B: No decomposition (simple)
+
+1. Write `.agtx/planning.done`
+2. Say: "No decomposition needed. Planning complete."
+**Stop.**

--- a/plugins/agtx/skills/plan.md
+++ b/plugins/agtx/skills/plan.md
@@ -35,8 +35,7 @@ What could go wrong — edge cases, breaking changes, areas needing extra care.
 
 ## CRITICAL: Stop After Writing
 
-After writing `.agtx/plan.md`:
-- Do NOT start implementing
-- Do NOT modify any source files
-- Say: "Plan written to `.agtx/plan.md`. Waiting for approval."
-- Wait for explicit instructions to proceed
+Once you have written `.agtx/plan.md`:
+1. Write `.agtx/planning.done` (signals phase complete to agtx)
+2. Say: "Planning complete."
+**Stop. Do not implement anything.**

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -36,10 +36,23 @@ impl Agent {
     /// Build the shell command to start the agent interactively.
     /// When prompt is empty, the agent starts with no initial message
     /// (task content and skill commands are sent later via tmux send_keys).
+    /// When model is set and the agent supports --model, the flag is appended.
     pub fn build_interactive_command(&self, prompt: &str) -> String {
+        self.build_interactive_command_with_model(prompt, None)
+    }
+
+    /// Build the shell command with an optional model override.
+    /// Currently only claude supports --model; other agents ignore the flag.
+    pub fn build_interactive_command_with_model(&self, prompt: &str, model: Option<&str>) -> String {
+        let model_suffix = match self.name.as_str() {
+            "claude" => model
+                .map(|m| format!(" --model {}", m))
+                .unwrap_or_default(),
+            _ => String::new(),
+        };
         if prompt.is_empty() {
             return match self.name.as_str() {
-                "claude" => "claude --dangerously-skip-permissions".to_string(),
+                "claude" => format!("claude --dangerously-skip-permissions{}", model_suffix),
                 "codex" => "codex --full-auto".to_string(),
                 "copilot" => "copilot --allow-all-tools".to_string(),
                 "gemini" => "gemini --approval-mode yolo".to_string(),
@@ -51,7 +64,7 @@ impl Agent {
 
         let escaped_prompt = prompt.replace('\'', "'\"'\"'");
         match self.name.as_str() {
-            "claude" => format!("claude --dangerously-skip-permissions '{}'", escaped_prompt),
+            "claude" => format!("claude --dangerously-skip-permissions{} '{}'", model_suffix, escaped_prompt),
             "codex" => format!("codex --full-auto '{}'", escaped_prompt),
             "copilot" => format!("copilot --allow-all-tools -p '{}'", escaped_prompt),
             "gemini" => format!("gemini --approval-mode yolo -i '{}'", escaped_prompt),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -205,6 +205,19 @@ pub struct ProjectConfig {
 
     /// Workflow plugin name (e.g. "gsd", "spec-kit")
     pub workflow_plugin: Option<String>,
+
+    /// Enable agent teams: planning phase splits tasks into parallel subtasks.
+    /// Defaults to false — opt-in per project.
+    #[serde(default)]
+    pub enable_agent_teams: bool,
+
+    /// Agent binary to use for subtasks (e.g. "claude", "codex").
+    /// Falls back to default_agent if not set.
+    pub subtask_agent: Option<String>,
+
+    /// Model flag passed when spawning subtask agents (e.g. "claude-sonnet-4-6").
+    /// Only used if the agent supports --model. Falls back to no model flag if not set.
+    pub subtask_model: Option<String>,
 }
 
 impl GlobalConfig {
@@ -327,6 +340,9 @@ pub struct MergedConfig {
     pub copy_files: Option<String>,
     pub init_script: Option<String>,
     pub workflow_plugin: Option<String>,
+    pub enable_agent_teams: bool,
+    pub subtask_agent: Option<String>,
+    pub subtask_model: Option<String>,
 }
 
 impl MergedConfig {
@@ -355,6 +371,9 @@ impl MergedConfig {
             copy_files: project.copy_files.clone(),
             init_script: project.init_script.clone(),
             workflow_plugin: project.workflow_plugin.clone(),
+            enable_agent_teams: project.enable_agent_teams,
+            subtask_agent: project.subtask_agent.clone(),
+            subtask_model: project.subtask_model.clone(),
         }
     }
 
@@ -414,6 +433,12 @@ pub struct WorkflowPlugin {
     /// Each rule specifies patterns to detect and keystrokes to send in response.
     #[serde(default)]
     pub auto_dismiss: Vec<AutoDismiss>,
+    /// Files to copy from the parent worktree into subtask worktrees at launch time.
+    /// Keys are source paths (relative to parent worktree), values are destination paths
+    /// (relative to child worktree). Supports `{slug}` substitution for the subtask slug.
+    /// e.g. { ".agtx/subtasks/{slug}/plan.md" = ".agtx/plan.md" }
+    #[serde(default)]
+    pub subtask_copy_files: std::collections::HashMap<String, String>,
 }
 
 /// Rule for auto-dismissing interactive prompts in the tmux pane.

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -73,6 +73,9 @@ pub struct Task {
     pub cycle: i32,
     pub referenced_tasks: Option<String>,
     pub escalation_note: Option<String>,
+    pub parent_task_id: Option<String>,  // None on regular tasks; Some(id) on subtasks
+    pub subtask_deps: Option<String>,    // comma-separated task IDs this task depends on
+    pub subtask_slug: Option<String>,    // agent-provided slug e.g. "subtask-1"
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -101,6 +104,9 @@ impl Task {
             cycle: 1,
             referenced_tasks: None,
             escalation_note: None,
+            parent_task_id: None,
+            subtask_deps: None,
+            subtask_slug: None,
             created_at: now,
             updated_at: now,
         }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -132,6 +132,15 @@ impl Database {
         let _ = self
             .conn
             .execute("ALTER TABLE tasks ADD COLUMN escalation_note TEXT", []);
+        let _ = self
+            .conn
+            .execute("ALTER TABLE tasks ADD COLUMN parent_task_id TEXT", []);
+        let _ = self
+            .conn
+            .execute("ALTER TABLE tasks ADD COLUMN subtask_deps TEXT", []);
+        let _ = self
+            .conn
+            .execute("ALTER TABLE tasks ADD COLUMN subtask_slug TEXT", []);
 
         // MCP transition request queue
         self.conn.execute_batch(
@@ -194,8 +203,8 @@ impl Database {
     pub fn create_task(&self, task: &Task) -> Result<()> {
         self.conn.execute(
             r#"
-            INSERT INTO tasks (id, title, description, status, agent, project_id, session_name, worktree_path, branch_name, pr_number, pr_url, plugin, cycle, referenced_tasks, escalation_note, created_at, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+            INSERT INTO tasks (id, title, description, status, agent, project_id, session_name, worktree_path, branch_name, pr_number, pr_url, plugin, cycle, referenced_tasks, escalation_note, parent_task_id, subtask_deps, subtask_slug, created_at, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
             "#,
             params![
                 task.id,
@@ -213,6 +222,9 @@ impl Database {
                 task.cycle,
                 task.referenced_tasks,
                 task.escalation_note,
+                task.parent_task_id,
+                task.subtask_deps,
+                task.subtask_slug,
                 task.created_at.to_rfc3339(),
                 task.updated_at.to_rfc3339(),
             ],
@@ -237,7 +249,10 @@ impl Database {
                 cycle = ?12,
                 referenced_tasks = ?13,
                 escalation_note = ?14,
-                updated_at = ?15
+                parent_task_id = ?15,
+                subtask_deps = ?16,
+                subtask_slug = ?17,
+                updated_at = ?18
             WHERE id = ?1
             "#,
             params![
@@ -255,6 +270,9 @@ impl Database {
                 task.cycle,
                 task.referenced_tasks,
                 task.escalation_note,
+                task.parent_task_id,
+                task.subtask_deps,
+                task.subtask_slug,
                 task.updated_at.to_rfc3339(),
             ],
         )?;
@@ -285,6 +303,9 @@ impl Database {
             cycle: row.get("cycle").unwrap_or(1),
             referenced_tasks: row.get("referenced_tasks").ok().flatten(),
             escalation_note: row.get("escalation_note").ok().flatten(),
+            parent_task_id: row.get("parent_task_id").ok().flatten(),
+            subtask_deps: row.get("subtask_deps").ok().flatten(),
+            subtask_slug: row.get("subtask_slug").ok().flatten(),
             created_at: chrono::DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at")?)
                 .map(|dt| dt.with_timezone(&chrono::Utc))
                 .unwrap_or_else(|_| chrono::Utc::now()),
@@ -322,6 +343,20 @@ impl Database {
 
         let tasks = stmt
             .query_map([], Self::task_from_row)?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(tasks)
+    }
+
+    /// Get all subtasks (child tasks) for a given parent task ID, ordered by creation time.
+    pub fn get_child_tasks(&self, parent_id: &str) -> Result<Vec<Task>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT * FROM tasks WHERE parent_task_id = ?1 ORDER BY created_at ASC")?;
+
+        let tasks = stmt
+            .query_map(params![parent_id], Self::task_from_row)?
             .filter_map(|r| r.ok())
             .collect();
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -83,6 +83,28 @@ pub struct SendToTaskParams {
     pub message: String,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct CreateSubtaskParams {
+    /// The parent task ID (UUID) — must be in Planning status
+    #[schemars(description = "The parent task ID (UUID) — must be in Planning status")]
+    pub parent_task_id: String,
+    /// Short slug for this subtask (e.g. "subtask-1") — used in depends_on references and file paths
+    #[schemars(description = "Short slug for this subtask (e.g. \"subtask-1\")")]
+    pub slug: String,
+    /// Short imperative title (3-5 words) describing the deliverable
+    #[schemars(description = "Short imperative title (3-5 words) describing the deliverable")]
+    pub title: String,
+    /// 1-3 sentence description of what to implement and which files to own
+    #[schemars(description = "1-3 sentence description of what to implement and which files to own")]
+    pub description: String,
+    /// Comma-separated files/dirs this subtask exclusively modifies
+    #[schemars(description = "Comma-separated files/dirs this subtask exclusively modifies")]
+    pub scope: String,
+    /// Sibling slugs that must complete before this subtask can start ([] if none)
+    #[schemars(description = "Sibling slugs that must complete before this subtask can start")]
+    pub depends_on: Vec<String>,
+}
+
 // === Response types ===
 
 #[derive(Serialize)]
@@ -119,6 +141,7 @@ struct TaskDetail {
     pr_url: Option<String>,
     plugin: Option<String>,
     cycle: i32,
+    parent_task_id: Option<String>,
     created_at: String,
     updated_at: String,
     /// Actions the orchestrator can take on this task given its current status and plugin rules.
@@ -181,6 +204,12 @@ struct SendToTaskResponse {
     message: String,
 }
 
+#[derive(Serialize)]
+struct CreateSubtaskResult {
+    subtask_id: String,
+    message: String,
+}
+
 // === MCP Server ===
 
 #[derive(Debug, Clone)]
@@ -207,10 +236,10 @@ impl AgtxMcpServer {
     }
 
     /// Compute which move_task actions are valid for a task given its status and plugin rules.
-    fn allowed_actions(&self, task: &Task) -> Vec<String> {
+    fn allowed_actions(&self, task: &Task, db: &Database) -> Vec<String> {
         let mut actions = Vec::new();
 
-        let plugin = match &task.plugin {
+        let _plugin = match &task.plugin {
             Some(name) => crate::config::WorkflowPlugin::load(name, Some(&self.project_path))
                 .ok()
                 .or_else(|| crate::skills::load_bundled_plugin(name)),
@@ -234,6 +263,36 @@ impl AgtxMcpServer {
                 actions.push("resume".to_string());
             }
             TaskStatus::Done => {}
+        }
+
+        // Dep-blocking: remove move_forward if sibling deps are not yet Done
+        if let Some(ref deps_str) = task.subtask_deps {
+            let blocked = deps_str
+                .split(',')
+                .filter(|s| !s.is_empty())
+                .any(|dep_id| {
+                    db.get_task(dep_id)
+                        .ok()
+                        .flatten()
+                        .map(|t| !matches!(t.status, TaskStatus::Done))
+                        .unwrap_or(true)
+                });
+            if blocked {
+                actions.retain(|a| a != "move_forward");
+            }
+        }
+
+        // Parent blocking: remove move_forward (Running→Review) if any child is not Done
+        if task.parent_task_id.is_none() && matches!(task.status, TaskStatus::Running) {
+            let children = db.get_child_tasks(&task.id).unwrap_or_default();
+            if !children.is_empty() {
+                let all_done = children
+                    .iter()
+                    .all(|c| matches!(c.status, TaskStatus::Done));
+                if !all_done {
+                    actions.retain(|a| a != "move_forward");
+                }
+            }
         }
 
         actions
@@ -310,7 +369,7 @@ impl AgtxMcpServer {
         match self.open_project_db() {
             Ok(db) => match db.get_task(&params.task_id) {
                 Ok(Some(t)) => {
-                    let allowed = self.allowed_actions(&t);
+                    let allowed = self.allowed_actions(&t, &db);
                     let detail = TaskDetail {
                         id: t.id,
                         title: t.title,
@@ -325,6 +384,7 @@ impl AgtxMcpServer {
                         pr_url: t.pr_url,
                         plugin: t.plugin,
                         cycle: t.cycle,
+                        parent_task_id: t.parent_task_id,
                         created_at: t.created_at.to_rfc3339(),
                         updated_at: t.updated_at.to_rfc3339(),
                         allowed_actions: allowed,
@@ -639,6 +699,95 @@ impl AgtxMcpServer {
                     .unwrap_or_else(|e| format!("Error serializing: {}", e))
             }
             Err(e) => format!("Error sending Enter: {}", e),
+        }
+    }
+
+    #[tool(
+        description = "Create a subtask (child task) under a parent task that is in Planning status. The subtask starts in Backlog and will be launched automatically when the parent advances to Running. Idempotent: if a subtask with the same parent_task_id + slug already exists, returns its existing ID."
+    )]
+    fn create_subtask(&self, Parameters(params): Parameters<CreateSubtaskParams>) -> String {
+        let db = match self.open_project_db() {
+            Ok(db) => db,
+            Err(e) => return e,
+        };
+
+        // Verify parent exists and is in Planning status
+        let parent = match db.get_task(&params.parent_task_id) {
+            Ok(Some(t)) => t,
+            Ok(None) => {
+                return format!("Parent task not found: {}", params.parent_task_id)
+            }
+            Err(e) => return format!("Error getting parent task: {}", e),
+        };
+        if !matches!(parent.status, TaskStatus::Planning) {
+            return format!(
+                "Parent task is not in Planning status (current: {}). Subtasks can only be created during the Planning phase.",
+                parent.status.as_str()
+            );
+        }
+
+        // Idempotency: if a subtask with same parent + slug already exists, return its ID
+        let existing_children = db.get_child_tasks(&params.parent_task_id).unwrap_or_default();
+        if let Some(existing) = existing_children
+            .iter()
+            .find(|c| c.subtask_slug.as_deref() == Some(&params.slug))
+        {
+            let result = CreateSubtaskResult {
+                subtask_id: existing.id.clone(),
+                message: format!(
+                    "Subtask with slug '{}' already exists under parent {}.",
+                    params.slug, params.parent_task_id
+                ),
+            };
+            return serde_json::to_string_pretty(&result)
+                .unwrap_or_else(|e| format!("Error serializing: {}", e));
+        }
+
+        // Resolve depends_on slugs → task IDs
+        let resolved_deps: Vec<String> = params
+            .depends_on
+            .iter()
+            .filter_map(|dep_slug| {
+                existing_children
+                    .iter()
+                    .find(|c| c.subtask_slug.as_deref() == Some(dep_slug.as_str()))
+                    .map(|c| c.id.clone())
+            })
+            .collect();
+        let subtask_deps = if resolved_deps.is_empty() {
+            None
+        } else {
+            Some(resolved_deps.join(","))
+        };
+
+        // Build description including scope
+        let full_description = format!("{}\n\nScope: {}", params.description, params.scope);
+
+        let mut subtask = crate::db::Task::new(
+            &params.title,
+            &parent.agent,
+            &parent.project_id,
+        );
+        subtask.status = TaskStatus::Backlog;
+        subtask.parent_task_id = Some(params.parent_task_id.clone());
+        subtask.subtask_slug = Some(params.slug.clone());
+        subtask.subtask_deps = subtask_deps;
+        subtask.description = Some(full_description);
+        subtask.plugin = parent.plugin.clone();
+
+        match db.create_task(&subtask) {
+            Ok(()) => {
+                let result = CreateSubtaskResult {
+                    subtask_id: subtask.id,
+                    message: format!(
+                        "Subtask '{}' (slug: {}) created under parent {}.",
+                        params.title, params.slug, params.parent_task_id
+                    ),
+                };
+                serde_json::to_string_pretty(&result)
+                    .unwrap_or_else(|e| format!("Error serializing: {}", e))
+            }
+            Err(e) => format!("Error creating subtask: {}", e),
         }
     }
 }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -4,6 +4,7 @@
 
 pub const RESEARCH_SKILL: &str = include_str!("../plugins/agtx/skills/research.md");
 pub const PLAN_SKILL: &str = include_str!("../plugins/agtx/skills/plan.md");
+pub const PLAN_TEAMS_SKILL: &str = include_str!("../plugins/agtx/skills/plan-teams.md");
 pub const EXECUTE_SKILL: &str = include_str!("../plugins/agtx/skills/execute.md");
 pub const REVIEW_SKILL: &str = include_str!("../plugins/agtx/skills/review.md");
 pub const ORCHESTRATE_SKILL: &str = include_str!("../plugins/agtx/skills/orchestrate.md");

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4809,13 +4809,21 @@ impl App {
 
             // Deploy skills to the worktree
             let agent_refs: Vec<&str> = all_agents.iter().map(|s| s.as_str()).collect();
-            write_skills_to_worktree(
-                &worktree_path_str,
-                &project_path,
-                &plugin,
-                &agent_refs,
-                enable_agent_teams,
-            );
+            if enable_agent_teams {
+                write_skills_to_worktree_teams(
+                    &worktree_path_str,
+                    &project_path,
+                    &plugin,
+                    &agent_refs,
+                );
+            } else {
+                write_skills_to_worktree(
+                    &worktree_path_str,
+                    &project_path,
+                    &plugin,
+                    &agent_refs,
+                );
+            }
 
             // Create tmux window and spawn agent with /agtx:execute
             let task_content = child.content_text();
@@ -6901,7 +6909,11 @@ fn setup_task_worktree(
     // Write skills to worktree .agtx/skills/ and agent-native discovery paths
     // Deploy for all unique agents configured across phases
     let agent_refs: Vec<&str> = all_phase_agents.iter().map(|s| s.as_str()).collect();
-    write_skills_to_worktree(&worktree_path_str, project_path, plugin, &agent_refs, enable_agent_teams);
+    if enable_agent_teams {
+        write_skills_to_worktree_teams(&worktree_path_str, project_path, plugin, &agent_refs);
+    } else {
+        write_skills_to_worktree(&worktree_path_str, project_path, plugin, &agent_refs);
+    }
 
     // Copy referenced task artifacts into .agtx/references/
     if !referenced_tasks.is_empty() {
@@ -8448,6 +8460,24 @@ fn load_plugin_if_configured(
 /// `agent_names` determines which native paths to use (e.g. `.claude/commands/agtx/` for Claude).
 /// When multiple agents are configured for different phases, skills are deployed for all of them.
 fn write_skills_to_worktree(
+    worktree_path: &str,
+    project_path: &Path,
+    plugin: &Option<WorkflowPlugin>,
+    agent_names: &[&str],
+) {
+    write_skills_to_worktree_impl(worktree_path, project_path, plugin, agent_names, false);
+}
+
+fn write_skills_to_worktree_teams(
+    worktree_path: &str,
+    project_path: &Path,
+    plugin: &Option<WorkflowPlugin>,
+    agent_names: &[&str],
+) {
+    write_skills_to_worktree_impl(worktree_path, project_path, plugin, agent_names, true);
+}
+
+fn write_skills_to_worktree_impl(
     worktree_path: &str,
     project_path: &Path,
     plugin: &Option<WorkflowPlugin>,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -249,6 +249,8 @@ struct AppState {
     review_to_running_task_id: Option<String>,
     // Git diff popup
     diff_popup: Option<DiffPopup>,
+    // Subtask dashboard popup (shown when pressing Enter on a parent with active subtasks)
+    subtask_dashboard: Option<SubtaskDashboard>,
     // Channel for receiving PR description generation results
     pr_generation_rx: Option<mpsc::Receiver<(String, String)>>,
     // PR creation status popup
@@ -294,6 +296,18 @@ struct AppState {
     orchestrator_last_check: Instant,
     // Background session refresh channel (non-blocking phase status polling)
     session_refresh_rx: Option<mpsc::Receiver<SessionRefreshResult>>,
+}
+
+/// Subtask dashboard popup shown when pressing Enter on a parent task with active subtasks.
+/// Lists each subtask with its status; keys 1-9 jump to that subtask's tmux pane.
+#[derive(Debug, Clone)]
+struct SubtaskDashboard {
+    /// Parent task ID
+    parent_id: String,
+    /// Parent task title
+    parent_title: String,
+    /// Ordered list of subtask IDs shown in the dashboard
+    subtask_ids: Vec<String>,
 }
 
 /// State for confirming move to Done
@@ -590,6 +604,7 @@ impl App {
                 pr_confirm_popup: None,
                 review_to_running_task_id: None,
                 diff_popup: None,
+                subtask_dashboard: None,
                 pr_generation_rx: None,
                 pr_status_popup: None,
                 pr_creation_rx: None,
@@ -765,6 +780,7 @@ impl App {
                 pr_confirm_popup: None,
                 review_to_running_task_id: None,
                 diff_popup: None,
+                subtask_dashboard: None,
                 pr_generation_rx: None,
                 pr_status_popup: None,
                 pr_creation_rx: None,
@@ -1017,16 +1033,43 @@ impl App {
             .split(chunks[1]);
 
         for (i, status) in TaskStatus::columns().iter().enumerate() {
-            let tasks: Vec<&Task> = state
+            // Column placement rule: subtasks always render in their parent's column.
+            // Collect tasks that "belong" to this column:
+            //   - Regular tasks (no parent_task_id) with this status
+            //   - Subtasks whose parent has this status
+            // Then interleave: for each parent in the column, insert its subtasks right below it.
+            let regular_tasks: Vec<&Task> = state
                 .board
                 .tasks
                 .iter()
-                .filter(|t| t.status == *status)
+                .filter(|t| t.status == *status && t.parent_task_id.is_none())
                 .collect();
+
+            // Build ordered task list: parent → its subtasks (sorted by created_at) → next parent
+            let mut tasks: Vec<(&Task, bool)> = Vec::new(); // (task, is_subtask_card)
+            for parent in &regular_tasks {
+                tasks.push((parent, false));
+                let mut children: Vec<&Task> = state
+                    .board
+                    .tasks
+                    .iter()
+                    .filter(|t| t.parent_task_id.as_deref() == Some(parent.id.as_str()))
+                    .collect();
+                children.sort_by_key(|t| &t.created_at);
+                for child in children {
+                    tasks.push((child, true));
+                }
+            }
+            // Also include orphan subtasks whose parent isn't in this column
+            // (e.g. subtask whose parent_task_id no longer exists — defensive)
+            // These are already shown in their own status column via the above logic.
+            // Subtasks with a valid parent in a different column: skip (parent's column owns them).
+            // But we must include subtasks whose parent is in this column (already done above).
 
             let is_selected_column = state.board.selected_column == i;
 
-            let title = format!(" {} ({}) ", status.display_name(), tasks.len());
+            // Column header count: only count regular (non-subtask) tasks in this status
+            let title = format!(" {} ({}) ", status.display_name(), regular_tasks.len());
             let (border_style, title_style) = if is_selected_column {
                 (
                     Style::default().fg(hex_to_color(&state.config.theme.color_selected)),
@@ -1057,7 +1100,7 @@ impl App {
 
             // Check if we need a scrollbar
             let needs_scrollbar = tasks.len() > max_visible_cards;
-            let content_width = if needs_scrollbar {
+            let _content_width = if needs_scrollbar {
                 columns[i].width.saturating_sub(3) // Leave room for scrollbar
             } else {
                 columns[i].width.saturating_sub(2)
@@ -1078,18 +1121,21 @@ impl App {
                 .skip(scroll_offset)
                 .take(max_visible_cards)
                 .collect();
-            for (j, task) in visible_tasks.iter().enumerate() {
+            for (j, (task, is_subtask_card)) in visible_tasks.iter().enumerate() {
                 let actual_index = scroll_offset + j;
                 let is_selected = is_selected_column && state.board.selected_row == actual_index;
 
+                // Subtask cards are indented 2 columns and reduced in width
+                let indent: u16 = if *is_subtask_card { 2 } else { 0 };
+                let base_width = if needs_scrollbar {
+                    inner_area.width.saturating_sub(1)
+                } else {
+                    inner_area.width
+                };
                 let card_area = Rect {
-                    x: inner_area.x,
+                    x: inner_area.x + indent,
                     y: inner_area.y + (j as u16 * card_height),
-                    width: if needs_scrollbar {
-                        inner_area.width.saturating_sub(1)
-                    } else {
-                        inner_area.width
-                    },
+                    width: base_width.saturating_sub(indent),
                     height: card_height
                         .min(inner_area.height.saturating_sub(j as u16 * card_height)),
                 };
@@ -1097,6 +1143,28 @@ impl App {
                 if card_area.height < 3 {
                     break;
                 }
+
+                // Count active (non-Done) subtasks for parent badge
+                let active_child_count = state
+                    .board
+                    .tasks
+                    .iter()
+                    .filter(|t| {
+                        t.parent_task_id.as_deref() == Some(task.id.as_str())
+                            && !matches!(t.status, TaskStatus::Done)
+                    })
+                    .count();
+
+                // Compute is_blocked: subtask with unresolved deps (deps not all Done)
+                let is_blocked = task.subtask_deps.as_ref().map_or(false, |deps_str| {
+                    deps_str.split(',').filter(|s| !s.is_empty()).any(|dep_id| {
+                        !state
+                            .board
+                            .tasks
+                            .iter()
+                            .any(|t| t.id == dep_id && matches!(t.status, TaskStatus::Done))
+                    })
+                });
 
                 Self::draw_task_card(
                     frame,
@@ -1106,6 +1174,8 @@ impl App {
                     &state.config.theme,
                     state.phase_status_cache.get(&task.id),
                     state.spinner_frame,
+                    active_child_count,
+                    is_blocked,
                 );
             }
 
@@ -1514,6 +1584,11 @@ impl App {
         // Shell popup overlay
         if let Some(popup) = &state.shell_popup {
             Self::draw_shell_popup(popup, frame, area, &state.config.theme);
+        }
+
+        // Subtask dashboard popup overlay
+        if let Some(ref dashboard) = state.subtask_dashboard {
+            Self::draw_subtask_dashboard(dashboard, state, frame, area);
         }
 
         // Task search popup
@@ -2033,6 +2108,109 @@ impl App {
         }
     }
 
+    /// Draw the subtask dashboard popup for a parent task.
+    fn draw_subtask_dashboard(
+        dashboard: &SubtaskDashboard,
+        state: &AppState,
+        frame: &mut Frame,
+        area: Rect,
+    ) {
+        let popup_area = centered_rect_fixed_width(60, 70, area);
+        frame.render_widget(Clear, popup_area);
+
+        let theme = &state.config.theme;
+        let block = Block::default()
+            .title(format!(" {} ", dashboard.parent_title))
+            .title_style(
+                Style::default()
+                    .fg(hex_to_color(&theme.color_popup_header))
+                    .bold(),
+            )
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(hex_to_color(&theme.color_popup_border)));
+
+        let inner = block.inner(popup_area);
+        frame.render_widget(block, popup_area);
+
+        // Build subtask rows
+        let mut lines: Vec<Line> = Vec::new();
+        lines.push(Line::from(""));
+
+        for (idx, subtask_id) in dashboard.subtask_ids.iter().enumerate() {
+            let num = idx + 1;
+            if let Some(task) = state.board.tasks.iter().find(|t| &t.id == subtask_id) {
+                // Status icon from phase_status_cache
+                let status_icon = match task.status {
+                    TaskStatus::Done => "✓",
+                    TaskStatus::Review => "⌛",
+                    _ => match state.phase_status_cache.get(&task.id).map(|(s, _)| s) {
+                        Some(PhaseStatus::Ready) => "✓",
+                        Some(PhaseStatus::Idle) => "⏸",
+                        Some(PhaseStatus::Exited) => "✗",
+                        _ => "⟳",
+                    },
+                };
+
+                let is_blocked = task.subtask_deps.as_ref().map_or(false, |deps_str| {
+                    deps_str.split(',').filter(|s| !s.is_empty()).any(|dep_id| {
+                        !state
+                            .board
+                            .tasks
+                            .iter()
+                            .any(|t| t.id == dep_id && matches!(t.status, TaskStatus::Done))
+                    })
+                });
+
+                let status_label = if is_blocked {
+                    "[Blocked]".to_string()
+                } else {
+                    format!("[{}]", task.status.display_name())
+                };
+
+                let num_span = Span::styled(
+                    format!("  {}. ", num),
+                    Style::default().fg(hex_to_color(&theme.color_dimmed)),
+                );
+                let icon_span = Span::styled(
+                    format!("{} ", status_icon),
+                    Style::default().fg(hex_to_color(&theme.color_accent)),
+                );
+                let title_span = Span::styled(
+                    task.title.clone(),
+                    Style::default().fg(hex_to_color(&theme.color_text)),
+                );
+                let status_span = Span::styled(
+                    format!("  {}", status_label),
+                    Style::default().fg(hex_to_color(&theme.color_dimmed)),
+                );
+
+                lines.push(Line::from(vec![
+                    num_span,
+                    icon_span,
+                    title_span,
+                    status_span,
+                ]));
+            }
+        }
+
+        lines.push(Line::from(""));
+
+        // Footer with key hints
+        let max_num = dashboard.subtask_ids.len().min(9);
+        let footer_text = if max_num > 0 {
+            format!("  [1-{}] Open subtask   [Esc] Close", max_num)
+        } else {
+            "  [Esc] Close".to_string()
+        };
+        lines.push(Line::from(Span::styled(
+            footer_text,
+            Style::default().fg(hex_to_color(&theme.color_dimmed)),
+        )));
+
+        let content = Paragraph::new(lines);
+        frame.render_widget(content, inner);
+    }
+
     fn draw_shell_popup(popup: &ShellPopup, frame: &mut Frame, area: Rect, theme: &ThemeConfig) {
         let popup_area =
             centered_rect_fixed_width(SHELL_POPUP_WIDTH, SHELL_POPUP_HEIGHT_PERCENT, area);
@@ -2062,6 +2240,8 @@ impl App {
         theme: &ThemeConfig,
         phase_status: Option<&(PhaseStatus, Instant)>,
         spinner_frame: usize,
+        active_child_count: usize,
+        is_blocked: bool,
     ) {
         let border_style = if is_selected {
             Style::default().fg(hex_to_color(&theme.color_selected))
@@ -2079,15 +2259,35 @@ impl App {
 
         // Truncate title to fit (char-safe for UTF-8)
         let max_title_len = area.width.saturating_sub(4) as usize;
-        let title: String = if task.title.chars().count() > max_title_len {
-            let truncated: String = task
-                .title
+
+        // Build title prefix for subtasks and badge for parents
+        let is_subtask = task.parent_task_id.is_some();
+        let subtask_prefix = if is_subtask { "\u{22a2} " } else { "" }; // ⊢
+        let child_badge = if active_child_count > 0 {
+            format!(" [\u{2193}{}]", active_child_count) // [↓ N]
+        } else {
+            String::new()
+        };
+        // [blocked] badge: only show when there are unresolved deps (not all Done).
+        // draw_task_card can't query the DB, so the caller passes in a pre-computed flag.
+        // For now we keep the conservative check (non-empty deps = potentially blocked);
+        // the accurate check is done in draw_board via the `is_blocked` parameter.
+        let blocked_badge = if is_subtask && is_blocked { " [blocked]" } else { "" };
+        let base_title = format!(
+            "{}{}{}{}",
+            subtask_prefix,
+            task.title,
+            child_badge,
+            blocked_badge
+        );
+        let title: String = if base_title.chars().count() > max_title_len {
+            let truncated: String = base_title
                 .chars()
                 .take(max_title_len.saturating_sub(3))
                 .collect();
             format!("{}...", truncated)
         } else {
-            task.title.clone()
+            base_title
         };
 
         let border_type = if is_selected {
@@ -2427,6 +2627,11 @@ impl App {
         // Handle shell popup if open
         if self.state.shell_popup.is_some() {
             return self.handle_shell_popup_key(key);
+        }
+
+        // Handle subtask dashboard popup if open
+        if self.state.subtask_dashboard.is_some() {
+            return self.handle_subtask_dashboard_key(key);
         }
 
         // Handle based on mode (Dashboard vs Project)
@@ -3041,6 +3246,70 @@ impl App {
                         self.state.tmux_ops.as_ref(),
                     );
                 }
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_subtask_dashboard_key(&mut self, key: crossterm::event::KeyEvent) -> Result<()> {
+        let dashboard = match self.state.subtask_dashboard.take() {
+            Some(d) => d,
+            None => return Ok(()),
+        };
+
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                // dashboard already taken (closed)
+            }
+            KeyCode::Char(c) if c.is_ascii_digit() => {
+                let idx = (c as u8 - b'0') as usize;
+                if idx >= 1 && idx <= dashboard.subtask_ids.len() {
+                    let subtask_id = dashboard.subtask_ids[idx - 1].clone();
+                    // Open the subtask's tmux pane
+                    if let Some(task) = self
+                        .state
+                        .board
+                        .tasks
+                        .iter()
+                        .find(|t| t.id == subtask_id)
+                    {
+                        if let Some(window_name) = task.session_name.clone() {
+                            let task_id = task.id.clone();
+                            let task_title = task.title.clone();
+                            let escalation_note = task.escalation_note.clone();
+                            let mut popup = ShellPopup::new(task_title, window_name.clone());
+                            popup.task_id = Some(task_id);
+                            popup.escalation_note = escalation_note;
+                            if let Ok((_term_width, term_height)) = crossterm::terminal::size() {
+                                let pane_width = SHELL_POPUP_CONTENT_WIDTH;
+                                let popup_height = (term_height as u32
+                                    * SHELL_POPUP_HEIGHT_PERCENT as u32
+                                    / 100) as u16;
+                                let pane_height = popup_height.saturating_sub(4);
+                                let _ = self.state.tmux_ops.resize_window(
+                                    &window_name,
+                                    pane_width,
+                                    pane_height,
+                                );
+                                popup.last_pane_size = Some((pane_width, pane_height));
+                                std::thread::sleep(std::time::Duration::from_millis(200));
+                            }
+                            popup.cached_content = capture_tmux_pane_with_history(
+                                &window_name,
+                                500,
+                                self.state.tmux_ops.as_ref(),
+                            );
+                            self.state.shell_popup = Some(popup);
+                        }
+                    }
+                } else {
+                    // Out of range — restore dashboard
+                    self.state.subtask_dashboard = Some(dashboard);
+                }
+            }
+            _ => {
+                // Restore dashboard for any other key
+                self.state.subtask_dashboard = Some(dashboard);
             }
         }
         Ok(())
@@ -4277,6 +4546,7 @@ impl App {
             .as_ref()
             .map_or_else(Vec::new, |p| p.auto_dismiss.clone());
         let project_path = project_path.to_path_buf();
+        let enable_agent_teams = self.state.config.enable_agent_teams;
 
         // Pre-fetch referenced task info (DB isn't Send, so fetch before spawning thread)
         let referenced_tasks: Vec<ReferencedTaskInfo> = task
@@ -4324,6 +4594,7 @@ impl App {
                 git_ops.as_ref(),
                 agent_ops.as_ref(),
                 &referenced_tasks,
+                enable_agent_teams,
             );
 
             match result {
@@ -4370,8 +4641,27 @@ impl App {
     }
 
     /// Planning → Running: send execution skill/prompt to agent.
+    /// If the parent task has subtasks in Backlog, launches all of them instead.
     /// Always returns Ok(false) to continue with db update.
     fn transition_to_running(&mut self, task: &mut Task) -> Result<bool> {
+        // Check if parent has Backlog subtasks — if so, launch them instead of the normal flow
+        if let Some(db) = &self.state.db {
+            let children = db.get_child_tasks(&task.id).unwrap_or_default();
+            let backlog_children: Vec<String> = children
+                .iter()
+                .filter(|c| matches!(c.status, TaskStatus::Backlog))
+                .map(|c| c.id.clone())
+                .collect();
+            if !backlog_children.is_empty() {
+                // Parent has subtasks — launch all of them, parent has no agent of its own
+                for child_id in backlog_children {
+                    self.launch_subtask(&child_id);
+                }
+                // Parent moves to Running but no agent is spawned for the parent itself
+                return Ok(false);
+            }
+        }
+
         if let Some(session_name) = &task.session_name {
             let plugin = self.load_task_plugin(task);
             let (running_agent, agent_switch) =
@@ -4414,6 +4704,171 @@ impl App {
         Ok(false)
     }
 
+    /// Launch a subtask: create its worktree (branched off parent branch), copy subtask_copy_files,
+    /// deploy skills, and spawn the agent with /agtx:execute.
+    fn launch_subtask(&mut self, child_id: &str) {
+        let db = match &self.state.db {
+            Some(db) => db,
+            None => return,
+        };
+
+        let child = match db.get_task(child_id).ok().flatten() {
+            Some(t) => t,
+            None => return,
+        };
+        let parent = match child
+            .parent_task_id
+            .as_ref()
+            .and_then(|pid| db.get_task(pid).ok().flatten())
+        {
+            Some(t) => t,
+            None => return,
+        };
+
+        let parent_branch = match &parent.branch_name {
+            Some(b) => b.clone(),
+            None => return,
+        };
+        let parent_worktree = match &parent.worktree_path {
+            Some(wt) => wt.clone(),
+            None => return,
+        };
+        let child_slug = match &child.subtask_slug {
+            Some(s) => s.clone(),
+            None => child.id.clone(),
+        };
+
+        let project_path = match &self.state.project_path {
+            Some(p) => p.clone(),
+            None => return,
+        };
+
+        // Determine agent and model for the subtask
+        let subtask_agent = self
+            .state
+            .config
+            .subtask_agent
+            .clone()
+            .unwrap_or_else(|| self.state.config.default_agent.clone());
+        let subtask_model = self.state.config.subtask_model.clone();
+
+        // Load plugin for subtask
+        let plugin = self.load_task_plugin(&child);
+
+        // Collect subtask copy files from plugin
+        let subtask_copy_files: std::collections::HashMap<String, String> = plugin
+            .as_ref()
+            .map(|p| p.subtask_copy_files.clone())
+            .unwrap_or_default();
+
+        let all_agents = collect_phase_agents(&self.state.config);
+        let tmux_project_name = self.state.tmux_project_name.clone();
+        let tmux_ops = Arc::clone(&self.state.tmux_ops);
+        let git_ops = Arc::clone(&self.state.git_ops);
+        let agent_ops = self.state.agent_registry.get(&subtask_agent);
+        let child_id_owned = child_id.to_string();
+        let enable_agent_teams = self.state.config.enable_agent_teams;
+
+        std::thread::spawn(move || {
+            // Create worktree branched off parent branch (not main)
+            let unique_slug = generate_task_slug(&child.id, &child.title);
+            let window_name = format!("task-{}", unique_slug);
+            let target = format!("{}:{}", tmux_project_name, window_name);
+
+            let worktree_path_str = match git_ops.create_worktree(
+                &project_path,
+                &unique_slug,
+                &parent_branch,
+            ) {
+                Ok(p) => p,
+                Err(e) => {
+                    eprintln!("Failed to create subtask worktree: {}", e);
+                    return;
+                }
+            };
+            let worktree_path = Path::new(&worktree_path_str);
+
+            // Copy subtask_copy_files from parent worktree with {slug} substitution
+            for (src_template, dst) in &subtask_copy_files {
+                let src_path_str = src_template.replace("{slug}", &child_slug);
+                let src = Path::new(&parent_worktree).join(&src_path_str);
+                let dst = worktree_path.join(dst);
+                if let Some(parent_dir) = dst.parent() {
+                    let _ = std::fs::create_dir_all(parent_dir);
+                }
+                if src.exists() {
+                    let _ = std::fs::copy(&src, &dst);
+                }
+            }
+
+            // Deploy skills to the worktree
+            let agent_refs: Vec<&str> = all_agents.iter().map(|s| s.as_str()).collect();
+            write_skills_to_worktree(
+                &worktree_path_str,
+                &project_path,
+                &plugin,
+                &agent_refs,
+                enable_agent_teams,
+            );
+
+            // Create tmux window and spawn agent with /agtx:execute
+            let task_content = child.content_text();
+            let skill_cmd = resolve_skill_command(&plugin, "running", &subtask_agent, &task_content, child.cycle);
+            let prompt = resolve_prompt(&plugin, "running", &task_content, &child.id, child.cycle);
+            let auto_dismiss = plugin
+                .as_ref()
+                .map_or_else(Vec::new, |p| p.auto_dismiss.clone());
+
+            let agent = crate::agent::get_agent(&subtask_agent).unwrap_or_else(|| {
+                crate::agent::known_agents()
+                    .into_iter()
+                    .next()
+                    .expect("at least one agent")
+            });
+            let cmd = if let Some(ref model) = subtask_model {
+                agent.build_interactive_command_with_model("", Some(model.as_str()))
+            } else {
+                agent.build_interactive_command("")
+            };
+
+            let session_name = format!(
+                "task-{}--{}--{}",
+                &child.id[..8],
+                tmux_project_name,
+                &unique_slug.chars().take(20).collect::<String>()
+            );
+
+            if tmux_ops.create_window(&tmux_project_name, &window_name, &worktree_path_str, Some(cmd)).is_ok() {
+                // Wait for agent, send skill+prompt
+                if let Some(ready_target) = wait_for_agent_ready(&tmux_ops, &target) {
+                    send_skill_and_prompt(
+                        &tmux_ops,
+                        &ready_target,
+                        &skill_cmd,
+                        &prompt,
+                        &None,
+                        &task_content,
+                        &subtask_agent,
+                        &auto_dismiss,
+                    );
+                }
+            }
+
+            // Update child task in DB
+            if let Ok(db) = crate::db::Database::open_project(&project_path) {
+                if let Ok(Some(mut updated_child)) = db.get_task(&child_id_owned) {
+                    updated_child.status = TaskStatus::Running;
+                    updated_child.session_name = Some(session_name);
+                    updated_child.worktree_path = Some(worktree_path_str);
+                    updated_child.branch_name = Some(format!("task/{}", unique_slug));
+                    updated_child.agent = subtask_agent;
+                    updated_child.updated_at = chrono::Utc::now();
+                    let _ = db.update_task(&updated_child);
+                }
+            }
+        });
+    }
+
     /// Running → Review: send review skill/prompt, then handle PR state.
     /// Returns Ok(true) always (PR push or review confirm popup shown).
     fn transition_to_review(&mut self, task: &mut Task, project_path: &Path) -> Result<bool> {
@@ -4443,6 +4898,11 @@ impl App {
             );
         }
         task.agent = review_agent.clone();
+
+        // Subtasks do NOT create PRs — just move to Review status
+        if task.parent_task_id.is_some() {
+            return Ok(false);
+        }
 
         // PR already exists (task was resumed from Review) — push new changes
         if task.pr_number.is_some() {
@@ -4493,6 +4953,93 @@ impl App {
     /// Review → Done: check PR state, uncommitted changes, or clean up.
     /// Returns Ok(true) if a confirmation popup was shown, Ok(false) to continue with db update.
     fn transition_to_done(&mut self, task: &mut Task, project_path: &Path) -> Result<bool> {
+        // Subtask Review → Done: merge subtask branch into parent branch locally (no PR)
+        if let Some(ref parent_id) = task.parent_task_id.clone() {
+            if let Some(db) = &self.state.db {
+                if let Ok(Some(parent)) = db.get_task(parent_id) {
+                    if let Some(ref parent_worktree) = parent.worktree_path {
+                        let child_branch = task.branch_name.clone().unwrap_or_default();
+                        let parent_wt = parent_worktree.clone();
+                        let git_ops = Arc::clone(&self.state.git_ops);
+                        let tmux_ops = Arc::clone(&self.state.tmux_ops);
+                        let task_id_clone = task.id.clone();
+                        let session_name = task.session_name.clone();
+                        let worktree_path = task.worktree_path.clone();
+                        let branch_name = task.branch_name.clone();
+                        let project_path_clone = project_path.to_path_buf();
+
+                        // Try the merge; if conflicts, send merge-conflicts skill to subtask
+                        let merge_result = std::process::Command::new("git")
+                            .args(["-C", &parent_wt, "merge", &child_branch])
+                            .output();
+
+                        match merge_result {
+                            Ok(out) if out.status.success() => {
+                                // Clean merge — proceed to Done cleanup
+                                task.session_name = None;
+                                task.worktree_path = None;
+                                std::thread::spawn(move || {
+                                    cleanup_task_resources(
+                                        &task_id_clone,
+                                        &branch_name,
+                                        &session_name,
+                                        &worktree_path,
+                                        &project_path_clone,
+                                        tmux_ops.as_ref(),
+                                        git_ops.as_ref(),
+                                    );
+                                });
+                                // Check if this was the last non-Done sibling — if so, notify orchestrator
+                                if self.state.orchestrator_session.is_some() {
+                                    let siblings = db.get_child_tasks(parent_id).unwrap_or_default();
+                                    let all_done = !siblings.is_empty()
+                                        && siblings.iter().all(|s| {
+                                            s.id == task.id || matches!(s.status, TaskStatus::Done)
+                                        });
+                                    if all_done {
+                                        let short_pid = if parent_id.len() >= 8 { &parent_id[..8] } else { parent_id.as_str() };
+                                        let notif = crate::db::Notification::new(format!(
+                                            "All subtasks of \"{}\" ({}) merged — parent ready for review",
+                                            parent.title, short_pid
+                                        ));
+                                        let _ = db.create_notification(&notif);
+                                    }
+                                }
+                                return Ok(false);
+                            }
+                            _ => {
+                                // Merge failed/conflicted — send merge-conflicts skill to subtask session
+                                if let Some(ref sess) = task.session_name {
+                                    let skill_cmd = skills::transform_plugin_command(
+                                        "/agtx:merge-conflicts",
+                                        &task.agent,
+                                    );
+                                    let prompt = format!(
+                                        "Base branch is {}. Merge conflicts detected — resolve them, then I'll retry the merge.",
+                                        parent_wt
+                                    );
+                                    send_skill_and_prompt(
+                                        &self.state.tmux_ops,
+                                        sess,
+                                        &skill_cmd,
+                                        &prompt,
+                                        &None,
+                                        "",
+                                        &task.agent,
+                                        &[],
+                                    );
+                                }
+                                // Don't advance to Done yet
+                                return Ok(true);
+                            }
+                        }
+                    }
+                }
+            }
+            // Parent worktree not available — proceed to Done without merge
+            return Ok(false);
+        }
+
         if let Some(pr_number) = task.pr_number {
             let pr_state = self
                 .state
@@ -4638,6 +5185,7 @@ impl App {
                 git_ops.as_ref(),
                 agent_ops.as_ref(),
                 &[],
+                false,
             );
 
             match result {
@@ -4831,6 +5379,7 @@ impl App {
                 git_ops.as_ref(),
                 agent_ops.as_ref(),
                 &[],
+                false,
             );
 
             match result {
@@ -5385,10 +5934,45 @@ impl App {
 
     fn open_selected_task(&mut self) -> Result<()> {
         if let Some(task) = self.state.board.selected_task() {
-            if let Some(window_name) = &task.session_name.clone() {
-                let task_id = task.id.clone();
-                let escalation_note = task.escalation_note.clone();
-                let mut popup = ShellPopup::new(task.title.clone(), window_name.clone());
+            let task_id = task.id.clone();
+            let task_title = task.title.clone();
+            let session_name = task.session_name.clone();
+            let escalation_note = task.escalation_note.clone();
+
+            // Check if this task is a parent with active subtasks — show dashboard instead of tmux pane
+            let active_subtasks: Vec<String> = self
+                .state
+                .board
+                .tasks
+                .iter()
+                .filter(|t| {
+                    t.parent_task_id.as_deref() == Some(task_id.as_str())
+                        && !matches!(t.status, TaskStatus::Done)
+                })
+                .map(|t| t.id.clone())
+                .collect();
+
+            if !active_subtasks.is_empty() {
+                // Sort by created_at for stable ordering
+                let mut ordered: Vec<&crate::db::Task> = self
+                    .state
+                    .board
+                    .tasks
+                    .iter()
+                    .filter(|t| t.parent_task_id.as_deref() == Some(task_id.as_str()))
+                    .collect();
+                ordered.sort_by_key(|t| &t.created_at);
+                let subtask_ids: Vec<String> = ordered.iter().map(|t| t.id.clone()).collect();
+                self.state.subtask_dashboard = Some(SubtaskDashboard {
+                    parent_id: task_id,
+                    parent_title: task_title,
+                    subtask_ids,
+                });
+                return Ok(());
+            }
+
+            if let Some(window_name) = session_name {
+                let mut popup = ShellPopup::new(task_title.clone(), window_name.clone());
                 popup.task_id = Some(task_id);
                 popup.escalation_note = escalation_note;
 
@@ -5414,7 +5998,7 @@ impl App {
 
                 // Capture initial content
                 popup.cached_content =
-                    capture_tmux_pane_with_history(window_name, 500, self.state.tmux_ops.as_ref());
+                    capture_tmux_pane_with_history(&window_name, 500, self.state.tmux_ops.as_ref());
 
                 self.state.shell_popup = Some(popup);
             }
@@ -5734,6 +6318,24 @@ impl App {
         for task_status in result.statuses {
             let mut phase = task_status.phase_status;
 
+            // Parent tasks in Running with active subtasks have no tmux window of their own.
+            // Override Exited/Working phase to reflect children status instead.
+            if task_status.status == TaskStatus::Running && phase == PhaseStatus::Exited {
+                let has_active_children = self
+                    .state
+                    .board
+                    .tasks
+                    .iter()
+                    .any(|t| {
+                        t.parent_task_id.as_deref() == Some(task_status.task_id.as_str())
+                            && !matches!(t.status, TaskStatus::Done)
+                    });
+                if has_active_children {
+                    // Parent is waiting on subtasks — show Working (spinner)
+                    phase = PhaseStatus::Working;
+                }
+            }
+
             if phase == PhaseStatus::Working {
                 // Idle detection: check if content hash has been stable for 15s
                 if let Some(hash) = task_status.content_hash {
@@ -5784,6 +6386,43 @@ impl App {
                             task_title, short_id, phase_name
                         ));
                         let _ = db.create_notification(&notif);
+                    }
+                }
+            }
+
+            // Parent phase override: if this is a subtask that just became Done,
+            // check if ALL siblings are Done — if so, the parent transitions to Ready.
+            {
+                let parent_id_opt = self
+                    .state
+                    .board
+                    .tasks
+                    .iter()
+                    .find(|t| t.id == task_status.task_id)
+                    .and_then(|t| t.parent_task_id.clone());
+
+                if let Some(ref parent_id) = parent_id_opt {
+                    if let Some(db) = &self.state.db {
+                        let siblings = db.get_child_tasks(parent_id).unwrap_or_default();
+                        // Also check board tasks for freshest status
+                        let all_done = !siblings.is_empty()
+                            && siblings.iter().all(|s| {
+                                // Prefer board task status (most up to date in this tick)
+                                self.state
+                                    .board
+                                    .tasks
+                                    .iter()
+                                    .find(|bt| bt.id == s.id)
+                                    .map_or(matches!(s.status, TaskStatus::Done), |bt| {
+                                        matches!(bt.status, TaskStatus::Done)
+                                    })
+                            });
+                        if all_done {
+                            // Override parent phase to Ready in TUI
+                            self.state
+                                .phase_status_cache
+                                .insert(parent_id.clone(), (PhaseStatus::Ready, now));
+                        }
                     }
                 }
             }
@@ -5954,6 +6593,7 @@ impl App {
 
         // Clear per-task caches from previous project
         self.state.merge_conflict_checked.clear();
+
         self.state.stuck_task_notified.clear();
         self.state.stuck_task_idle_since.clear();
 
@@ -6192,6 +6832,7 @@ fn setup_task_worktree(
     git_ops: &dyn GitOperations,
     agent_ops: &dyn AgentOperations,
     referenced_tasks: &[ReferencedTaskInfo],
+    enable_agent_teams: bool,
 ) -> Result<String> {
     let unique_slug = generate_task_slug(&task.id, &task.title);
     let window_name = format!("task-{}", unique_slug);
@@ -6248,7 +6889,7 @@ fn setup_task_worktree(
     // Write skills to worktree .agtx/skills/ and agent-native discovery paths
     // Deploy for all unique agents configured across phases
     let agent_refs: Vec<&str> = all_phase_agents.iter().map(|s| s.as_str()).collect();
-    write_skills_to_worktree(&worktree_path_str, project_path, plugin, &agent_refs);
+    write_skills_to_worktree(&worktree_path_str, project_path, plugin, &agent_refs, enable_agent_teams);
 
     // Copy referenced task artifacts into .agtx/references/
     if !referenced_tasks.is_empty() {
@@ -7720,16 +8361,34 @@ fn write_skills_to_worktree(
     project_path: &Path,
     plugin: &Option<WorkflowPlugin>,
     agent_names: &[&str],
+    enable_agent_teams: bool,
 ) {
     let agtx_dir = Path::new(worktree_path).join(".agtx");
     let _ = std::fs::create_dir_all(&agtx_dir);
+
+    // Build the effective skill list — replace agtx-plan with plan-teams when flag is on
+    let plan_content: &str = if enable_agent_teams {
+        skills::PLAN_TEAMS_SKILL
+    } else {
+        skills::PLAN_SKILL
+    };
+    let effective_skills: Vec<(&str, &str)> = skills::BUILTIN_SKILLS
+        .iter()
+        .map(|(name, default)| {
+            if *name == "agtx-plan" {
+                (*name, plan_content)
+            } else {
+                (*name, *default)
+            }
+        })
+        .collect();
 
     // Write canonical .agtx/skills/ directory
     let skills_dir = agtx_dir.join("skills");
     if let Some(ref p) = plugin {
         // Copy skills from plugin directory, falling back to built-in defaults
         if let Some(plugin_dir) = WorkflowPlugin::plugin_dir(&p.name, Some(project_path)) {
-            for (skill_name, default_content) in skills::BUILTIN_SKILLS {
+            for (skill_name, default_content) in &effective_skills {
                 let src = plugin_dir.join(skill_name).join("SKILL.md");
                 let dst_dir = skills_dir.join(skill_name);
                 let _ = std::fs::create_dir_all(&dst_dir);
@@ -7741,7 +8400,7 @@ fn write_skills_to_worktree(
             }
         } else {
             // Plugin dir not found, write defaults
-            for (skill_name, skill_content) in skills::BUILTIN_SKILLS {
+            for (skill_name, skill_content) in &effective_skills {
                 let skill_dir = skills_dir.join(skill_name);
                 let _ = std::fs::create_dir_all(&skill_dir);
                 let _ = std::fs::write(skill_dir.join("SKILL.md"), skill_content);
@@ -7749,7 +8408,7 @@ fn write_skills_to_worktree(
         }
     } else {
         // Write built-in default skills
-        for (skill_name, skill_content) in skills::BUILTIN_SKILLS {
+        for (skill_name, skill_content) in &effective_skills {
             let skill_dir = skills_dir.join(skill_name);
             let _ = std::fs::create_dir_all(&skill_dir);
             let _ = std::fs::write(skill_dir.join("SKILL.md"), skill_content);
@@ -7767,7 +8426,7 @@ fn write_skills_to_worktree(
             };
             let _ = std::fs::create_dir_all(&native_dir);
 
-            for (skill_dir_name, default_content) in skills::BUILTIN_SKILLS {
+            for (skill_dir_name, default_content) in &effective_skills {
                 let content =
                     resolve_skill_content(plugin, skill_dir_name, project_path, default_content);
 

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -3503,7 +3503,7 @@ fn test_write_skills_to_worktree_claude() {
     let dir = tempfile::tempdir().unwrap();
     let wt = dir.path().to_string_lossy().to_string();
 
-    write_skills_to_worktree(&wt, dir.path(), &None, &["claude"], false);
+    write_skills_to_worktree(&wt, dir.path(), &None, &["claude"]);
 
     // Canonical skills
     assert!(dir.path().join(".agtx/skills/agtx-plan/SKILL.md").exists());
@@ -3535,7 +3535,7 @@ fn test_write_skills_to_worktree_gemini_toml() {
     let dir = tempfile::tempdir().unwrap();
     let wt = dir.path().to_string_lossy().to_string();
 
-    write_skills_to_worktree(&wt, dir.path(), &None, &["gemini"], false);
+    write_skills_to_worktree(&wt, dir.path(), &None, &["gemini"]);
 
     let toml_path = dir.path().join(".gemini/commands/agtx/plan.toml");
     assert!(toml_path.exists());
@@ -3555,7 +3555,7 @@ fn test_write_skills_to_worktree_codex() {
     let dir = tempfile::tempdir().unwrap();
     let wt = dir.path().to_string_lossy().to_string();
 
-    write_skills_to_worktree(&wt, dir.path(), &None, &["codex"], false);
+    write_skills_to_worktree(&wt, dir.path(), &None, &["codex"]);
 
     // Codex uses subdirectories with SKILL.md
     assert!(dir.path().join(".codex/skills/agtx-plan/SKILL.md").exists());
@@ -3570,7 +3570,7 @@ fn test_write_skills_to_worktree_opencode() {
     let dir = tempfile::tempdir().unwrap();
     let wt = dir.path().to_string_lossy().to_string();
 
-    write_skills_to_worktree(&wt, dir.path(), &None, &["opencode"], false);
+    write_skills_to_worktree(&wt, dir.path(), &None, &["opencode"]);
 
     let md_path = dir.path().join(".opencode/command/agtx-plan.md");
     assert!(md_path.exists());
@@ -3578,6 +3578,52 @@ fn test_write_skills_to_worktree_opencode() {
     assert!(
         content.starts_with("---\ndescription:"),
         "OpenCode should have description frontmatter"
+    );
+}
+
+#[test]
+fn test_write_skills_to_worktree_teams_deploys_plan_teams() {
+    let dir = tempfile::tempdir().unwrap();
+    let wt = dir.path().to_string_lossy().to_string();
+
+    write_skills_to_worktree_teams(&wt, dir.path(), &None, &["claude"]);
+
+    // Canonical plan skill should contain plan-teams content, not plan content
+    let plan_path = dir.path().join(".agtx/skills/agtx-plan/SKILL.md");
+    assert!(plan_path.exists());
+    let content = std::fs::read_to_string(&plan_path).unwrap();
+    assert!(
+        content.contains("create_subtask"),
+        "plan-teams skill should mention create_subtask MCP tool"
+    );
+
+    // Claude-native plan.md should also have teams content
+    let claude_plan = dir.path().join(".claude/commands/agtx/plan.md");
+    assert!(claude_plan.exists());
+    let claude_content = std::fs::read_to_string(&claude_plan).unwrap();
+    assert!(
+        claude_content.contains("create_subtask"),
+        "Claude-native plan skill should have teams content"
+    );
+
+    // Other skills (execute, review, research) are unaffected
+    assert!(dir.path().join(".agtx/skills/agtx-execute/SKILL.md").exists());
+    assert!(dir.path().join(".agtx/skills/agtx-review/SKILL.md").exists());
+    assert!(dir.path().join(".agtx/skills/agtx-research/SKILL.md").exists());
+}
+
+#[test]
+fn test_write_skills_to_worktree_regular_does_not_deploy_plan_teams() {
+    let dir = tempfile::tempdir().unwrap();
+    let wt = dir.path().to_string_lossy().to_string();
+
+    write_skills_to_worktree(&wt, dir.path(), &None, &["claude"]);
+
+    let plan_path = dir.path().join(".agtx/skills/agtx-plan/SKILL.md");
+    let content = std::fs::read_to_string(&plan_path).unwrap();
+    assert!(
+        !content.contains("create_subtask"),
+        "regular plan skill should not contain teams content"
     );
 }
 

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -208,6 +208,9 @@ fn test_create_pr_with_content_success() {
         cycle: 1,
         referenced_tasks: None,
         escalation_note: None,
+        parent_task_id: None,
+        subtask_deps: None,
+        subtask_slug: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -303,6 +306,9 @@ fn test_create_pr_with_content_no_changes() {
         cycle: 1,
         referenced_tasks: None,
         escalation_note: None,
+        parent_task_id: None,
+        subtask_deps: None,
+        subtask_slug: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -357,6 +363,9 @@ fn test_create_pr_with_content_push_failure() {
         cycle: 1,
         referenced_tasks: None,
         escalation_note: None,
+        parent_task_id: None,
+        subtask_deps: None,
+        subtask_slug: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -417,6 +426,9 @@ fn test_push_changes_to_existing_pr_success() {
         cycle: 1,
         referenced_tasks: None,
         escalation_note: None,
+        parent_task_id: None,
+        subtask_deps: None,
+        subtask_slug: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -471,6 +483,9 @@ fn test_push_changes_to_existing_pr_no_changes() {
         cycle: 1,
         referenced_tasks: None,
         escalation_note: None,
+        parent_task_id: None,
+        subtask_deps: None,
+        subtask_slug: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -508,6 +523,9 @@ fn test_push_changes_to_existing_pr_no_url() {
         cycle: 1,
         referenced_tasks: None,
         escalation_note: None,
+        parent_task_id: None,
+        subtask_deps: None,
+        subtask_slug: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -1416,6 +1434,7 @@ fn test_setup_task_worktree_success() {
         &mock_git,
         &mock_agent,
         &[],
+        false,
     );
 
     assert!(result.is_ok());
@@ -1468,6 +1487,7 @@ fn test_setup_task_worktree_sets_task_fields() {
         &mock_git,
         &mock_agent,
         &[],
+        false,
     )
     .unwrap();
 
@@ -1528,6 +1548,7 @@ fn test_setup_task_worktree_worktree_creation_fails() {
         &mock_git,
         &mock_agent,
         &[],
+        false,
     );
 
     // Should succeed despite worktree creation failure (uses fallback path)
@@ -1583,6 +1604,7 @@ fn test_setup_task_worktree_tmux_window_fails() {
         &mock_git,
         &mock_agent,
         &[],
+        false,
     );
 
     // Should propagate the error
@@ -1634,6 +1656,7 @@ fn test_setup_task_worktree_creates_session_when_missing() {
         &mock_git,
         &mock_agent,
         &[],
+        false,
     );
 
     assert!(result.is_ok());
@@ -1688,6 +1711,7 @@ fn test_setup_task_worktree_passes_init_config() {
         &mock_git,
         &mock_agent,
         &[],
+        false,
     );
 
     assert!(result.is_ok());
@@ -1937,7 +1961,7 @@ fn test_agtx_plugin_artifacts() {
         plugin.artifacts.research.as_deref(),
         Some(".agtx/research.md")
     );
-    assert_eq!(plugin.artifacts.planning.as_deref(), Some(".agtx/plan.md"));
+    assert_eq!(plugin.artifacts.planning.as_deref(), Some(".agtx/planning.done"));
     assert_eq!(
         plugin.artifacts.running.as_deref(),
         Some(".agtx/execute.md")
@@ -2046,6 +2070,7 @@ fn test_resolve_skill_command_with_plugin() {
         cyclic: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
+        subtask_copy_files: std::collections::HashMap::new(),
     });
     // Claude/Gemini: canonical form unchanged
     assert_eq!(
@@ -2108,6 +2133,7 @@ fn test_plugin_supports_agent() {
         cyclic: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
+        subtask_copy_files: std::collections::HashMap::new(),
     };
     assert!(plugin.supports_agent("claude"));
     assert!(plugin.supports_agent("copilot"));
@@ -2133,6 +2159,7 @@ fn test_plugin_supports_agent() {
         cyclic: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
+        subtask_copy_files: std::collections::HashMap::new(),
     };
     assert!(plugin.supports_agent("claude"));
     assert!(plugin.supports_agent("codex"));
@@ -2204,6 +2231,7 @@ fn test_phase_artifact_exists_with_glob() {
         cyclic: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
+        subtask_copy_files: std::collections::HashMap::new(),
     });
 
     let worktree = tmp.to_string_lossy().to_string();
@@ -2524,6 +2552,7 @@ fn test_resolve_prompt_trigger_with_gsd() {
         cyclic: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
+        subtask_copy_files: std::collections::HashMap::new(),
     });
     assert_eq!(
         resolve_prompt_trigger(&plugin, "research"),
@@ -2562,6 +2591,7 @@ fn test_resolve_prompt_trigger_empty_string_filtered() {
         cyclic: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
+        subtask_copy_files: std::collections::HashMap::new(),
     });
     // Empty strings should be filtered out
     assert_eq!(resolve_prompt_trigger(&plugin, "research"), None);
@@ -3472,7 +3502,7 @@ fn test_write_skills_to_worktree_claude() {
     let dir = tempfile::tempdir().unwrap();
     let wt = dir.path().to_string_lossy().to_string();
 
-    write_skills_to_worktree(&wt, dir.path(), &None, &["claude"]);
+    write_skills_to_worktree(&wt, dir.path(), &None, &["claude"], false);
 
     // Canonical skills
     assert!(dir.path().join(".agtx/skills/agtx-plan/SKILL.md").exists());
@@ -3504,7 +3534,7 @@ fn test_write_skills_to_worktree_gemini_toml() {
     let dir = tempfile::tempdir().unwrap();
     let wt = dir.path().to_string_lossy().to_string();
 
-    write_skills_to_worktree(&wt, dir.path(), &None, &["gemini"]);
+    write_skills_to_worktree(&wt, dir.path(), &None, &["gemini"], false);
 
     let toml_path = dir.path().join(".gemini/commands/agtx/plan.toml");
     assert!(toml_path.exists());
@@ -3524,7 +3554,7 @@ fn test_write_skills_to_worktree_codex() {
     let dir = tempfile::tempdir().unwrap();
     let wt = dir.path().to_string_lossy().to_string();
 
-    write_skills_to_worktree(&wt, dir.path(), &None, &["codex"]);
+    write_skills_to_worktree(&wt, dir.path(), &None, &["codex"], false);
 
     // Codex uses subdirectories with SKILL.md
     assert!(dir.path().join(".codex/skills/agtx-plan/SKILL.md").exists());
@@ -3539,7 +3569,7 @@ fn test_write_skills_to_worktree_opencode() {
     let dir = tempfile::tempdir().unwrap();
     let wt = dir.path().to_string_lossy().to_string();
 
-    write_skills_to_worktree(&wt, dir.path(), &None, &["opencode"]);
+    write_skills_to_worktree(&wt, dir.path(), &None, &["opencode"], false);
 
     let md_path = dir.path().join(".opencode/commands/agtx-plan.md");
     assert!(md_path.exists());
@@ -8161,4 +8191,117 @@ fn test_should_send_stuck_notification_other_plugins() {
     assert!(should_send_stuck_notification(Some("bmad")));
     // No plugin set (None) should also produce notifications
     assert!(should_send_stuck_notification(None));
+}
+
+// === Subtask board rendering tests ===
+
+#[test]
+fn test_draw_board_subtask_column_placement() {
+    // Subtasks should appear in their parent's column, regardless of their own status.
+    // Verify the task list built in draw_board: parent (Planning) + child (Running)
+    // should both appear in the Planning column grouping.
+    use crate::db::{Task, TaskStatus};
+
+    let mut parent = Task::new("Parent task", "claude", "proj");
+    parent.status = TaskStatus::Planning;
+
+    let mut child = Task::new("Child task", "claude", "proj");
+    child.status = TaskStatus::Running; // child is running
+    child.parent_task_id = Some(parent.id.clone());
+    child.subtask_slug = Some("subtask-1".to_string());
+
+    let tasks = vec![parent.clone(), child.clone()];
+
+    // Simulate the column grouping logic from draw_board for the Planning column
+    let planning_status = TaskStatus::Planning;
+    let regular_in_planning: Vec<&Task> = tasks
+        .iter()
+        .filter(|t| t.status == planning_status && t.parent_task_id.is_none())
+        .collect();
+    assert_eq!(regular_in_planning.len(), 1, "one regular task in Planning");
+
+    // Build the grouped render list (parent + subtasks)
+    let mut grouped: Vec<(&Task, bool)> = Vec::new();
+    for p in &regular_in_planning {
+        grouped.push((p, false));
+        let mut children: Vec<&Task> = tasks
+            .iter()
+            .filter(|t| t.parent_task_id.as_deref() == Some(p.id.as_str()))
+            .collect();
+        children.sort_by_key(|t| &t.created_at);
+        for c in children {
+            grouped.push((c, true));
+        }
+    }
+
+    assert_eq!(grouped.len(), 2, "parent + child both in Planning column");
+    assert!(!grouped[0].1, "first entry is not a subtask card");
+    assert!(grouped[1].1, "second entry is a subtask card");
+    assert_eq!(grouped[0].0.id, parent.id);
+    assert_eq!(grouped[1].0.id, child.id);
+
+    // The Running column should NOT show this child (it follows parent)
+    let running_status = TaskStatus::Running;
+    let regular_in_running: Vec<&Task> = tasks
+        .iter()
+        .filter(|t| t.status == running_status && t.parent_task_id.is_none())
+        .collect();
+    assert_eq!(regular_in_running.len(), 0, "no regular tasks in Running");
+}
+
+#[test]
+fn test_blocked_badge_logic() {
+    // is_blocked should be true only when deps are not all Done
+    use crate::db::{Task, TaskStatus};
+
+    let mut dep = Task::new("Dep task", "claude", "proj");
+    dep.status = TaskStatus::Running; // not Done
+
+    let mut child = Task::new("Child task", "claude", "proj");
+    child.subtask_deps = Some(dep.id.clone());
+
+    let tasks = vec![dep.clone(), child.clone()];
+
+    // Simulate is_blocked computation from draw_board
+    let is_blocked = child.subtask_deps.as_ref().map_or(false, |deps_str| {
+        deps_str.split(',').filter(|s| !s.is_empty()).any(|dep_id| {
+            !tasks
+                .iter()
+                .any(|t| t.id == dep_id && matches!(t.status, TaskStatus::Done))
+        })
+    });
+    assert!(is_blocked, "blocked when dep is Running");
+
+    // Now dep is Done
+    let mut dep_done = dep.clone();
+    dep_done.status = TaskStatus::Done;
+    let tasks2 = vec![dep_done, child.clone()];
+
+    let is_blocked2 = child.subtask_deps.as_ref().map_or(false, |deps_str| {
+        deps_str.split(',').filter(|s| !s.is_empty()).any(|dep_id| {
+            !tasks2
+                .iter()
+                .any(|t| t.id == dep_id && matches!(t.status, TaskStatus::Done))
+        })
+    });
+    assert!(!is_blocked2, "not blocked when dep is Done");
+}
+
+#[test]
+fn test_blocked_badge_empty_deps_not_blocked() {
+    use crate::db::Task;
+
+    let mut child = Task::new("Child", "claude", "proj");
+    child.subtask_deps = None;
+
+    let tasks: Vec<crate::db::Task> = vec![child.clone()];
+
+    let is_blocked = child.subtask_deps.as_ref().map_or(false, |deps_str| {
+        deps_str.split(',').filter(|s| !s.is_empty()).any(|dep_id| {
+            !tasks
+                .iter()
+                .any(|t| t.id == dep_id && matches!(t.status, crate::db::TaskStatus::Done))
+        })
+    });
+    assert!(!is_blocked, "no deps → not blocked");
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -109,6 +109,9 @@ fn test_merged_config_project_overrides() {
         copy_files: Some(".env, .env.local".to_string()),
         init_script: Some("npm install".to_string()),
         workflow_plugin: None,
+        enable_agent_teams: false,
+        subtask_agent: None,
+        subtask_model: None,
     };
 
     let merged = MergedConfig::merge(&global, &project);

--- a/tests/db_tests.rs
+++ b/tests/db_tests.rs
@@ -232,3 +232,90 @@ fn test_notifications_empty_queue() {
     let notifs = db.consume_notifications().unwrap();
     assert_eq!(notifs.len(), 0);
 }
+
+// === Subtask / parent_task_id Tests ===
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_create_task_with_parent_task_id() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let parent = Task::new("Parent task", "claude", "project-1");
+    db.create_task(&parent).unwrap();
+
+    let mut child = Task::new("Child task", "claude", "project-1");
+    child.parent_task_id = Some(parent.id.clone());
+    child.subtask_slug = Some("subtask-1".to_string());
+    db.create_task(&child).unwrap();
+
+    let fetched = db.get_task(&child.id).unwrap().unwrap();
+    assert_eq!(fetched.parent_task_id.as_deref(), Some(parent.id.as_str()));
+    assert_eq!(fetched.subtask_slug.as_deref(), Some("subtask-1"));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_get_child_tasks_returns_children() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let parent = Task::new("Parent", "claude", "project-1");
+    db.create_task(&parent).unwrap();
+
+    let mut child1 = Task::new("Child 1", "claude", "project-1");
+    child1.parent_task_id = Some(parent.id.clone());
+    child1.subtask_slug = Some("subtask-1".to_string());
+
+    let mut child2 = Task::new("Child 2", "claude", "project-1");
+    child2.parent_task_id = Some(parent.id.clone());
+    child2.subtask_slug = Some("subtask-2".to_string());
+
+    db.create_task(&child1).unwrap();
+    db.create_task(&child2).unwrap();
+
+    let children = db.get_child_tasks(&parent.id).unwrap();
+    assert_eq!(children.len(), 2);
+    assert!(children.iter().any(|t| t.id == child1.id));
+    assert!(children.iter().any(|t| t.id == child2.id));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_get_child_tasks_empty_for_non_parent() {
+    let db = Database::open_in_memory_project().unwrap();
+    let task = Task::new("Regular task", "claude", "project-1");
+    db.create_task(&task).unwrap();
+
+    let children = db.get_child_tasks(&task.id).unwrap();
+    assert!(children.is_empty());
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_update_task_roundtrips_subtask_deps_and_slug() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let parent = Task::new("Parent", "claude", "project-1");
+    db.create_task(&parent).unwrap();
+
+    let mut child = Task::new("Child", "claude", "project-1");
+    child.parent_task_id = Some(parent.id.clone());
+    child.subtask_slug = Some("subtask-2".to_string());
+    child.subtask_deps = Some("dep-id-1,dep-id-2".to_string());
+    db.create_task(&child).unwrap();
+
+    let fetched = db.get_task(&child.id).unwrap().unwrap();
+    assert_eq!(fetched.subtask_slug.as_deref(), Some("subtask-2"));
+    assert_eq!(
+        fetched.subtask_deps.as_deref(),
+        Some("dep-id-1,dep-id-2")
+    );
+
+    // Update: clear deps
+    let mut updated = fetched;
+    updated.subtask_deps = None;
+    db.update_task(&updated).unwrap();
+
+    let refetched = db.get_task(&child.id).unwrap().unwrap();
+    assert!(refetched.subtask_deps.is_none());
+    assert_eq!(refetched.subtask_slug.as_deref(), Some("subtask-2"));
+}

--- a/tests/mcp_tests.rs
+++ b/tests/mcp_tests.rs
@@ -1,4 +1,4 @@
-use agtx::db::{Database, Task, TransitionRequest};
+use agtx::db::{Database, Task, TaskStatus, TransitionRequest};
 
 // === TransitionRequest Model Tests ===
 
@@ -147,4 +147,109 @@ fn test_transition_request_with_task() {
     let fetched_req = db.get_transition_request(&req.id).unwrap();
     assert!(fetched_req.is_some());
     assert_eq!(fetched_req.unwrap().task_id, task.id);
+}
+
+// === Subtask dep-blocking tests ===
+// These test the DB queries that allowed_actions uses for dep-blocking and parent-blocking.
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_dep_blocking_with_unresolved_dep() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let mut dep = Task::new("Dep task", "claude", "proj");
+    dep.status = TaskStatus::Running; // not Done
+    db.create_task(&dep).unwrap();
+
+    let mut child = Task::new("Child task", "claude", "proj");
+    child.subtask_deps = Some(dep.id.clone());
+    child.status = TaskStatus::Running;
+    db.create_task(&child).unwrap();
+
+    // Simulate allowed_actions dep-blocking check
+    let is_blocked = child.subtask_deps.as_ref().map_or(false, |deps_str| {
+        deps_str.split(',').filter(|s| !s.is_empty()).any(|dep_id| {
+            db.get_task(dep_id)
+                .ok()
+                .flatten()
+                .map(|t| !matches!(t.status, TaskStatus::Done))
+                .unwrap_or(true)
+        })
+    });
+    assert!(is_blocked, "move_forward should be blocked when dep is Running");
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_dep_blocking_clears_when_dep_done() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let mut dep = Task::new("Dep task", "claude", "proj");
+    dep.status = agtx::db::TaskStatus::Running;
+    db.create_task(&dep).unwrap();
+
+    let mut child = Task::new("Child task", "claude", "proj");
+    child.subtask_deps = Some(dep.id.clone());
+    child.status = TaskStatus::Running;
+    db.create_task(&child).unwrap();
+
+    // Move dep to Done
+    let mut dep_updated = dep.clone();
+    dep_updated.status = TaskStatus::Done;
+    db.update_task(&dep_updated).unwrap();
+
+    let is_blocked = child.subtask_deps.as_ref().map_or(false, |deps_str| {
+        deps_str.split(',').filter(|s| !s.is_empty()).any(|dep_id| {
+            db.get_task(dep_id)
+                .ok()
+                .flatten()
+                .map(|t| !matches!(t.status, TaskStatus::Done))
+                .unwrap_or(true)
+        })
+    });
+    assert!(!is_blocked, "move_forward unblocked when dep is Done");
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_parent_blocking_with_active_children() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let mut parent = Task::new("Parent", "claude", "proj");
+    parent.status = TaskStatus::Running;
+    db.create_task(&parent).unwrap();
+
+    let mut child = Task::new("Child", "claude", "proj");
+    child.parent_task_id = Some(parent.id.clone());
+    child.status = TaskStatus::Running; // not Done
+    db.create_task(&child).unwrap();
+
+    // Simulate parent-blocking check
+    let children = db.get_child_tasks(&parent.id).unwrap();
+    let all_done = children
+        .iter()
+        .all(|c| matches!(c.status, TaskStatus::Done));
+    assert!(!all_done, "parent blocked while child is Running");
+    assert!(!children.is_empty());
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_parent_blocking_clears_when_all_children_done() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let mut parent = Task::new("Parent", "claude", "proj");
+    parent.status = TaskStatus::Running;
+    db.create_task(&parent).unwrap();
+
+    let mut child = Task::new("Child", "claude", "proj");
+    child.parent_task_id = Some(parent.id.clone());
+    child.status = TaskStatus::Done;
+    db.create_task(&child).unwrap();
+
+    let children = db.get_child_tasks(&parent.id).unwrap();
+    let all_done = children
+        .iter()
+        .all(|c| matches!(c.status, TaskStatus::Done));
+    assert!(all_done, "parent unblocked when all children are Done");
 }


### PR DESCRIPTION
## feat: task decomposition into parallel subtasks (agent teams)

  Introduces agtx-native subagents: a task in Planning can be decomposed into parallel
  subtasks, each running as a first-class agtx task with its own tmux window, git worktree,
  and agent session. Agent-agnostic — works with Claude, Codex, Gemini, and any other
  supported agent uniformly.

  ### How it works

  When `enable_agent_teams = true` in `.agtx/config.toml`, the planning phase deploys
  `plan-teams.md` instead of `plan.md`. The agent analyses the task, applies a decomposition
  heuristic (3+ directories, sequential layers, or 5+ independent steps), and either:

  - **Decomposes**: writes per-subtask plans to `.agtx/subtasks/{slug}/plan.md`, calls the
    `create_subtask` MCP tool for each, then writes `.agtx/planning.done`
  - **Stays simple**: writes `.agtx/planning.done` directly — normal single-task flow

  When the parent task advances to Running, all Backlog subtasks are launched in parallel as
  independent agtx tasks branching off the parent's worktree branch.

  ### Changes

  **DB / models**
  - Added `parent_task_id`, `subtask_slug`, `subtask_deps` fields to `Task`
  - Schema migration adds the three columns (idempotent `ALTER TABLE`)
  - New `get_child_tasks(parent_id)` query
  - `allowed_actions` dep-blocking: `move_forward` is omitted when unresolved `subtask_deps`
    exist or when a parent has active (non-Done) children

  **MCP server**
  - New `create_subtask` tool: idempotent (returns existing ID on slug collision), resolves
    dep slugs to IDs, inherits parent plugin
  - `get_task` response now includes `allowed_actions` computed with dep-blocking and
    parent-blocking rules

  **TUI / board**
  - Subtask cards render in their parent's column (regardless of their own status), indented
    2px, sorted by `created_at`
  - `[blocked]` badge on subtask cards is accurate: computed from live board state against
    dep IDs
  - Column header count shows only top-level tasks
  - Opening a parent task with active subtasks shows a **subtask dashboard** popup listing
    each subtask's status, with `[1–N]` to jump to that subtask's tmux pane
  - `launch_subtask` creates a worktree branched from the parent branch, copies
    `subtask_copy_files` from the parent worktree, deploys skills, spawns the agent
  - Subtask Review → Done performs a local `git merge` into the parent worktree (no PR).
    On conflict, sends `/agtx:merge-conflicts` to the subtask agent via `send_skill_and_prompt`
    (correctly handles Gemini/Codex combined-message requirement)
  - When the last subtask merges, a notification is written so the orchestrator knows the
    parent is ready for review

  **Orchestrator**
  - `orchestrate.md` updated with subtask wave section: advance subtasks via the same
    `move_forward` flow, trust `allowed_actions` for dep-blocking, advance parent on
    "all subtasks merged" notification
  - Notification fires from `transition_to_done` after the actual git merge, not prematurely
    from the polling loop

  **Config**
  - `ProjectConfig` / `MergedConfig`: `enable_agent_teams`, `subtask_agent`, `subtask_model`
  - `WorkflowPlugin`: `subtask_copy_files` map for copying parent worktree files into subtask
    worktrees at launch (supports `{slug}` substitution)