### PR TITLE
feat: make worktree location configurable via worktree_dir

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Backlog → Planning → Running → Review → Done
 ```
 
 - **Backlog**: Task ideas, not started
-- **Planning**: Creates git worktree at `.agtx/worktrees/{slug}`, copies configured files, runs init script, deploys skills, starts agent in planning mode
+- **Planning**: Creates git worktree at `{worktree_dir}/{slug}` (default `.agtx/worktrees/{slug}`, configurable via `worktree_dir`), copies configured files, runs init script, deploys skills, starts agent in planning mode
 - **Running**: Agent is implementing (sends execute command/prompt)
 - **Review**: Optionally create PR. Tmux window stays open. Can resume to address feedback
 - **Done**: Cleanup worktree + tmux window (branch kept locally)

--- a/README.md
+++ b/README.md
@@ -153,7 +153,11 @@ Global worktree defaults can be set here:
 # ~/.config/agtx/config.toml
 [worktree]
 base_branch = "dev"
+worktree_dir = ".worktrees"  # default: ".agtx/worktrees"
 ```
+
+`worktree_dir` is the directory (relative to project root) where task worktrees are created. Defaults
+to `.agtx/worktrees` if not set.
 
 ### Project Configuration
 
@@ -162,6 +166,9 @@ Per-project settings can be placed in `.agtx/config.toml` at the project root:
 ```toml
 # Base branch used when creating new task worktrees (optional)
 base_branch = "dev"
+
+# Directory where worktrees are created (optional, default: ".agtx/worktrees")
+worktree_dir = ".worktrees"
 
 # Files to copy from project root into each new worktree (comma-separated)
 # Paths are relative and preserve directory structure

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -69,11 +69,13 @@ review = "codex"
 
 [worktree]
 base_branch = "dev"
+worktree_dir = ".worktrees"  # default: ".agtx/worktrees"
 ```
 
 ```toml
 # Project config (.agtx/config.toml)
 base_branch = "dev"
+worktree_dir = ".worktrees"  # overrides global
 copy_files = ".env, .env.local"
 init_script = "scripts/init_worktree.sh"
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -166,6 +166,10 @@ pub struct WorktreeConfig {
     /// Base branch to create worktrees from (empty = auto-detect main/master)
     #[serde(default)]
     pub base_branch: String,
+
+    /// Directory (relative to project root) where worktrees are created
+    #[serde(default = "default_worktree_dir")]
+    pub worktree_dir: String,
 }
 
 impl Default for WorktreeConfig {
@@ -174,8 +178,13 @@ impl Default for WorktreeConfig {
             enabled: true,
             auto_cleanup: true,
             base_branch: String::new(),
+            worktree_dir: default_worktree_dir(),
         }
     }
+}
+
+fn default_worktree_dir() -> String {
+    ".agtx/worktrees".to_string()
 }
 
 fn default_true() -> bool {
@@ -196,6 +205,9 @@ pub struct ProjectConfig {
 
     /// GitHub URL for this project
     pub github_url: Option<String>,
+
+    /// Directory (relative to project root) where worktrees are created
+    pub worktree_dir: Option<String>,
 
     /// Comma-separated list of files to copy from project root into worktrees
     pub copy_files: Option<String>,
@@ -322,6 +334,7 @@ pub struct MergedConfig {
     pub worktree_enabled: bool,
     pub auto_cleanup: bool,
     pub base_branch: String,
+    pub worktree_dir: String,
     pub github_url: Option<String>,
     pub theme: ThemeConfig,
     pub copy_files: Option<String>,
@@ -350,6 +363,10 @@ impl MergedConfig {
                 .base_branch
                 .clone()
                 .unwrap_or_else(|| global.worktree.base_branch.clone()),
+            worktree_dir: project
+                .worktree_dir
+                .clone()
+                .unwrap_or_else(|| global.worktree.worktree_dir.clone()),
             github_url: project.github_url.clone(),
             theme: global.theme.clone(),
             copy_files: project.copy_files.clone(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -184,7 +184,7 @@ impl Default for WorktreeConfig {
 }
 
 fn default_worktree_dir() -> String {
-    ".agtx/worktrees".to_string()
+    crate::git::DEFAULT_WORKTREE_DIR.to_string()
 }
 
 fn default_true() -> bool {

--- a/src/git/operations.rs
+++ b/src/git/operations.rs
@@ -15,13 +15,14 @@ pub trait GitOperations: Send + Sync {
         project_path: &Path,
         task_slug: &str,
         base_branch: &str,
+        worktree_dir: &str,
     ) -> Result<String>;
 
     /// Remove a worktree
     fn remove_worktree(&self, project_path: &Path, worktree_path: &str) -> Result<()>;
 
     /// Check if worktree exists
-    fn worktree_exists(&self, project_path: &Path, task_slug: &str) -> bool;
+    fn worktree_exists(&self, project_path: &Path, task_slug: &str, worktree_dir: &str) -> bool;
 
     /// Delete a branch
     fn delete_branch(&self, project_path: &Path, branch_name: &str) -> Result<()>;
@@ -82,8 +83,10 @@ impl GitOperations for RealGitOps {
         project_path: &Path,
         task_slug: &str,
         base_branch: &str,
+        worktree_dir: &str,
     ) -> Result<String> {
-        let path = super::create_worktree_from_base(project_path, task_slug, base_branch)?;
+        let path =
+            super::create_worktree_from_base(project_path, task_slug, base_branch, worktree_dir)?;
         Ok(path.to_string_lossy().to_string())
     }
 
@@ -95,8 +98,8 @@ impl GitOperations for RealGitOps {
         Ok(())
     }
 
-    fn worktree_exists(&self, project_path: &Path, task_slug: &str) -> bool {
-        super::worktree_exists(project_path, task_slug)
+    fn worktree_exists(&self, project_path: &Path, task_slug: &str, worktree_dir: &str) -> bool {
+        super::worktree_exists_with_dir(project_path, task_slug, worktree_dir)
     }
 
     fn delete_branch(&self, project_path: &Path, branch_name: &str) -> Result<()> {

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -2,14 +2,13 @@ use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Directory name for agtx data within a project
-const AGTX_DIR: &str = ".agtx";
-const WORKTREES_DIR: &str = "worktrees";
+/// Default worktree directory relative to project root
+pub const DEFAULT_WORKTREE_DIR: &str = ".agtx/worktrees";
 
 /// Create a new git worktree for a task from the detected default branch.
 pub fn create_worktree(project_path: &Path, task_slug: &str) -> Result<PathBuf> {
     let base_branch = detect_main_branch(project_path)?;
-    create_worktree_from_base(project_path, task_slug, &base_branch)
+    create_worktree_from_base(project_path, task_slug, &base_branch, DEFAULT_WORKTREE_DIR)
 }
 
 /// Create a new git worktree for a task from the specified base branch.
@@ -17,10 +16,10 @@ pub fn create_worktree_from_base(
     project_path: &Path,
     task_slug: &str,
     base_branch: &str,
+    worktree_dir: &str,
 ) -> Result<PathBuf> {
     let worktree_path = project_path
-        .join(AGTX_DIR)
-        .join(WORKTREES_DIR)
+        .join(worktree_dir)
         .join(task_slug);
 
     // If worktree already exists and is valid, return it
@@ -255,8 +254,7 @@ pub fn detect_main_branch(project_path: &Path) -> Result<String> {
 /// Remove a git worktree
 pub fn remove_worktree(project_path: &Path, task_id: &str) -> Result<()> {
     let worktree_path = project_path
-        .join(AGTX_DIR)
-        .join(WORKTREES_DIR)
+        .join(DEFAULT_WORKTREE_DIR)
         .join(task_id);
 
     // Remove the worktree
@@ -282,12 +280,21 @@ pub fn remove_worktree(project_path: &Path, task_id: &str) -> Result<()> {
 /// Get the worktree path for a task
 pub fn worktree_path(project_path: &Path, task_id: &str) -> PathBuf {
     project_path
-        .join(AGTX_DIR)
-        .join(WORKTREES_DIR)
+        .join(DEFAULT_WORKTREE_DIR)
         .join(task_id)
+}
+
+/// Get the worktree path for a task using a custom worktree directory
+pub fn worktree_path_with_dir(project_path: &Path, task_id: &str, worktree_dir: &str) -> PathBuf {
+    project_path.join(worktree_dir).join(task_id)
 }
 
 /// Check if a worktree exists for a task
 pub fn worktree_exists(project_path: &Path, task_id: &str) -> bool {
     worktree_path(project_path, task_id).exists()
+}
+
+/// Check if a worktree exists for a task using a custom worktree directory
+pub fn worktree_exists_with_dir(project_path: &Path, task_id: &str, worktree_dir: &str) -> bool {
+    worktree_path_with_dir(project_path, task_id, worktree_dir).exists()
 }

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -282,16 +282,14 @@ pub fn detect_main_branch(project_path: &Path) -> Result<String> {
 }
 
 /// Remove a git worktree
-pub fn remove_worktree(project_path: &Path, task_id: &str) -> Result<()> {
-    let worktree_path = project_path
-        .join(DEFAULT_WORKTREE_DIR)
-        .join(task_id);
+pub fn remove_worktree(project_path: &Path, task_id: &str, worktree_dir: &str) -> Result<()> {
+    let wt_path = worktree_path(project_path, task_id, worktree_dir);
 
     // Remove the worktree
     let output = Command::new("git")
         .current_dir(project_path)
         .args(["worktree", "remove"])
-        .arg(&worktree_path)
+        .arg(&wt_path)
         .args(["--force"]) // Force in case of uncommitted changes
         .output()
         .context("Failed to remove git worktree")?;
@@ -308,20 +306,18 @@ pub fn remove_worktree(project_path: &Path, task_id: &str) -> Result<()> {
 }
 
 /// Get the worktree path for a task
-pub fn worktree_path(project_path: &Path, task_id: &str) -> PathBuf {
-    project_path
-        .join(DEFAULT_WORKTREE_DIR)
-        .join(task_id)
+pub fn worktree_path(project_path: &Path, task_id: &str, worktree_dir: &str) -> PathBuf {
+    project_path.join(worktree_dir).join(task_id)
 }
 
 /// Get the worktree path for a task using a custom worktree directory
 pub fn worktree_path_with_dir(project_path: &Path, task_id: &str, worktree_dir: &str) -> PathBuf {
-    project_path.join(worktree_dir).join(task_id)
+    worktree_path(project_path, task_id, worktree_dir)
 }
 
 /// Check if a worktree exists for a task
 pub fn worktree_exists(project_path: &Path, task_id: &str) -> bool {
-    worktree_path(project_path, task_id).exists()
+    worktree_path(project_path, task_id, DEFAULT_WORKTREE_DIR).exists()
 }
 
 /// Check if a worktree exists for a task using a custom worktree directory

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4267,6 +4267,7 @@ impl App {
         let project_name = self.state.project_name.clone();
         let tmux_project_name = self.state.tmux_project_name.clone();
         let base_branch = self.state.config.base_branch.clone();
+        let worktree_dir = self.state.config.worktree_dir.clone();
         let copy_files = self.state.config.copy_files.clone();
         let init_script = self.state.config.init_script.clone();
         let tmux_ops = Arc::clone(&self.state.tmux_ops);
@@ -4318,6 +4319,7 @@ impl App {
                 &tmux_project_name,
                 &prompt,
                 &base_branch,
+                &worktree_dir,
                 copy_files,
                 init_script,
                 &plugin,
@@ -4607,6 +4609,7 @@ impl App {
         let project_name = self.state.project_name.clone();
         let tmux_project_name = self.state.tmux_project_name.clone();
         let base_branch = self.state.config.base_branch.clone();
+        let worktree_dir = self.state.config.worktree_dir.clone();
         let copy_files = self.state.config.copy_files.clone();
         let init_script = self.state.config.init_script.clone();
 
@@ -4638,6 +4641,7 @@ impl App {
                 &tmux_project_name,
                 "",
                 &base_branch,
+                &worktree_dir,
                 copy_files,
                 init_script,
                 &plugin,
@@ -4805,6 +4809,7 @@ impl App {
         let project_name = self.state.project_name.clone();
         let tmux_project_name = self.state.tmux_project_name.clone();
         let base_branch = self.state.config.base_branch.clone();
+        let worktree_dir = self.state.config.worktree_dir.clone();
         let copy_files = self.state.config.copy_files.clone();
         let init_script = self.state.config.init_script.clone();
         let tmux_ops = Arc::clone(&self.state.tmux_ops);
@@ -4831,6 +4836,7 @@ impl App {
                 &tmux_project_name,
                 &prompt,
                 &base_branch,
+                &worktree_dir,
                 copy_files,
                 init_script,
                 &plugin,
@@ -6195,6 +6201,7 @@ fn setup_task_worktree(
     tmux_project_name: &str,
     prompt: &str,
     base_branch: &str,
+    worktree_dir: &str,
     copy_files: Option<String>,
     init_script: Option<String>,
     plugin: &Option<WorkflowPlugin>,
@@ -6210,18 +6217,18 @@ fn setup_task_worktree(
     let target = format!("{}:{}", tmux_project_name, window_name);
 
     // Create git worktree from the configured base branch
-    let worktree_path_str = match git_ops.create_worktree(project_path, &unique_slug, base_branch) {
-        Ok(path) => path,
-        Err(e) => {
-            eprintln!("Failed to create worktree: {}", e);
-            project_path
-                .join(".agtx")
-                .join("worktrees")
-                .join(&unique_slug)
-                .to_string_lossy()
-                .to_string()
-        }
-    };
+    let worktree_path_str =
+        match git_ops.create_worktree(project_path, &unique_slug, base_branch, worktree_dir) {
+            Ok(path) => path,
+            Err(e) => {
+                eprintln!("Failed to create worktree: {}", e);
+                project_path
+                    .join(worktree_dir)
+                    .join(&unique_slug)
+                    .to_string_lossy()
+                    .to_string()
+            }
+        };
 
     // Initialize worktree: copy files and run init script
     // Merge plugin-level copy_files with project-level copy_files

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -1379,7 +1379,7 @@ fn test_setup_task_worktree_success() {
     // Expect worktree creation
     mock_git
         .expect_create_worktree()
-        .returning(|_, slug, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
+        .returning(|_, slug, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
 
     // Expect worktree initialization
     mock_git
@@ -1407,6 +1407,7 @@ fn test_setup_task_worktree_success() {
         "my-project",
         "implement this",
         "main",
+        ".agtx/worktrees",
         None,
         None,
         &None,
@@ -1439,7 +1440,7 @@ fn test_setup_task_worktree_sets_task_fields() {
 
     mock_git
         .expect_create_worktree()
-        .returning(|_, slug, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
+        .returning(|_, slug, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
     mock_git
         .expect_initialize_worktree()
         .returning(|_, _, _, _, _| vec![]);
@@ -1459,6 +1460,7 @@ fn test_setup_task_worktree_sets_task_fields() {
         "my-project",
         "fix the bug",
         "main",
+        ".agtx/worktrees",
         Some("CLAUDE.md".to_string()),
         Some("./init.sh".to_string()),
         &None,
@@ -1497,7 +1499,7 @@ fn test_setup_task_worktree_worktree_creation_fails() {
     // Worktree creation fails
     mock_git
         .expect_create_worktree()
-        .returning(|_, _, _| Err(anyhow::anyhow!("worktree already exists")));
+        .returning(|_, _, _, _| Err(anyhow::anyhow!("worktree already exists")));
 
     // Should still initialize and create window with fallback path
     mock_git
@@ -1519,6 +1521,7 @@ fn test_setup_task_worktree_worktree_creation_fails() {
         "my-project",
         "do something",
         "main",
+        ".agtx/worktrees",
         None,
         None,
         &None,
@@ -1552,7 +1555,7 @@ fn test_setup_task_worktree_tmux_window_fails() {
 
     mock_git
         .expect_create_worktree()
-        .returning(|_, slug, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
+        .returning(|_, slug, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
     mock_git
         .expect_initialize_worktree()
         .returning(|_, _, _, _, _| vec![]);
@@ -1574,6 +1577,7 @@ fn test_setup_task_worktree_tmux_window_fails() {
         "my-project",
         "do something",
         "main",
+        ".agtx/worktrees",
         None,
         None,
         &None,
@@ -1602,7 +1606,7 @@ fn test_setup_task_worktree_creates_session_when_missing() {
 
     mock_git
         .expect_create_worktree()
-        .returning(|_, slug, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
+        .returning(|_, slug, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
     mock_git
         .expect_initialize_worktree()
         .returning(|_, _, _, _, _| vec![]);
@@ -1625,6 +1629,7 @@ fn test_setup_task_worktree_creates_session_when_missing() {
         "my-project",
         "do work",
         "main",
+        ".agtx/worktrees",
         None,
         None,
         &None,
@@ -1651,8 +1656,8 @@ fn test_setup_task_worktree_passes_init_config() {
 
     mock_git
         .expect_create_worktree()
-        .withf(|_, _, base_branch| base_branch == "development")
-        .returning(|_, slug, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
+        .withf(|_, _, base_branch, _| base_branch == "development")
+        .returning(|_, slug, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
 
     // Verify copy_files and init_script are passed through
     mock_git
@@ -1679,6 +1684,7 @@ fn test_setup_task_worktree_passes_init_config() {
         "my-project",
         "implement feature",
         "development",
+        ".agtx/worktrees",
         Some("CLAUDE.md,.env".to_string()),
         Some("./setup.sh".to_string()),
         &None,

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -105,6 +105,7 @@ fn test_merged_config_project_overrides() {
         default_agent: Some("codex".to_string()),
         agents: None,
         base_branch: Some("develop".to_string()),
+        worktree_dir: None,
         github_url: Some("https://github.com/user/repo".to_string()),
         copy_files: Some(".env, .env.local".to_string()),
         init_script: Some("npm install".to_string()),
@@ -121,6 +122,30 @@ fn test_merged_config_project_overrides() {
     );
     assert_eq!(merged.copy_files, Some(".env, .env.local".to_string()));
     assert_eq!(merged.init_script, Some("npm install".to_string()));
+    // worktree_dir not overridden, uses global default
+    assert_eq!(merged.worktree_dir, ".agtx/worktrees");
+}
+
+#[test]
+fn test_merged_config_worktree_dir_override() {
+    let global = GlobalConfig::default();
+    let project = ProjectConfig {
+        worktree_dir: Some(".worktrees".to_string()),
+        ..Default::default()
+    };
+
+    let merged = MergedConfig::merge(&global, &project);
+    assert_eq!(merged.worktree_dir, ".worktrees");
+}
+
+#[test]
+fn test_merged_config_worktree_dir_global() {
+    let mut global = GlobalConfig::default();
+    global.worktree.worktree_dir = ".wt".to_string();
+    let project = ProjectConfig::default();
+
+    let merged = MergedConfig::merge(&global, &project);
+    assert_eq!(merged.worktree_dir, ".wt");
 }
 
 // === FirstRunAction Tests ===

--- a/tests/git_tests.rs
+++ b/tests/git_tests.rs
@@ -38,6 +38,16 @@ fn test_worktree_path_nested_project() {
 }
 
 #[test]
+fn test_worktree_path_with_custom_dir() {
+    let project = PathBuf::from("/home/user/project");
+    let path = git::worktree_path_with_dir(&project, "task-123", ".worktrees");
+    assert_eq!(
+        path,
+        PathBuf::from("/home/user/project/.worktrees/task-123")
+    );
+}
+
+#[test]
 fn test_worktree_exists_false_for_nonexistent() {
     let temp_dir = TempDir::new().unwrap();
     assert!(!git::worktree_exists(temp_dir.path(), "nonexistent-task"));

--- a/tests/git_tests.rs
+++ b/tests/git_tests.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 #[test]
 fn test_worktree_path() {
     let project = PathBuf::from("/home/user/project");
-    let path = git::worktree_path(&project, "task-123");
+    let path = git::worktree_path(&project, "task-123", git::DEFAULT_WORKTREE_DIR);
     assert_eq!(
         path,
         PathBuf::from("/home/user/project/.agtx/worktrees/task-123")
@@ -20,7 +20,7 @@ fn test_worktree_path() {
 #[test]
 fn test_worktree_path_with_special_chars() {
     let project = PathBuf::from("/home/user/my-project");
-    let path = git::worktree_path(&project, "fix-bug-456");
+    let path = git::worktree_path(&project, "fix-bug-456", git::DEFAULT_WORKTREE_DIR);
     assert_eq!(
         path,
         PathBuf::from("/home/user/my-project/.agtx/worktrees/fix-bug-456")
@@ -30,7 +30,7 @@ fn test_worktree_path_with_special_chars() {
 #[test]
 fn test_worktree_path_nested_project() {
     let project = PathBuf::from("/home/user/projects/rust/agtx");
-    let path = git::worktree_path(&project, "feature-abc");
+    let path = git::worktree_path(&project, "feature-abc", git::DEFAULT_WORKTREE_DIR);
     assert_eq!(
         path,
         PathBuf::from("/home/user/projects/rust/agtx/.agtx/worktrees/feature-abc")
@@ -167,7 +167,7 @@ fn test_create_and_remove_worktree() {
     assert!(git::worktree_exists(temp_dir.path(), "test-task"));
 
     // Remove worktree
-    git::remove_worktree(temp_dir.path(), "test-task").unwrap();
+    git::remove_worktree(temp_dir.path(), "test-task", git::DEFAULT_WORKTREE_DIR).unwrap();
 
     // Verify it's gone
     assert!(!worktree_path.exists());
@@ -262,7 +262,7 @@ fn test_remove_worktree_nonexistent() {
 
     // Removing a non-existent worktree should not panic
     // (it may return Ok or Err depending on git version, but shouldn't crash)
-    let result = git::remove_worktree(temp_dir.path(), "does-not-exist");
+    let result = git::remove_worktree(temp_dir.path(), "does-not-exist", git::DEFAULT_WORKTREE_DIR);
 
     // The function should complete without panicking
     // We don't assert success/failure since behavior may vary
@@ -307,9 +307,9 @@ fn test_create_multiple_worktrees() {
     assert_ne!(path1, path3);
 
     // Clean up
-    git::remove_worktree(temp_dir.path(), "task-1").unwrap();
-    git::remove_worktree(temp_dir.path(), "task-2").unwrap();
-    git::remove_worktree(temp_dir.path(), "task-3").unwrap();
+    git::remove_worktree(temp_dir.path(), "task-1", git::DEFAULT_WORKTREE_DIR).unwrap();
+    git::remove_worktree(temp_dir.path(), "task-2", git::DEFAULT_WORKTREE_DIR).unwrap();
+    git::remove_worktree(temp_dir.path(), "task-3", git::DEFAULT_WORKTREE_DIR).unwrap();
 
     assert!(!path1.exists());
     assert!(!path2.exists());
@@ -327,7 +327,7 @@ fn test_worktree_with_uncommitted_changes() {
     std::fs::write(worktree_path.join("dirty-file.txt"), "uncommitted content").unwrap();
 
     // Remove should still work (with --force)
-    let result = git::remove_worktree(temp_dir.path(), "dirty-task");
+    let result = git::remove_worktree(temp_dir.path(), "dirty-task", git::DEFAULT_WORKTREE_DIR);
     assert!(result.is_ok());
 }
 


### PR DESCRIPTION
## Summary

- Add `worktree_dir` config option (default: `.agtx/worktrees`) at global, project, and merged config levels
- Previously the worktree path was hardcoded to `.agtx/worktrees/{slug}` — now configurable to e.g. `.worktrees/`
- Single source of truth for the default value via `git::DEFAULT_WORKTREE_DIR`

### Configuration

**Global** (`~/.config/agtx/config.toml`):
```toml
[worktree]
worktree_dir = ".worktrees"
```

**Per-project** (`.agtx/config.toml`):
```toml
worktree_dir = ".worktrees"
```

## Test plan

- [x] All 574 tests pass (`cargo test --features test-mocks`)
- [x] Config merge: project overrides global, global overrides default
- [x] `worktree_path_with_dir` produces correct paths
- [x] Backward compatible — default unchanged at `.agtx/worktrees`