### PR TITLE
feat(sidebar): add project remove and init script commands

### DIFF
--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -379,6 +379,22 @@ impl Database {
         Ok(projects)
     }
 
+    pub fn delete_project(&self, project_path_str: &str) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM projects WHERE path = ?1",
+            params![project_path_str],
+        )?;
+        if let Some(config_dir) = directories::ProjectDirs::from("", "", "agtx") {
+            let hash = Self::hash_path(project_path_str);
+            let db_file = config_dir
+                .config_dir()
+                .join("projects")
+                .join(format!("{}.db", hash));
+            let _ = std::fs::remove_file(db_file);
+        }
+        Ok(())
+    }
+
     // === Transition Request Operations (MCP command queue) ===
 
     pub fn create_transition_request(&self, req: &TransitionRequest) -> Result<()> {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -45,7 +45,7 @@ fn build_footer_text(
     match input_mode {
         InputMode::Normal => {
             if sidebar_focused {
-                " [j/k] navigate  [Enter] open  [l] board  [e] hide sidebar  [q] quit ".to_string()
+                " [j/k] navigate  [Enter] open  [i] init script  [x] remove  [l] board  [e] hide  [q] quit ".to_string()
             } else {
                 match selected_column {
                     0 => " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [R] research  [m] plan  [M] run  [e] sidebar  [q] quit".to_string(),
@@ -58,6 +58,7 @@ fn build_footer_text(
             }
         }
         InputMode::InputTitle => " Enter task title... [Esc] cancel [Enter] next ".to_string(),
+        InputMode::InputInitScript => " [Ctrl+S] save  [Enter] newline  [Esc] cancel ".to_string(),
         InputMode::SelectPlugin => {
             " [j/k] select plugin  [Tab] cycle  [Enter] next  [Esc] cancel ".to_string()
         }
@@ -263,6 +264,10 @@ struct AppState {
     skip_move_confirm: bool,
     // Confirmation popup for deleting a task
     delete_confirm_popup: Option<DeleteConfirmPopup>,
+    // Confirmation popup for removing a project from tracking
+    project_delete_confirm_popup: Option<ProjectDeleteConfirmPopup>,
+    // Path of the project whose init script is being edited
+    editing_init_script_path: Option<PathBuf>,
     // Confirmation popup for asking if user wants to create PR when moving to Review
     review_confirm_popup: Option<ReviewConfirmPopup>,
     // Channel for receiving background worktree setup results
@@ -456,6 +461,13 @@ struct DeleteConfirmPopup {
     task_title: String,
 }
 
+/// State for project removal confirmation popup
+#[derive(Debug, Clone)]
+struct ProjectDeleteConfirmPopup {
+    project_name: String,
+    project_path: String,
+}
+
 /// State for asking if user wants to create PR when moving to Review
 #[derive(Debug, Clone)]
 struct ReviewConfirmPopup {
@@ -598,6 +610,8 @@ impl App {
                 move_confirm_popup: None,
                 skip_move_confirm: false,
                 delete_confirm_popup: None,
+                project_delete_confirm_popup: None,
+                editing_init_script_path: None,
                 review_confirm_popup: None,
                 phase_status_cache: HashMap::new(),
                 spinner_frame: 0,
@@ -773,6 +787,8 @@ impl App {
                 move_confirm_popup: None,
                 skip_move_confirm: false,
                 delete_confirm_popup: None,
+                project_delete_confirm_popup: None,
+                editing_init_script_path: None,
                 review_confirm_popup: None,
                 phase_status_cache: HashMap::new(),
                 spinner_frame: 0,
@@ -1856,6 +1872,55 @@ impl App {
             frame.render_widget(content, inner);
         }
 
+        // Init script editor overlay
+        if state.input_mode == InputMode::InputInitScript {
+            let overlay_area = centered_rect(65, 60, area);
+            frame.render_widget(Clear, overlay_area);
+
+            let selected_color = hex_to_color(&state.config.theme.color_selected);
+            let text_color = hex_to_color(&state.config.theme.color_text);
+            let dimmed_color = hex_to_color(&state.config.theme.color_dimmed);
+
+            let (before_cursor, after_cursor) = state
+                .input_buffer
+                .split_at(state.input_cursor.min(state.input_buffer.len()));
+            let full_text = format!("{}█{}", before_cursor, after_cursor);
+
+            let mut lines: Vec<Line> = full_text
+                .split('\n')
+                .map(|l| {
+                    Line::from(Span::styled(
+                        l.to_string(),
+                        Style::default().fg(text_color),
+                    ))
+                })
+                .collect();
+
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  [Ctrl+S] save  [Enter] newline  [Esc] cancel",
+                Style::default().fg(dimmed_color),
+            )));
+
+            let title = state
+                .editing_init_script_path
+                .as_ref()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                .map(|n| format!(" Init Script — {} ", n))
+                .unwrap_or_else(|| " Init Script ".to_string());
+
+            let content = Paragraph::new(Text::from(lines))
+                .wrap(Wrap { trim: false })
+                .block(
+                    Block::default()
+                        .title(title)
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(selected_color)),
+                );
+            frame.render_widget(content, overlay_area);
+        }
+
         // Delete confirmation popup
         if let Some(ref popup) = state.delete_confirm_popup {
             let popup_area = centered_rect(50, 25, area);
@@ -1874,6 +1939,32 @@ impl App {
             let text = format!(
                 "Are you sure you want to delete:\n\n\"{}\"\n\nThis will also remove the worktree and tmux session.\n\n[y] Yes, delete    [n/Esc] Cancel",
                 popup.task_title
+            );
+            let content = Paragraph::new(text)
+                .style(Style::default().fg(Color::White))
+                .alignment(ratatui::layout::Alignment::Center)
+                .wrap(Wrap { trim: false });
+            frame.render_widget(content, inner);
+        }
+
+        // Project removal confirmation popup
+        if let Some(ref popup) = state.project_delete_confirm_popup {
+            let popup_area = centered_rect(50, 30, area);
+            frame.render_widget(Clear, popup_area);
+
+            let main_block = Block::default()
+                .title(" Remove Project? ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Red));
+            frame.render_widget(main_block, popup_area);
+
+            let inner = popup_area.inner(ratatui::layout::Margin {
+                horizontal: 2,
+                vertical: 2,
+            });
+            let text = format!(
+                "Remove \"{}\" from the project list?\n\nThis removes it from agtx tracking only.\nWorktrees, git history, and files are untouched.\n\n[y] Yes, remove    [n/Esc] Cancel",
+                popup.project_name
             );
             let content = Paragraph::new(text)
                 .style(Style::default().fg(Color::White))
@@ -2399,6 +2490,11 @@ impl App {
             return self.handle_delete_confirm_key(key);
         }
 
+        // Handle project removal confirmation popup if open
+        if self.state.project_delete_confirm_popup.is_some() {
+            return self.handle_project_delete_confirm_key(key);
+        }
+
         // Handle Review confirmation popup if open
         if self.state.review_confirm_popup.is_some() {
             return self.handle_review_confirm_key(key);
@@ -2437,6 +2533,7 @@ impl App {
                 InputMode::InputTitle => self.handle_title_input(key),
                 InputMode::SelectPlugin => self.handle_plugin_select_wizard(key),
                 InputMode::InputDescription => self.handle_description_input(key),
+                InputMode::InputInitScript => self.handle_init_script_input(key),
             },
         }
     }
@@ -2495,6 +2592,57 @@ impl App {
         Ok(())
     }
 
+    fn handle_project_delete_confirm_key(
+        &mut self,
+        key: crossterm::event::KeyEvent,
+    ) -> Result<()> {
+        if let Some(popup) = self.state.project_delete_confirm_popup.clone() {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    self.state.project_delete_confirm_popup = None;
+                    self.perform_delete_project(&popup.project_path)?;
+                }
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                    self.state.project_delete_confirm_popup = None;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn perform_delete_project(&mut self, project_path: &str) -> Result<()> {
+        self.state.global_db.delete_project(project_path)?;
+
+        let is_current = self
+            .state
+            .project_path
+            .as_ref()
+            .map(|p| p.to_string_lossy() == project_path)
+            .unwrap_or(false);
+
+        self.refresh_projects()?;
+
+        if self.state.selected_project >= self.state.projects.len()
+            && !self.state.projects.is_empty()
+        {
+            self.state.selected_project = self.state.projects.len() - 1;
+        }
+
+        if is_current {
+            if let Some(next) = self.state.projects.get(self.state.selected_project).cloned() {
+                self.switch_to_project_keep_sidebar(&next)?;
+            } else {
+                self.state.db = None;
+                self.state.project_path = None;
+                self.state.project_name = String::new();
+                self.state.board = BoardState::new();
+            }
+        }
+
+        Ok(())
+    }
+
     fn handle_review_confirm_key(&mut self, key: crossterm::event::KeyEvent) -> Result<()> {
         if let Some(popup) = self.state.review_confirm_popup.clone() {
             match key.code {
@@ -2515,6 +2663,125 @@ impl App {
                 _ => {}
             }
         }
+        Ok(())
+    }
+
+    fn open_init_script_editor(&mut self, project: &ProjectInfo) {
+        let project_path = PathBuf::from(&project.path);
+        let script_path = project_path.join(".agtx").join("init.sh");
+        self.state.input_buffer = if script_path.exists() {
+            std::fs::read_to_string(&script_path).unwrap_or_default()
+        } else {
+            String::new()
+        };
+        self.state.input_cursor = self.state.input_buffer.len();
+        self.state.editing_init_script_path = Some(project_path);
+        self.state.input_mode = InputMode::InputInitScript;
+    }
+
+    fn handle_init_script_input(&mut self, key: crossterm::event::KeyEvent) -> Result<()> {
+        use crossterm::event::KeyModifiers;
+        match key.code {
+            KeyCode::Esc => {
+                self.state.input_mode = InputMode::Normal;
+                self.state.input_buffer.clear();
+                self.state.input_cursor = 0;
+                self.state.editing_init_script_path = None;
+            }
+            KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.save_init_script()?;
+            }
+            KeyCode::Enter => {
+                self.state.input_buffer.insert(self.state.input_cursor, '\n');
+                self.state.input_cursor += 1;
+            }
+            KeyCode::Left if key.modifiers.contains(KeyModifiers::ALT) => {
+                self.state.input_cursor =
+                    word_boundary_left(&self.state.input_buffer, self.state.input_cursor);
+            }
+            KeyCode::Right if key.modifiers.contains(KeyModifiers::ALT) => {
+                self.state.input_cursor =
+                    word_boundary_right(&self.state.input_buffer, self.state.input_cursor);
+            }
+            KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::ALT) => {
+                self.state.input_cursor =
+                    word_boundary_left(&self.state.input_buffer, self.state.input_cursor);
+            }
+            KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::ALT) => {
+                self.state.input_cursor =
+                    word_boundary_right(&self.state.input_buffer, self.state.input_cursor);
+            }
+            KeyCode::Backspace if key.modifiers.contains(KeyModifiers::ALT) => {
+                let new_pos =
+                    word_boundary_left(&self.state.input_buffer, self.state.input_cursor);
+                self.state
+                    .input_buffer
+                    .drain(new_pos..self.state.input_cursor);
+                self.state.input_cursor = new_pos;
+            }
+            KeyCode::Left => {
+                if self.state.input_cursor > 0 {
+                    self.state.input_cursor -= 1;
+                }
+            }
+            KeyCode::Right => {
+                if self.state.input_cursor < self.state.input_buffer.len() {
+                    self.state.input_cursor += 1;
+                }
+            }
+            KeyCode::Home => self.state.input_cursor = 0,
+            KeyCode::End => self.state.input_cursor = self.state.input_buffer.len(),
+            KeyCode::Backspace => {
+                if self.state.input_cursor > 0 {
+                    self.state.input_cursor -= 1;
+                    self.state.input_buffer.remove(self.state.input_cursor);
+                }
+            }
+            KeyCode::Delete => {
+                if self.state.input_cursor < self.state.input_buffer.len() {
+                    self.state.input_buffer.remove(self.state.input_cursor);
+                }
+            }
+            KeyCode::Char(c) => {
+                self.state.input_buffer.insert(self.state.input_cursor, c);
+                self.state.input_cursor += 1;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn save_init_script(&mut self) -> Result<()> {
+        if let Some(project_path) = self.state.editing_init_script_path.clone() {
+            let agtx_dir = project_path.join(".agtx");
+            std::fs::create_dir_all(&agtx_dir)?;
+
+            let script_path = agtx_dir.join("init.sh");
+            std::fs::write(&script_path, &self.state.input_buffer)?;
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(
+                    &script_path,
+                    std::fs::Permissions::from_mode(0o755),
+                );
+            }
+
+            let mut config = ProjectConfig::load(&project_path).unwrap_or_default();
+            config.init_script = Some("bash .agtx/init.sh".to_string());
+            let _ = config.save(&project_path);
+
+            let is_current = self.state.project_path.as_deref() == Some(project_path.as_path());
+            if is_current {
+                self.state.config.init_script = Some("bash .agtx/init.sh".to_string());
+            }
+        }
+
+        self.state.input_mode = InputMode::Normal;
+        self.state.input_buffer.clear();
+        self.state.input_cursor = 0;
+        self.state.editing_init_script_path = None;
         Ok(())
     }
 
@@ -3187,6 +3454,19 @@ impl App {
                 KeyCode::Enter => {
                     // Enter focuses the board (sidebar stays visible)
                     self.state.sidebar_focused = false;
+                }
+                KeyCode::Char('x') => {
+                    if let Some(p) = self.state.projects.get(self.state.selected_project).cloned() {
+                        self.state.project_delete_confirm_popup = Some(ProjectDeleteConfirmPopup {
+                            project_name: p.name,
+                            project_path: p.path,
+                        });
+                    }
+                }
+                KeyCode::Char('i') => {
+                    if let Some(p) = self.state.projects.get(self.state.selected_project).cloned() {
+                        self.open_init_script_editor(&p);
+                    }
                 }
                 _ => {}
             }
@@ -4004,6 +4284,7 @@ impl App {
         self.state.wizard_plugin_options.clear();
         self.state.wizard_referenced_task_ids.clear();
         self.state.task_ref_search = None;
+        self.state.editing_init_script_path = None;
     }
 
     /// Advance from title step to plugin selection or description.

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -1326,7 +1326,9 @@ fn test_word_boundary_roundtrip() {
 fn test_footer_text_sidebar_focused() {
     let text = build_footer_text(InputMode::Normal, true, 0, false);
     assert!(text.contains("[j/k] navigate"));
-    assert!(text.contains("[e] hide sidebar"));
+    assert!(text.contains("[e] hide"));
+    assert!(text.contains("[x] remove"));
+    assert!(text.contains("[i] init script"));
     assert!(!text.contains("[o] new"));
 }
 
@@ -8995,4 +8997,210 @@ fn test_should_send_stuck_notification_other_plugins() {
     assert!(should_send_stuck_notification(Some("bmad")));
     // No plugin set (None) should also produce notifications
     assert!(should_send_stuck_notification(None));
+}
+
+// =============================================================================
+// Tests for InputInitScript footer text
+// =============================================================================
+
+#[test]
+fn test_footer_text_input_init_script() {
+    let text = build_footer_text(InputMode::InputInitScript, false, 0, false);
+    assert!(text.contains("[Ctrl+S] save"));
+    assert!(text.contains("[Enter] newline"));
+    assert!(text.contains("[Esc] cancel"));
+}
+
+// =============================================================================
+// Tests for project delete confirm popup
+// =============================================================================
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_project_delete_confirm_popup_opens_on_x() {
+    let mut app = make_test_app();
+    app.state.sidebar_visible = true;
+    app.state.sidebar_focused = true;
+    app.state.projects = vec![
+        ProjectInfo { name: "proj-a".to_string(), path: "/tmp/proj-a".to_string() },
+    ];
+    app.state.selected_project = 0;
+
+    press_key(&mut app, KeyCode::Char('x'));
+
+    assert!(app.state.project_delete_confirm_popup.is_some());
+    let popup = app.state.project_delete_confirm_popup.as_ref().unwrap();
+    assert_eq!(popup.project_name, "proj-a");
+    assert_eq!(popup.project_path, "/tmp/proj-a");
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_project_delete_confirm_popup_n_cancels() {
+    let mut app = make_test_app();
+    app.state.project_delete_confirm_popup = Some(ProjectDeleteConfirmPopup {
+        project_name: "proj-a".to_string(),
+        project_path: "/tmp/proj-a".to_string(),
+    });
+
+    press_key(&mut app, KeyCode::Char('n'));
+
+    assert!(app.state.project_delete_confirm_popup.is_none());
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_project_delete_confirm_popup_esc_cancels() {
+    let mut app = make_test_app();
+    app.state.project_delete_confirm_popup = Some(ProjectDeleteConfirmPopup {
+        project_name: "proj-a".to_string(),
+        project_path: "/tmp/proj-a".to_string(),
+    });
+
+    press_key(&mut app, KeyCode::Esc);
+
+    assert!(app.state.project_delete_confirm_popup.is_none());
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_project_delete_confirm_popup_x_no_projects_does_nothing() {
+    let mut app = make_test_app();
+    app.state.sidebar_visible = true;
+    app.state.sidebar_focused = true;
+    app.state.projects = vec![];
+
+    press_key(&mut app, KeyCode::Char('x'));
+
+    assert!(app.state.project_delete_confirm_popup.is_none());
+}
+
+// =============================================================================
+// Tests for init script editor
+// =============================================================================
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_init_script_editor_opens_on_i() {
+    let mut app = make_test_app();
+    app.state.sidebar_visible = true;
+    app.state.sidebar_focused = true;
+    app.state.projects = vec![
+        ProjectInfo { name: "proj-a".to_string(), path: "/tmp/proj-a".to_string() },
+    ];
+    app.state.selected_project = 0;
+
+    press_key(&mut app, KeyCode::Char('i'));
+
+    assert_eq!(app.state.input_mode, InputMode::InputInitScript);
+    assert_eq!(
+        app.state.editing_init_script_path,
+        Some(PathBuf::from("/tmp/proj-a"))
+    );
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_init_script_editor_esc_cancels() {
+    let mut app = make_test_app();
+    app.state.input_mode = InputMode::InputInitScript;
+    app.state.input_buffer = "echo hello".to_string();
+    app.state.input_cursor = 10;
+    app.state.editing_init_script_path = Some(PathBuf::from("/tmp/proj-a"));
+
+    press_key(&mut app, KeyCode::Esc);
+
+    assert_eq!(app.state.input_mode, InputMode::Normal);
+    assert!(app.state.input_buffer.is_empty());
+    assert_eq!(app.state.input_cursor, 0);
+    assert!(app.state.editing_init_script_path.is_none());
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_init_script_editor_enter_inserts_newline() {
+    let mut app = make_test_app();
+    app.state.input_mode = InputMode::InputInitScript;
+    app.state.input_buffer = "echo hello".to_string();
+    app.state.input_cursor = 10;
+    app.state.editing_init_script_path = Some(PathBuf::from("/tmp/proj-a"));
+
+    press_key(&mut app, KeyCode::Enter);
+
+    assert_eq!(app.state.input_buffer, "echo hello\n");
+    assert_eq!(app.state.input_cursor, 11);
+    assert_eq!(app.state.input_mode, InputMode::InputInitScript);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_init_script_editor_typing() {
+    let mut app = make_test_app();
+    app.state.input_mode = InputMode::InputInitScript;
+    app.state.editing_init_script_path = Some(PathBuf::from("/tmp/proj-a"));
+
+    type_str(&mut app, "npm install");
+
+    assert_eq!(app.state.input_buffer, "npm install");
+    assert_eq!(app.state.input_cursor, 11);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_init_script_ctrl_s_saves_file() {
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().unwrap();
+    let project_path = tmp.path().to_path_buf();
+
+    let mut app = make_test_app();
+    app.state.input_mode = InputMode::InputInitScript;
+    app.state.input_buffer = "npm install\nnpm run build".to_string();
+    app.state.input_cursor = app.state.input_buffer.len();
+    app.state.editing_init_script_path = Some(project_path.clone());
+
+    app.handle_key(crossterm::event::KeyEvent::new(
+        KeyCode::Char('s'),
+        crossterm::event::KeyModifiers::CONTROL,
+    ))
+    .unwrap();
+
+    assert_eq!(app.state.input_mode, InputMode::Normal);
+    assert!(app.state.editing_init_script_path.is_none());
+
+    let script_path = project_path.join(".agtx").join("init.sh");
+    assert!(script_path.exists());
+    let content = std::fs::read_to_string(&script_path).unwrap();
+    assert_eq!(content, "npm install\nnpm run build");
+
+    let config_path = project_path.join(".agtx").join("config.toml");
+    assert!(config_path.exists());
+    let config_content = std::fs::read_to_string(&config_path).unwrap();
+    assert!(config_content.contains("bash .agtx/init.sh"));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_init_script_editor_loads_existing_file() {
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().unwrap();
+    let project_path = tmp.path().to_path_buf();
+    let agtx_dir = project_path.join(".agtx");
+    std::fs::create_dir_all(&agtx_dir).unwrap();
+    std::fs::write(agtx_dir.join("init.sh"), "echo existing").unwrap();
+
+    let mut app = make_test_app();
+    app.state.sidebar_visible = true;
+    app.state.sidebar_focused = true;
+    app.state.projects = vec![ProjectInfo {
+        name: "proj".to_string(),
+        path: project_path.to_string_lossy().to_string(),
+    }];
+    app.state.selected_project = 0;
+
+    press_key(&mut app, KeyCode::Char('i'));
+
+    assert_eq!(app.state.input_mode, InputMode::InputInitScript);
+    assert_eq!(app.state.input_buffer, "echo existing");
 }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -9,6 +9,8 @@ pub enum InputMode {
     SelectPlugin,
     /// Entering task description/prompt
     InputDescription,
+    /// Editing a project's worktree init script
+    InputInitScript,
 }
 
 impl Default for InputMode {

--- a/tests/db_tests.rs
+++ b/tests/db_tests.rs
@@ -232,3 +232,47 @@ fn test_notifications_empty_queue() {
     let notifs = db.consume_notifications().unwrap();
     assert_eq!(notifs.len(), 0);
 }
+
+// === delete_project Tests ===
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_delete_project_removes_from_list() {
+    let db = Database::open_in_memory_global().unwrap();
+    let project = Project::new("my-project", "/path/to/project");
+    db.upsert_project(&project).unwrap();
+
+    let before = db.get_all_projects().unwrap();
+    assert_eq!(before.len(), 1);
+
+    db.delete_project("/path/to/project").unwrap();
+
+    let after = db.get_all_projects().unwrap();
+    assert_eq!(after.len(), 0);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_delete_project_only_removes_matching_path() {
+    let db = Database::open_in_memory_global().unwrap();
+    db.upsert_project(&Project::new("proj-a", "/path/a")).unwrap();
+    db.upsert_project(&Project::new("proj-b", "/path/b")).unwrap();
+
+    db.delete_project("/path/a").unwrap();
+
+    let remaining = db.get_all_projects().unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].name, "proj-b");
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_delete_project_nonexistent_path_is_noop() {
+    let db = Database::open_in_memory_global().unwrap();
+    db.upsert_project(&Project::new("proj", "/real/path")).unwrap();
+
+    db.delete_project("/nonexistent/path").unwrap();
+
+    let remaining = db.get_all_projects().unwrap();
+    assert_eq!(remaining.len(), 1);
+}


### PR DESCRIPTION
## Summary

- Add `x` key in sidebar to remove a project from agtx tracking (with confirmation popup)
- Add `i` key in sidebar to open an inline editor for the project's `.agtx/init.sh` script (saves with `Ctrl+S`, auto-sets `init_script` in project config)
- Add `Database::delete_project()` that removes from the index and cleans up the per-project `.db` file

## Test plan

- [ ] `x` on a project opens confirmation popup; `y` removes it, `n`/`Esc` cancels
- [ ] Removing the currently open project switches to the next available project (or clears state if none)
- [ ] `i` on a project opens the init script editor with existing content pre-loaded
- [ ] `Ctrl+S` writes `.agtx/init.sh` (executable), updates `.agtx/config.toml`, and closes the editor
- [ ] `Esc` discards changes without writing anything
- [ ] All 15 new tests pass: `cargo test --features test-mocks`