### PR TITLE
feat: fullscreen tmux attach with Ctrl+f

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,7 @@ color_popup_header = "#69fae7"  # Popup headers (light cyan)
 | `o` | Create new task |
 | `Enter` | Open task popup (tmux view) / Edit task (backlog) |
 | `x` | Delete task (with confirmation) |
+| `f` | Fullscreen attach to task's tmux session |
 | `d` | Show git diff for task |
 | `m` | Move task forward (advance workflow) |
 | `r` | Resume task (Review → Running) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,7 @@ color_popup_header = "#69fae7"  # Popup headers (light cyan)
 | `Ctrl+j/k` or `Ctrl+n/p` | Scroll up/down |
 | `Ctrl+d/u` | Page down/up |
 | `Ctrl+g` | Jump to bottom |
+| `Ctrl+f` | Fullscreen attach to tmux session |
 | `Ctrl+q` or `Esc` | Close popup |
 | Other keys | Forwarded to tmux/agent |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,12 @@ A dedicated Claude Code agent that autonomously manages the kanban board. Enable
 
 **MCP tools**: `list_tasks`, `get_task` (includes `allowed_actions`), `move_task`, `get_transition_status`, `check_conflicts`, `get_notifications`
 
+### General Configuration
+Configurable via `~/.config/agtx/config.toml`:
+```toml
+fullscreen_on_enter = false  # When true, Enter on a task attaches to tmux directly instead of opening the in-TUI popup
+```
+
 ### Theme Configuration
 Colors configurable via `~/.config/agtx/config.toml`:
 ```toml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ color_popup_header = "#69fae7"  # Popup headers (light cyan)
 | `o` | Create new task |
 | `Enter` | Open task popup (tmux view) / Edit task (backlog) |
 | `x` | Delete task (with confirmation) |
-| `f` | Fullscreen attach to task's tmux session |
+| `Ctrl+f` | Fullscreen attach to task's tmux session |
 | `d` | Show git diff for task |
 | `m` | Move task forward (advance workflow) |
 | `r` | Resume task (Review → Running) |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,6 +20,10 @@ pub struct GlobalConfig {
     /// UI theme/colors
     #[serde(default)]
     pub theme: ThemeConfig,
+
+    /// Whether to automatically fullscreen-attach to the tmux session when opening a task popup
+    #[serde(default)]
+    pub fullscreen_on_enter: bool,
 }
 
 impl Default for GlobalConfig {
@@ -29,6 +33,7 @@ impl Default for GlobalConfig {
             agents: PhaseAgentsConfig::default(),
             worktree: WorktreeConfig::default(),
             theme: ThemeConfig::default(),
+            fullscreen_on_enter: false,
         }
     }
 }
@@ -327,6 +332,7 @@ pub struct MergedConfig {
     pub copy_files: Option<String>,
     pub init_script: Option<String>,
     pub workflow_plugin: Option<String>,
+    pub fullscreen_on_enter: bool,
 }
 
 impl MergedConfig {
@@ -355,6 +361,7 @@ impl MergedConfig {
             copy_files: project.copy_files.clone(),
             init_script: project.init_script.clone(),
             workflow_plugin: project.workflow_plugin.clone(),
+            fullscreen_on_enter: global.fullscreen_on_enter,
         }
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5447,43 +5447,57 @@ impl App {
         let session = &self.state.tmux_project_name;
         let window_target = format!("{}:{}", session, window_name);
 
-        // Leave alternate screen and disable raw mode
-        match self.terminal.backend_mut() {
-            AppBackend::Crossterm(backend) => {
-                let _ = disable_raw_mode();
-                let _ = execute!(backend, LeaveAlternateScreen);
+        // Check if we're already inside the agtx tmux server — if so, just
+        // switch windows instead of nesting with attach.
+        let inside_agtx = std::env::var("TMUX")
+            .map(|v| v.contains(tmux::AGENT_SERVER))
+            .unwrap_or(false);
+
+        if inside_agtx {
+            // Already inside agtx tmux — just switch to the task window
+            let _ = std::process::Command::new("tmux")
+                .args([
+                    "-L", tmux::AGENT_SERVER,
+                    "select-window", "-t", window_name,
+                    ";", "resize-window", "-A",
+                ])
+                .status();
+        } else {
+            // Leave alternate screen and disable raw mode
+            match self.terminal.backend_mut() {
+                AppBackend::Crossterm(backend) => {
+                    let _ = disable_raw_mode();
+                    let _ = execute!(backend, LeaveAlternateScreen);
+                }
+                #[cfg(feature = "test-mocks")]
+                AppBackend::Test(_) => {}
             }
-            #[cfg(feature = "test-mocks")]
-            AppBackend::Test(_) => {}
-        }
 
-        // Select the task window, attach, and resize in one tmux invocation.
-        // Uses just window_name (no session: prefix) for select-window since
-        // that's how the rest of the codebase targets windows.
-        // Unset $TMUX so tmux allows attaching to the agtx server even when
-        // the user is already inside their own tmux session.
-        let _ = std::process::Command::new("tmux")
-            .args([
-                "-L", tmux::AGENT_SERVER,
-                "attach", "-t", session,
-                ";", "select-window", "-t", window_name,
-                ";", "resize-window", "-A",
-            ])
-            .env_remove("TMUX")
-            .status();
+            // Attach to the agtx tmux server, select the task window, and resize.
+            // Unset $TMUX so tmux allows attaching when inside a different tmux.
+            let _ = std::process::Command::new("tmux")
+                .args([
+                    "-L", tmux::AGENT_SERVER,
+                    "attach", "-t", session,
+                    ";", "select-window", "-t", window_name,
+                    ";", "resize-window", "-A",
+                ])
+                .env_remove("TMUX")
+                .status();
 
-        // Restore terminal
-        match self.terminal.backend_mut() {
-            AppBackend::Crossterm(backend) => {
-                enable_raw_mode()?;
-                execute!(backend, EnterAlternateScreen)?;
+            // Restore terminal
+            match self.terminal.backend_mut() {
+                AppBackend::Crossterm(backend) => {
+                    enable_raw_mode()?;
+                    execute!(backend, EnterAlternateScreen)?;
+                }
+                #[cfg(feature = "test-mocks")]
+                AppBackend::Test(_) => {}
             }
-            #[cfg(feature = "test-mocks")]
-            AppBackend::Test(_) => {}
-        }
 
-        // Force full redraw
-        self.terminal.clear()?;
+            // Force full redraw
+            self.terminal.clear()?;
+        }
 
         Ok(())
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5469,6 +5469,7 @@ impl App {
                 ";", "select-window", "-t", window_name,
                 ";", "resize-window", "-A",
             ])
+            .env_remove("TMUX")
             .status();
 
         // Restore terminal

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5497,11 +5497,12 @@ impl App {
             .unwrap_or(false);
 
         if inside_agtx {
-            // Already inside agtx tmux — just switch to the task window
+            // Already inside agtx tmux — just switch to the task window.
+            // Use session:window target to work across multiple project sessions.
             let _ = std::process::Command::new("tmux")
                 .args([
                     "-L", tmux::AGENT_SERVER,
-                    "select-window", "-t", window_name,
+                    "select-window", "-t", &window_target,
                     ";", "resize-window", "-A",
                 ])
                 .status();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -49,10 +49,10 @@ fn build_footer_text(
             } else {
                 match selected_column {
                     0 => " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [R] research  [m] plan  [M] run  [e] sidebar  [q] quit".to_string(),
-                    1 => " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [m] run  [e] sidebar  [q] quit".to_string(),
-                    2 => " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string(),
-                    3 if has_cyclic_plugin => " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [m] done  [r] resume  [p] next phase  [e] sidebar  [q] quit".to_string(),
-                    3 => " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string(),
+                    1 => " [o] new  [/] search  [Enter] open  [f] fullscreen  [x] del  [d] diff  [m] run  [e] sidebar  [q] quit".to_string(),
+                    2 => " [o] new  [/] search  [Enter] open  [f] fullscreen  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string(),
+                    3 if has_cyclic_plugin => " [o] new  [/] search  [Enter] open  [f] fullscreen  [x] del  [d] diff  [m] done  [r] resume  [p] next phase  [e] sidebar  [q] quit".to_string(),
+                    3 => " [o] new  [/] search  [Enter] open  [f] fullscreen  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string(),
                     _ => " [o] new  [/] search  [Enter] open  [x] del  [e] sidebar  [q] quit".to_string(),
                 }
             }
@@ -3241,6 +3241,14 @@ impl App {
                     } else if task.session_name.is_some() {
                         // Open shell popup
                         self.open_selected_task()?;
+                    }
+                }
+            }
+            KeyCode::Char('f') => {
+                // Fullscreen attach to task's tmux session
+                if let Some(task) = self.state.board.selected_task() {
+                    if let Some(window_name) = task.session_name.clone() {
+                        self.attach_to_tmux_fullscreen(&window_name)?;
                     }
                 }
             }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -41,6 +41,7 @@ fn build_footer_text(
     sidebar_focused: bool,
     selected_column: usize,
     has_cyclic_plugin: bool,
+    fullscreen_on_enter: bool,
 ) -> String {
     match input_mode {
         InputMode::Normal => {
@@ -49,10 +50,26 @@ fn build_footer_text(
             } else {
                 match selected_column {
                     0 => " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [R] research  [m] plan  [M] run  [e] sidebar  [q] quit".to_string(),
-                    1 => " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] run  [e] sidebar  [q] quit".to_string(),
-                    2 => " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string(),
-                    3 if has_cyclic_plugin => " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] done  [r] resume  [p] next phase  [e] sidebar  [q] quit".to_string(),
-                    3 => " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string(),
+                    1 => if fullscreen_on_enter {
+                        " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [m] run  [e] sidebar  [q] quit".to_string()
+                    } else {
+                        " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] run  [e] sidebar  [q] quit".to_string()
+                    },
+                    2 => if fullscreen_on_enter {
+                        " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string()
+                    } else {
+                        " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string()
+                    },
+                    3 if has_cyclic_plugin => if fullscreen_on_enter {
+                        " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [m] done  [r] resume  [p] next phase  [e] sidebar  [q] quit".to_string()
+                    } else {
+                        " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] done  [r] resume  [p] next phase  [e] sidebar  [q] quit".to_string()
+                    },
+                    3 => if fullscreen_on_enter {
+                        " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string()
+                    } else {
+                        " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string()
+                    },
                     _ => " [o] new  [/] search  [Enter] open  [x] del  [e] sidebar  [q] quit".to_string(),
                 }
             }
@@ -1161,6 +1178,7 @@ impl App {
                         state.sidebar_focused,
                         state.board.selected_column,
                         has_cyclic_plugin,
+                        state.config.fullscreen_on_enter,
                     ),
                     Style::default().fg(hex_to_color(&state.config.theme.color_dimmed)),
                 )
@@ -1172,6 +1190,7 @@ impl App {
                     state.sidebar_focused,
                     state.board.selected_column,
                     has_cyclic_plugin,
+                    state.config.fullscreen_on_enter,
                 ),
                 Style::default().fg(hex_to_color(&state.config.theme.color_dimmed)),
             )
@@ -3243,8 +3262,13 @@ impl App {
             KeyCode::Enter => {
                 if let Some(task) = self.state.board.selected_task() {
                     if task.status == TaskStatus::Backlog && task.session_name.is_some() {
-                        // Backlog task with active research session — open tmux popup
-                        self.open_selected_task()?;
+                        // Backlog task with active research session
+                        if self.state.config.fullscreen_on_enter {
+                            let window_name = task.session_name.clone().unwrap();
+                            self.attach_to_tmux_fullscreen(&window_name)?;
+                        } else {
+                            self.open_selected_task()?;
+                        }
                     } else if task.status == TaskStatus::Backlog {
                         // Edit task
                         self.state.editing_task_id = Some(task.id.clone());
@@ -3253,8 +3277,13 @@ impl App {
                         self.state.pending_task_title.clear();
                         self.state.input_mode = InputMode::InputTitle;
                     } else if task.session_name.is_some() {
-                        // Open shell popup
-                        self.open_selected_task()?;
+                        // Open shell popup or fullscreen
+                        if self.state.config.fullscreen_on_enter {
+                            let window_name = task.session_name.clone().unwrap();
+                            self.attach_to_tmux_fullscreen(&window_name)?;
+                        } else {
+                            self.open_selected_task()?;
+                        }
                     }
                 }
             }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3031,6 +3031,13 @@ impl App {
                 KeyCode::Char('g') if has_ctrl => {
                     popup.scroll_to_bottom();
                 }
+                // Ctrl+f = fullscreen attach to tmux session
+                KeyCode::Char('f') if has_ctrl => {
+                    // Close the popup first so the tmux window isn't stuck at popup dimensions
+                    self.state.shell_popup = None;
+                    self.attach_to_tmux_fullscreen(&window_name)?;
+                    return Ok(());
+                }
                 _ => {
                     // Forward all other keys to tmux window (including Esc)
                     send_key_to_tmux(&window_name, key.code, self.state.tmux_ops.as_ref());
@@ -5431,6 +5438,52 @@ impl App {
                 self.state.shell_popup = Some(popup);
             }
         }
+        Ok(())
+    }
+
+    /// Suspend the TUI and attach directly to a tmux window for full interaction.
+    /// Restores the TUI when the user detaches (Ctrl+b d).
+    fn attach_to_tmux_fullscreen(&mut self, window_name: &str) -> Result<()> {
+        let session = &self.state.tmux_project_name;
+        let window_target = format!("{}:{}", session, window_name);
+
+        // Leave alternate screen and disable raw mode
+        match self.terminal.backend_mut() {
+            AppBackend::Crossterm(backend) => {
+                let _ = disable_raw_mode();
+                let _ = execute!(backend, LeaveAlternateScreen);
+            }
+            #[cfg(feature = "test-mocks")]
+            AppBackend::Test(_) => {}
+        }
+
+        // Select the task window, attach, and resize in one tmux invocation.
+        // Uses just window_name (no session: prefix) for select-window since
+        // that's how the rest of the codebase targets windows.
+        // Unset $TMUX so tmux allows attaching to the agtx server even when
+        // the user is already inside their own tmux session.
+        let _ = std::process::Command::new("tmux")
+            .args([
+                "-L", tmux::AGENT_SERVER,
+                "attach", "-t", session,
+                ";", "select-window", "-t", window_name,
+                ";", "resize-window", "-A",
+            ])
+            .status();
+
+        // Restore terminal
+        match self.terminal.backend_mut() {
+            AppBackend::Crossterm(backend) => {
+                enable_raw_mode()?;
+                execute!(backend, EnterAlternateScreen)?;
+            }
+            #[cfg(feature = "test-mocks")]
+            AppBackend::Test(_) => {}
+        }
+
+        // Force full redraw
+        self.terminal.clear()?;
+
         Ok(())
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -49,10 +49,10 @@ fn build_footer_text(
             } else {
                 match selected_column {
                     0 => " [o] new  [/] search  [Enter] open  [x] del  [d] diff  [R] research  [m] plan  [M] run  [e] sidebar  [q] quit".to_string(),
-                    1 => " [o] new  [/] search  [Enter] open  [f] fullscreen  [x] del  [d] diff  [m] run  [e] sidebar  [q] quit".to_string(),
-                    2 => " [o] new  [/] search  [Enter] open  [f] fullscreen  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string(),
-                    3 if has_cyclic_plugin => " [o] new  [/] search  [Enter] open  [f] fullscreen  [x] del  [d] diff  [m] done  [r] resume  [p] next phase  [e] sidebar  [q] quit".to_string(),
-                    3 => " [o] new  [/] search  [Enter] open  [f] fullscreen  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string(),
+                    1 => " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] run  [e] sidebar  [q] quit".to_string(),
+                    2 => " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string(),
+                    3 if has_cyclic_plugin => " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] done  [r] resume  [p] next phase  [e] sidebar  [q] quit".to_string(),
+                    3 => " [o] new  [/] search  [Enter] open  [C-f] fullscreen  [x] del  [d] diff  [m] move  [r] move left  [e] sidebar  [q] quit".to_string(),
                     _ => " [o] new  [/] search  [Enter] open  [x] del  [e] sidebar  [q] quit".to_string(),
                 }
             }
@@ -2433,7 +2433,21 @@ impl App {
         match &self.state.mode {
             AppMode::Dashboard => self.handle_dashboard_key(key.code),
             AppMode::Project(_) => match self.state.input_mode {
-                InputMode::Normal => self.handle_normal_key(key.code),
+                InputMode::Normal => {
+                    // Ctrl+f = fullscreen attach (handled here since handle_normal_key only gets KeyCode)
+                    if key.code == KeyCode::Char('f')
+                        && key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                    {
+                        if let Some(task) = self.state.board.selected_task() {
+                            if let Some(window_name) = task.session_name.clone() {
+                                self.state.shell_popup = None;
+                                return self.attach_to_tmux_fullscreen(&window_name);
+                            }
+                        }
+                        return Ok(());
+                    }
+                    self.handle_normal_key(key.code)
+                }
                 InputMode::InputTitle => self.handle_title_input(key),
                 InputMode::SelectPlugin => self.handle_plugin_select_wizard(key),
                 InputMode::InputDescription => self.handle_description_input(key),
@@ -3241,14 +3255,6 @@ impl App {
                     } else if task.session_name.is_some() {
                         // Open shell popup
                         self.open_selected_task()?;
-                    }
-                }
-            }
-            KeyCode::Char('f') => {
-                // Fullscreen attach to task's tmux session
-                if let Some(task) = self.state.board.selected_task() {
-                    if let Some(window_name) = task.session_name.clone() {
-                        self.attach_to_tmux_fullscreen(&window_name)?;
                     }
                 }
             }

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -1324,6 +1324,20 @@ fn test_footer_text_running_column() {
 }
 
 #[test]
+fn test_footer_text_fullscreen_on_enter_hides_ctrl_f() {
+    // Columns 1-3 should hide [C-f] when fullscreen_on_enter is true
+    for col in 1..=3 {
+        let text = build_footer_text(InputMode::Normal, false, col, false, true);
+        assert!(!text.contains("[C-f]"), "Column {} should hide [C-f] when fullscreen_on_enter=true", col);
+    }
+    // And show it when false
+    for col in 1..=3 {
+        let text = build_footer_text(InputMode::Normal, false, col, false, false);
+        assert!(text.contains("[C-f]"), "Column {} should show [C-f] when fullscreen_on_enter=false", col);
+    }
+}
+
+#[test]
 fn test_footer_text_review_column() {
     let text = build_footer_text(InputMode::Normal, false, 3, false, false);
     assert!(text.contains("[r] move left"));

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -1294,7 +1294,7 @@ fn test_word_boundary_roundtrip() {
 
 #[test]
 fn test_footer_text_sidebar_focused() {
-    let text = build_footer_text(InputMode::Normal, true, 0, false);
+    let text = build_footer_text(InputMode::Normal, true, 0, false, false);
     assert!(text.contains("[j/k] navigate"));
     assert!(text.contains("[e] hide sidebar"));
     assert!(!text.contains("[o] new"));
@@ -1302,7 +1302,7 @@ fn test_footer_text_sidebar_focused() {
 
 #[test]
 fn test_footer_text_backlog_column() {
-    let text = build_footer_text(InputMode::Normal, false, 0, false);
+    let text = build_footer_text(InputMode::Normal, false, 0, false, false);
     assert!(text.contains("[M] run"));
     assert!(text.contains("[m] plan"));
     assert!(!text.contains("[r] move left"));
@@ -1310,7 +1310,7 @@ fn test_footer_text_backlog_column() {
 
 #[test]
 fn test_footer_text_planning_column() {
-    let text = build_footer_text(InputMode::Normal, false, 1, false);
+    let text = build_footer_text(InputMode::Normal, false, 1, false, false);
     assert!(text.contains("[m] run"));
     assert!(!text.contains("[M] run"));
     assert!(!text.contains("[r] move left"));
@@ -1318,21 +1318,21 @@ fn test_footer_text_planning_column() {
 
 #[test]
 fn test_footer_text_running_column() {
-    let text = build_footer_text(InputMode::Normal, false, 2, false);
+    let text = build_footer_text(InputMode::Normal, false, 2, false, false);
     assert!(text.contains("[r] move left"));
     assert!(text.contains("[m] move"));
 }
 
 #[test]
 fn test_footer_text_review_column() {
-    let text = build_footer_text(InputMode::Normal, false, 3, false);
+    let text = build_footer_text(InputMode::Normal, false, 3, false, false);
     assert!(text.contains("[r] move left"));
     assert!(text.contains("[m] move"));
 }
 
 #[test]
 fn test_footer_text_review_column_cyclic() {
-    let text = build_footer_text(InputMode::Normal, false, 3, true);
+    let text = build_footer_text(InputMode::Normal, false, 3, true, false);
     assert!(text.contains("[p] next phase"));
     assert!(text.contains("[r] resume"));
     assert!(text.contains("[m] done"));
@@ -1340,7 +1340,7 @@ fn test_footer_text_review_column_cyclic() {
 
 #[test]
 fn test_footer_text_done_column() {
-    let text = build_footer_text(InputMode::Normal, false, 4, false);
+    let text = build_footer_text(InputMode::Normal, false, 4, false, false);
     assert!(!text.contains("[m] move"));
     assert!(!text.contains("[r]"));
     assert!(!text.contains("[d] diff"));
@@ -1348,14 +1348,14 @@ fn test_footer_text_done_column() {
 
 #[test]
 fn test_footer_text_input_title() {
-    let text = build_footer_text(InputMode::InputTitle, false, 0, false);
+    let text = build_footer_text(InputMode::InputTitle, false, 0, false, false);
     assert!(text.contains("Enter task title"));
     assert!(text.contains("[Esc] cancel"));
 }
 
 #[test]
 fn test_footer_text_input_description() {
-    let text = build_footer_text(InputMode::InputDescription, false, 0, false);
+    let text = build_footer_text(InputMode::InputDescription, false, 0, false, false);
     assert!(text.contains("[#] files"));
     assert!(text.contains("[/] skills"));
     assert!(text.contains("[!] tasks"));
@@ -2392,7 +2392,7 @@ fn test_install_plugin_none_clears_config() {
 
 #[test]
 fn test_footer_text_backlog_includes_research() {
-    let text = build_footer_text(InputMode::Normal, false, 0, false);
+    let text = build_footer_text(InputMode::Normal, false, 0, false, false);
     assert!(text.contains("[R] research"));
 }
 
@@ -3118,7 +3118,7 @@ fn test_determine_phase_variant_review_passthrough() {
 
 #[test]
 fn test_footer_text_review_non_cyclic_no_next_phase() {
-    let text = build_footer_text(InputMode::Normal, false, 3, false);
+    let text = build_footer_text(InputMode::Normal, false, 3, false, false);
     assert!(!text.contains("[p] next phase"));
     assert!(text.contains("[m] move"));
 }
@@ -4302,7 +4302,7 @@ fn test_task_ref_after_space() {
 #[test]
 #[cfg(feature = "test-mocks")]
 fn test_footer_text_select_plugin() {
-    let text = build_footer_text(InputMode::SelectPlugin, false, 0, false);
+    let text = build_footer_text(InputMode::SelectPlugin, false, 0, false, false);
     assert!(text.contains("select plugin"));
     assert!(text.contains("Tab"));
     assert!(text.contains("Enter"));
@@ -4312,7 +4312,7 @@ fn test_footer_text_select_plugin() {
 #[test]
 #[cfg(feature = "test-mocks")]
 fn test_footer_text_description_shows_all_triggers() {
-    let text = build_footer_text(InputMode::InputDescription, false, 0, false);
+    let text = build_footer_text(InputMode::InputDescription, false, 0, false, false);
     assert!(
         text.contains("[#] files"),
         "Missing files trigger: {}",

--- a/src/tui/shell_popup.rs
+++ b/src/tui/shell_popup.rs
@@ -119,11 +119,11 @@ pub fn compute_visible_lines<'a>(
 pub fn build_footer_text(scroll_offset: i32, start_line: usize) -> String {
     if scroll_offset < 0 {
         format!(
-            " [Ctrl+j/k] scroll [Ctrl+d/u] page [Ctrl+g] bottom [Ctrl+q] close | Line {} ",
+            " [C-j/k] scroll [C-d/u] page [C-g] bottom [C-f] fullscreen [C-q] close | Line {} ",
             start_line + 1
         )
     } else {
-        " [Ctrl+j/k] scroll [Ctrl+d/u] page [Ctrl+q] close | At bottom ".to_string()
+        " [C-j/k] scroll [C-d/u] page [C-f] fullscreen [C-q] close | At bottom ".to_string()
     }
 }
 

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -291,3 +291,74 @@ default_agent = "claude"
     assert_eq!(config.agents.running, None);
     assert_eq!(config.agents.review, None);
 }
+
+#[test]
+fn test_fullscreen_on_enter_defaults_to_false() {
+    let config: GlobalConfig = toml::from_str("").unwrap();
+    assert!(!config.fullscreen_on_enter);
+}
+
+#[test]
+fn test_fullscreen_on_enter_set_true() {
+    let toml_str = r#"
+fullscreen_on_enter = true
+"#;
+    let config: GlobalConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.fullscreen_on_enter);
+}
+
+#[test]
+fn test_fullscreen_on_enter_merged() {
+    let mut global = GlobalConfig::default();
+    global.fullscreen_on_enter = true;
+    let config = MergedConfig::merge(&global, &ProjectConfig::default());
+    assert!(config.fullscreen_on_enter);
+}
+
+#[test]
+fn test_fullscreen_on_enter_from_real_config() {
+    let toml_str = r##"
+default_agent = "claude"
+fullscreen_on_enter = true
+
+[worktree]
+enabled = true
+
+[theme]
+color_selected = "#ead49a"
+"##;
+    let config: GlobalConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.fullscreen_on_enter);
+    assert_eq!(config.default_agent, "claude");
+}
+
+#[test]
+fn test_fullscreen_on_enter_exact_user_config() {
+    let toml_str = r##"
+default_agent = "claude"
+fullscreen_on_enter = true
+
+[agents]
+
+[worktree]
+enabled = true
+auto_cleanup = true
+base_branch = ""
+worktree_dir = ".worktrees"
+
+[theme]
+color_selected = "#ead49a"
+color_normal = "#5cfff7"
+color_dimmed = "#9C9991"
+color_text = "#f2ece6"
+color_accent = "#5cfff7"
+color_description = "#C4B0AC"
+color_column_header = "#a0d2fa"
+color_popup_border = "#9ffcf8"
+color_popup_header = "#69fae7"
+"##;
+    let config: GlobalConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.fullscreen_on_enter, "fullscreen_on_enter should be true");
+    let merged = MergedConfig::merge(&config, &ProjectConfig::default());
+    assert!(merged.fullscreen_on_enter, "merged fullscreen_on_enter should be true");
+}


### PR DESCRIPTION
## Summary

- **Ctrl+f** from task popup or board view attaches directly to the task's tmux session for full native terminal interaction
- Smart context detection: switches tabs when already inside agtx tmux, suspends TUI and attaches otherwise
- **`fullscreen_on_enter`** config option: when `true`, Enter goes directly to fullscreen instead of the in-TUI popup
- Footer hints for `[C-f]` hidden when `fullscreen_on_enter` is enabled

## Details

Three attach paths based on context:
1. **Inside agtx tmux** - `select-window` to switch tabs (no nesting)
2. **Inside a different tmux** - suspend TUI, attach with `$TMUX` unset, restore on detach
3. **Bare terminal** - suspend TUI, attach, restore on detach

## Config

```toml
# ~/.config/agtx/config.toml
fullscreen_on_enter = false  # default; set true to make Enter = fullscreen
```

## Test plan

- [x] Ctrl+f from popup opens fullscreen tmux session
- [x] Ctrl+f from board view opens fullscreen tmux session
- [x] Inside agtx tmux: Ctrl+f switches tabs
- [x] Outside tmux: Ctrl+f suspends TUI, attaches, Ctrl+b d returns to TUI
- [ ] Inside different tmux: same as outside, no nesting error
- [ ] `fullscreen_on_enter = true`: Enter goes to fullscreen
- [ ] `fullscreen_on_enter = true`: `[C-f]` hint hidden in board footer
- [ ] `fullscreen_on_enter = false`: `[C-f]` hint visible