### PR TITLE
feat: dependency enforcement and stacked PR support

### DIFF
--- a/.agtx/execute.md
+++ b/.agtx/execute.md
@@ -1,0 +1,42 @@
+# Execution Summary: Dependency Enforcement & Stacked PRs
+
+## Changes
+
+### `src/db/schema.rs`
+- Added `deps_satisfied(&self, task: &Task) -> bool` method on `Database`. Resolves `referenced_tasks` comma-separated IDs, returns `true` only if all referenced tasks are in Review or Done (or if no deps exist). Missing refs treated as satisfied.
+
+### `src/mcp/server.rs`
+- Added `deps_satisfied: bool` field to both `TaskDetail` and `TaskSummary` structs.
+- Added `BlockingTask` struct (`id`, `title`, `status`) and `blocking_tasks: Vec<BlockingTask>` to `TaskDetail` — lists deps not yet in Review/Done.
+- Added `escalation_note: Option<String>` to `TaskDetail`.
+- Added `referenced_tasks`, `base_branch` to both `TaskDetail` and `TaskSummary`.
+- Changed `allowed_actions()` to accept `deps_satisfied: bool` parameter. When false and task is in Backlog, filters out `move_forward`, `move_to_planning`, `move_to_running`.
+- Updated `get_task` handler to compute `deps_satisfied`, `blocking_tasks`, and pass them to `TaskDetail` and `allowed_actions()`.
+- Updated `list_tasks` handler to compute and include `deps_satisfied` per task.
+- Added eager dep validation in `move_task` handler — rejects `move_forward`, `move_to_planning`, `move_to_running`, `research` for Backlog tasks with unsatisfied deps before queuing the transition.
+
+### `src/tui/app.rs`
+- **`move_task_right()`**: Added dep check before Backlog transitions — shows warning message and returns early if deps unsatisfied.
+- **`move_backlog_to_running_by_id()`**: Same dep check added.
+- **`execute_transition_request()`**: Added dep check for orchestrator forward transitions (`move_forward`, `move_to_planning`, `move_to_running`, `research`) — bails with error when deps unsatisfied.
+- **`AppState`**: Added `deps_satisfied_cache: HashMap<String, bool>` field.
+- **`refresh_tasks()`**: Populates deps cache for all tasks with `referenced_tasks`.
+- **`draw_task_card()`**: Added `deps_blocked` parameter. Shows `⊘` indicator in dimmed style for blocked tasks in Backlog.
+- **`create_pr_with_content()`**: Passes `task.base_branch.clone()` to `create_pr()`.
+
+### `src/git/provider.rs`
+- Extended `GitProviderOperations::create_pr()` trait with `base_branch: Option<String>` parameter.
+- Updated `RealGitHubOps::create_pr()` to add `--base <branch>` args when `base_branch` is Some.
+
+### `src/tui/app_tests.rs`
+- Updated 3 mock `expect_create_pr()` expectations to include the new 5th `base_branch` parameter.
+
+### `tests/db_tests.rs`
+- Added 5 tests: `test_deps_satisfied_no_refs`, `test_deps_satisfied_all_review_or_done`, `test_deps_not_satisfied_dep_in_backlog`, `test_deps_satisfied_missing_ref_treated_as_ok`, `test_deps_not_satisfied_dep_in_planning`.
+
+## Testing
+
+- `cargo build` — compiles cleanly (warnings are pre-existing, unrelated)
+- `cargo test --features test-mocks` — **607 tests pass**, 0 failures
+  - 5 new dependency satisfaction tests in db_tests
+  - 3 existing PR creation tests updated for new signature

--- a/.agtx/review.md
+++ b/.agtx/review.md
@@ -1,0 +1,28 @@
+# Review
+
+## Findings
+
+### Fixed during review
+
+1. **Lock icon width**: Changed from `🔒` (U+1F512, wide emoji that takes 2 cells in most terminals) to `⊘` (U+2298, narrow unicode symbol) — consistent with existing indicators (`✓`, `✗`, `⏸`, `⚠`) which are all single-width.
+
+2. **Dep filter scope in `allowed_actions()`**: The initial implementation filtered `move_forward` from *all* statuses when deps were unsatisfied. This would incorrectly block Planning→Running and Running→Review transitions for tasks that already started. Fixed to only filter when `task.status == TaskStatus::Backlog`. The TUI-side checks were already correctly scoped to Backlog.
+
+### What looks good
+
+- **`deps_satisfied()` helper**: Clean, handles empty refs and missing tasks gracefully. Missing refs default to satisfied (deleted tasks shouldn't block).
+- **Four enforcement points**: TUI (`move_task_right`, `move_backlog_to_running_by_id`), orchestrator (`execute_transition_request`), MCP (`allowed_actions`), and MCP eager validation (`move_task` handler). Complete coverage.
+- **Warning message**: Uses existing `warning_message` pattern with auto-clear — no new UI state needed.
+- **Deps cache**: Refreshed only on `refresh_tasks()`, avoids DB queries per render frame.
+- **`base_branch` for stacked PRs**: Clean trait extension with `Option<String>` (avoids mockall lifetime issues with `Option<&str>`). The `--base` flag is only added when `base_branch` is Some.
+- **MCP/TUI parity**: Full parity achieved — `deps_satisfied` in both `list_tasks` and `get_task`, `blocking_tasks` array with blocker details in `get_task`, `escalation_note` exposed, `research` action dep-gated on both sides, eager dep validation in `move_task` handler.
+- **Tests**: 5 new dep satisfaction tests covering all cases (no refs, all satisfied, partial block, missing ref, planning block). 607 total tests pass.
+
+### Concerns (acceptable)
+
+- **Circular deps**: Two tasks referencing each other will both be permanently blocked. Not worth adding cycle detection — this is a user error and easily visible on the board.
+- **`_plugin` variable**: Renamed from `plugin` to suppress unused warning in `allowed_actions()`. The plugin loading was pre-existing dead code in this method — left as-is since removing it is out of scope.
+
+## Status
+
+READY

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -369,6 +369,21 @@ impl Database {
         Ok(tasks)
     }
 
+    /// Check whether all referenced_tasks (dependencies) are in Review or Done.
+    /// Returns true if the task has no dependencies or all deps are satisfied.
+    pub fn deps_satisfied(&self, task: &Task) -> bool {
+        let refs_str = match &task.referenced_tasks {
+            Some(s) if !s.is_empty() => s,
+            _ => return true,
+        };
+        refs_str.split(',').filter(|s| !s.is_empty()).all(|ref_id| {
+            self.get_task(ref_id)
+                .ok()
+                .flatten()
+                .map_or(true, |t| matches!(t.status, TaskStatus::Review | TaskStatus::Done))
+        })
+    }
+
     // === Project Operations (for global db) ===
 
     pub fn upsert_project(&self, project: &Project) -> Result<()> {

--- a/src/git/provider.rs
+++ b/src/git/provider.rs
@@ -26,12 +26,14 @@ pub trait GitProviderOperations: Send + Sync {
 
     /// Create a pull/merge request
     /// Returns (pr_number, pr_url)
+    /// If `base_branch` is Some, uses `--base` to target that branch (for stacked PRs).
     fn create_pr(
         &self,
         project_path: &Path,
         title: &str,
         body: &str,
         head_branch: &str,
+        base_branch: Option<String>,
     ) -> Result<(i32, String)>;
 }
 
@@ -67,19 +69,25 @@ impl GitProviderOperations for RealGitHubOps {
         title: &str,
         body: &str,
         head_branch: &str,
+        base_branch: Option<String>,
     ) -> Result<(i32, String)> {
+        let mut args = vec![
+            "pr",
+            "create",
+            "--title",
+            title,
+            "--body",
+            body,
+            "--head",
+            head_branch,
+        ];
+        if let Some(ref base) = base_branch {
+            args.push("--base");
+            args.push(base);
+        }
         let output = std::process::Command::new("gh")
             .current_dir(project_path)
-            .args([
-                "pr",
-                "create",
-                "--title",
-                title,
-                "--body",
-                body,
-                "--head",
-                head_branch,
-            ])
+            .args(&args)
             .output()?;
 
         if !output.status.success() {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -208,6 +208,8 @@ struct TaskDetail {
     cycle: i32,
     created_at: String,
     updated_at: String,
+    /// Whether all referenced_tasks (dependencies) are in Review or Done.
+    deps_satisfied: bool,
     /// Actions the orchestrator can take on this task given its current status and plugin rules.
     allowed_actions: Vec<String>,
 }
@@ -347,10 +349,10 @@ impl AgtxMcpServer {
     }
 
     /// Compute which move_task actions are valid for a task given its status and plugin rules.
-    fn allowed_actions(&self, task: &Task) -> Vec<String> {
+    fn allowed_actions(&self, task: &Task, deps_satisfied: bool) -> Vec<String> {
         let mut actions = Vec::new();
 
-        let plugin = match &task.plugin {
+        let _plugin = match &task.plugin {
             Some(name) => crate::config::WorkflowPlugin::load(name, Some(&self.project_path))
                 .ok()
                 .or_else(|| crate::skills::load_bundled_plugin(name)),
@@ -374,6 +376,16 @@ impl AgtxMcpServer {
                 actions.push("resume".to_string());
             }
             TaskStatus::Done => {}
+        }
+
+        // Block forward transitions out of Backlog when dependencies are not satisfied
+        if !deps_satisfied && task.status == TaskStatus::Backlog {
+            actions.retain(|a| {
+                !matches!(
+                    a.as_str(),
+                    "move_forward" | "move_to_planning" | "move_to_running"
+                )
+            });
         }
 
         actions
@@ -450,7 +462,8 @@ impl AgtxMcpServer {
         match self.open_project_db() {
             Ok(db) => match db.get_task(&params.task_id) {
                 Ok(Some(t)) => {
-                    let allowed = self.allowed_actions(&t);
+                    let deps_ok = db.deps_satisfied(&t);
+                    let allowed = self.allowed_actions(&t, deps_ok);
                     let detail = TaskDetail {
                         id: t.id,
                         title: t.title,
@@ -467,6 +480,7 @@ impl AgtxMcpServer {
                         cycle: t.cycle,
                         created_at: t.created_at.to_rfc3339(),
                         updated_at: t.updated_at.to_rfc3339(),
+                        deps_satisfied: deps_ok,
                         allowed_actions: allowed,
                     };
                     serde_json::to_string_pretty(&detail)

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -189,6 +189,8 @@ struct TaskSummary {
     branch_name: Option<String>,
     pr_url: Option<String>,
     plugin: Option<String>,
+    referenced_tasks: Option<String>,
+    base_branch: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -206,6 +208,8 @@ struct TaskDetail {
     pr_url: Option<String>,
     plugin: Option<String>,
     cycle: i32,
+    referenced_tasks: Option<String>,
+    base_branch: Option<String>,
     created_at: String,
     updated_at: String,
     /// Whether all referenced_tasks (dependencies) are in Review or Done.
@@ -443,6 +447,8 @@ impl AgtxMcpServer {
                                 branch_name: t.branch_name,
                                 pr_url: t.pr_url,
                                 plugin: t.plugin,
+                                referenced_tasks: t.referenced_tasks,
+                                base_branch: t.base_branch,
                             })
                             .collect();
                         serde_json::to_string_pretty(&summaries)
@@ -478,6 +484,8 @@ impl AgtxMcpServer {
                         pr_url: t.pr_url,
                         plugin: t.plugin,
                         cycle: t.cycle,
+                        referenced_tasks: t.referenced_tasks,
+                        base_branch: t.base_branch,
                         created_at: t.created_at.to_rfc3339(),
                         updated_at: t.updated_at.to_rfc3339(),
                         deps_satisfied: deps_ok,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -191,6 +191,7 @@ struct TaskSummary {
     plugin: Option<String>,
     referenced_tasks: Option<String>,
     base_branch: Option<String>,
+    deps_satisfied: bool,
 }
 
 #[derive(Serialize)]
@@ -210,12 +211,22 @@ struct TaskDetail {
     cycle: i32,
     referenced_tasks: Option<String>,
     base_branch: Option<String>,
+    escalation_note: Option<String>,
     created_at: String,
     updated_at: String,
     /// Whether all referenced_tasks (dependencies) are in Review or Done.
     deps_satisfied: bool,
+    /// Dependencies that are not yet in Review or Done status.
+    blocking_tasks: Vec<BlockingTask>,
     /// Actions the orchestrator can take on this task given its current status and plugin rules.
     allowed_actions: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct BlockingTask {
+    id: String,
+    title: String,
+    status: String,
 }
 
 #[derive(Serialize)]
@@ -438,17 +449,21 @@ impl AgtxMcpServer {
                     Ok(tasks) => {
                         let summaries: Vec<TaskSummary> = tasks
                             .into_iter()
-                            .map(|t| TaskSummary {
-                                id: t.id,
-                                title: t.title,
-                                description: t.description,
-                                status: t.status.as_str().to_string(),
-                                agent: t.agent,
-                                branch_name: t.branch_name,
-                                pr_url: t.pr_url,
-                                plugin: t.plugin,
-                                referenced_tasks: t.referenced_tasks,
-                                base_branch: t.base_branch,
+                            .map(|t| {
+                                let deps_satisfied = db.deps_satisfied(&t);
+                                TaskSummary {
+                                    id: t.id,
+                                    title: t.title,
+                                    description: t.description,
+                                    status: t.status.as_str().to_string(),
+                                    agent: t.agent,
+                                    branch_name: t.branch_name,
+                                    pr_url: t.pr_url,
+                                    plugin: t.plugin,
+                                    referenced_tasks: t.referenced_tasks,
+                                    base_branch: t.base_branch,
+                                    deps_satisfied,
+                                }
                             })
                             .collect();
                         serde_json::to_string_pretty(&summaries)
@@ -470,6 +485,29 @@ impl AgtxMcpServer {
                 Ok(Some(t)) => {
                     let deps_ok = db.deps_satisfied(&t);
                     let allowed = self.allowed_actions(&t, deps_ok);
+                    let blocking = match &t.referenced_tasks {
+                        Some(refs) if !refs.is_empty() => refs
+                            .split(',')
+                            .filter(|s| !s.is_empty())
+                            .filter_map(|ref_id| {
+                                db.get_task(ref_id)
+                                    .ok()
+                                    .flatten()
+                                    .filter(|dep| {
+                                        !matches!(
+                                            dep.status,
+                                            TaskStatus::Review | TaskStatus::Done
+                                        )
+                                    })
+                                    .map(|dep| BlockingTask {
+                                        id: dep.id,
+                                        title: dep.title,
+                                        status: dep.status.as_str().to_string(),
+                                    })
+                            })
+                            .collect(),
+                        _ => Vec::new(),
+                    };
                     let detail = TaskDetail {
                         id: t.id,
                         title: t.title,
@@ -486,9 +524,11 @@ impl AgtxMcpServer {
                         cycle: t.cycle,
                         referenced_tasks: t.referenced_tasks,
                         base_branch: t.base_branch,
+                        escalation_note: t.escalation_note,
                         created_at: t.created_at.to_rfc3339(),
                         updated_at: t.updated_at.to_rfc3339(),
                         deps_satisfied: deps_ok,
+                        blocking_tasks: blocking,
                         allowed_actions: allowed,
                     };
                     serde_json::to_string_pretty(&detail)
@@ -526,10 +566,24 @@ impl AgtxMcpServer {
         match self.open_project_db() {
             Ok(db) => {
                 // Verify task exists
-                match db.get_task(&params.task_id) {
-                    Ok(Some(_)) => {}
+                let task = match db.get_task(&params.task_id) {
+                    Ok(Some(t)) => t,
                     Ok(None) => return format!("Task not found: {}", params.task_id),
                     Err(e) => return format!("Error checking task: {}", e),
+                };
+
+                // Eagerly check dependency gates for forward transitions from Backlog
+                let forward_actions = [
+                    "move_forward",
+                    "move_to_planning",
+                    "move_to_running",
+                    "research",
+                ];
+                if forward_actions.contains(&params.action.as_str())
+                    && task.status == TaskStatus::Backlog
+                    && !db.deps_satisfied(&task)
+                {
+                    return "Cannot advance task: dependencies not in Review/Done. Use get_task to see blocking_tasks.".to_string();
                 }
 
                 let mut req = TransitionRequest::new(&params.task_id, &params.action);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5268,7 +5268,7 @@ impl App {
         // Block forward transitions when dependencies are not satisfied
         let is_forward = matches!(
             req.action.as_str(),
-            "move_forward" | "move_to_planning" | "move_to_running"
+            "move_forward" | "move_to_planning" | "move_to_running" | "research"
         );
         if is_forward && task.status == TaskStatus::Backlog && !db.deps_satisfied(&task) {
             anyhow::bail!(

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4706,6 +4706,14 @@ impl App {
             let Some(task) = db.get_task(task_id)? else {
                 return Ok(());
             };
+            // Block research when dependencies are not satisfied
+            if task.status == TaskStatus::Backlog && !db.deps_satisfied(&task) {
+                self.state.warning_message = Some((
+                    "Dependencies not in Review/Done — cannot start task".to_string(),
+                    Instant::now(),
+                ));
+                return Ok(());
+            }
             task
         };
         let Some(project_path) = self.state.project_path.clone() else {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -311,6 +311,8 @@ struct AppState {
     orchestrator_last_check: Instant,
     // Background session refresh channel (non-blocking phase status polling)
     session_refresh_rx: Option<mpsc::Receiver<SessionRefreshResult>>,
+    // Cache of dependency satisfaction per task ID (refreshed with tasks)
+    deps_satisfied_cache: HashMap<String, bool>,
 }
 
 /// State for confirming move to Done
@@ -631,6 +633,7 @@ impl App {
                 orchestrator_stable_since: None,
                 orchestrator_last_check: Instant::now(),
                 session_refresh_rx: None,
+                deps_satisfied_cache: HashMap::new(),
             },
         };
 
@@ -842,6 +845,7 @@ impl App {
                 orchestrator_stable_since: None,
                 orchestrator_last_check: Instant::now(),
                 session_refresh_rx: None,
+                deps_satisfied_cache: HashMap::new(),
             },
         })
     }
@@ -1151,6 +1155,10 @@ impl App {
                     break;
                 }
 
+                let deps_blocked = state
+                    .deps_satisfied_cache
+                    .get(&task.id)
+                    .map_or(false, |satisfied| !satisfied);
                 Self::draw_task_card(
                     frame,
                     task,
@@ -1159,6 +1167,7 @@ impl App {
                     &state.config.theme,
                     state.phase_status_cache.get(&task.id),
                     state.spinner_frame,
+                    deps_blocked,
                 );
             }
 
@@ -2117,6 +2126,7 @@ impl App {
         theme: &ThemeConfig,
         phase_status: Option<&(PhaseStatus, Instant)>,
         spinner_frame: usize,
+        deps_blocked: bool,
     ) {
         let border_style = if is_selected {
             Style::default().fg(hex_to_color(&theme.color_selected))
@@ -2200,6 +2210,21 @@ impl App {
             };
             let title_spans =
                 Line::from(vec![indicator, warn_span, Span::styled(title, title_style)]);
+            let title_line = Paragraph::new(title_spans);
+            let title_area = Rect {
+                x: inner.x,
+                y: inner.y,
+                width: inner.width,
+                height: 1,
+            };
+            frame.render_widget(title_line, title_area);
+        } else if deps_blocked {
+            let lock_span = Span::styled(
+                "\u{2298} ",
+                Style::default()
+                    .fg(hex_to_color(&theme.color_dimmed)),
+            );
+            let title_spans = Line::from(vec![lock_span, Span::styled(title, title_style)]);
             let title_line = Paragraph::new(title_spans);
             let title_area = Rect {
                 x: inner.x,
@@ -4180,6 +4205,17 @@ impl App {
         };
 
         if let Some(new_status) = next_status {
+            // Block moving out of Backlog when dependencies are not satisfied
+            if current_status == TaskStatus::Backlog {
+                if let Some(db) = &self.state.db {
+                    if !db.deps_satisfied(&task) {
+                        self.state.warning_message =
+                            Some(("Dependencies not in Review/Done — cannot start task".to_string(), Instant::now()));
+                        return Ok(());
+                    }
+                }
+            }
+
             if self.check_phase_incomplete(&task, current_status, new_status) {
                 return Ok(());
             }
@@ -4863,6 +4899,15 @@ impl App {
             );
         }
 
+        // Block when dependencies are not satisfied
+        if let Some(db) = &self.state.db {
+            if !db.deps_satisfied(&task) {
+                self.state.warning_message =
+                    Some(("Dependencies not in Review/Done — cannot start task".to_string(), Instant::now()));
+                return Ok(());
+            }
+        }
+
         // Stamp plugin on task before checking research requirement
         if task.plugin.is_none() {
             task.plugin = self.state.config.workflow_plugin.clone();
@@ -5219,6 +5264,17 @@ impl App {
         let mut task = db
             .get_task(&req.task_id)?
             .ok_or_else(|| anyhow::anyhow!("Task not found: {}", req.task_id))?;
+
+        // Block forward transitions when dependencies are not satisfied
+        let is_forward = matches!(
+            req.action.as_str(),
+            "move_forward" | "move_to_planning" | "move_to_running"
+        );
+        if is_forward && task.status == TaskStatus::Backlog && !db.deps_satisfied(&task) {
+            anyhow::bail!(
+                "Cannot advance task: dependencies not in Review/Done"
+            );
+        }
 
         match req.action.as_str() {
             "research" => {
@@ -5662,6 +5718,15 @@ impl App {
     pub fn refresh_tasks(&mut self) -> Result<()> {
         if let Some(db) = &self.state.db {
             self.state.board.tasks = db.get_all_tasks()?;
+            // Refresh dependency satisfaction cache for backlog tasks with references
+            self.state.deps_satisfied_cache.clear();
+            for task in &self.state.board.tasks {
+                if task.referenced_tasks.is_some() {
+                    self.state
+                        .deps_satisfied_cache
+                        .insert(task.id.clone(), db.deps_satisfied(task));
+                }
+            }
         }
         Ok(())
     }
@@ -6863,12 +6928,13 @@ fn create_pr_with_content(
         git_ops.push(worktree_path, branch, true)?;
     }
 
-    // Create PR
+    // Create PR (use base_branch for stacked PRs)
     git_provider_ops.create_pr(
         project_path,
         pr_title,
         pr_body,
         task.branch_name.as_deref().unwrap_or(""),
+        task.base_branch.clone(),
     )
 }
 

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -255,14 +255,15 @@ fn test_create_pr_with_content_success() {
     // Expect: create PR
     mock_git_provider
         .expect_create_pr()
-        .withf(|path: &Path, title: &str, body: &str, branch: &str| {
+        .withf(|path: &Path, title: &str, body: &str, branch: &str, base: &Option<String>| {
             path == Path::new("/project")
                 && title == "Test PR"
                 && body == "Test body"
                 && branch == "feature/test"
+                && base.is_none()
         })
         .times(1)
-        .returning(|_, _, _, _| Ok((42, "https://github.com/org/repo/pull/42".to_string())));
+        .returning(|_, _, _, _, _| Ok((42, "https://github.com/org/repo/pull/42".to_string())));
 
     let result = create_pr_with_content(
         &task,
@@ -320,7 +321,7 @@ fn test_create_pr_with_content_no_changes() {
 
     mock_git_provider
         .expect_create_pr()
-        .returning(|_, _, _, _| Ok((1, "https://github.com/pr/1".to_string())));
+        .returning(|_, _, _, _, _| Ok((1, "https://github.com/pr/1".to_string())));
 
     let result = create_pr_with_content(
         &task,
@@ -5682,7 +5683,7 @@ fn test_handle_pr_confirm_ctrl_s_submits_pr() {
     let mut mock_git_provider = MockGitProviderOperations::new();
     mock_git_provider
         .expect_create_pr()
-        .returning(|_, _, _, _| Ok((1, "https://github.com/pr/1".to_string())));
+        .returning(|_, _, _, _, _| Ok((1, "https://github.com/pr/1".to_string())));
 
     let mut mock_registry = MockAgentRegistry::new();
     let mut mock_agent_ops = MockAgentOperations::new();

--- a/tests/db_tests.rs
+++ b/tests/db_tests.rs
@@ -232,3 +232,77 @@ fn test_notifications_empty_queue() {
     let notifs = db.consume_notifications().unwrap();
     assert_eq!(notifs.len(), 0);
 }
+
+// === Dependency Satisfaction Tests ===
+
+#[test]
+fn test_deps_satisfied_no_refs() {
+    let db = Database::open_in_memory_project().unwrap();
+    let task = Task::new("No deps", "claude", "proj");
+    db.create_task(&task).unwrap();
+    assert!(db.deps_satisfied(&task));
+}
+
+#[test]
+fn test_deps_satisfied_all_review_or_done() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let mut dep1 = Task::new("Dep 1", "claude", "proj");
+    dep1.status = TaskStatus::Review;
+    db.create_task(&dep1).unwrap();
+
+    let mut dep2 = Task::new("Dep 2", "claude", "proj");
+    dep2.status = TaskStatus::Done;
+    db.create_task(&dep2).unwrap();
+
+    let mut task = Task::new("Main task", "claude", "proj");
+    task.referenced_tasks = Some(format!("{},{}", dep1.id, dep2.id));
+    db.create_task(&task).unwrap();
+
+    assert!(db.deps_satisfied(&task));
+}
+
+#[test]
+fn test_deps_not_satisfied_dep_in_backlog() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let dep1 = Task::new("Dep in backlog", "claude", "proj");
+    db.create_task(&dep1).unwrap();
+
+    let mut dep2 = Task::new("Dep done", "claude", "proj");
+    dep2.status = TaskStatus::Done;
+    db.create_task(&dep2).unwrap();
+
+    let mut task = Task::new("Blocked task", "claude", "proj");
+    task.referenced_tasks = Some(format!("{},{}", dep1.id, dep2.id));
+    db.create_task(&task).unwrap();
+
+    assert!(!db.deps_satisfied(&task));
+}
+
+#[test]
+fn test_deps_satisfied_missing_ref_treated_as_ok() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let mut task = Task::new("Task with missing ref", "claude", "proj");
+    task.referenced_tasks = Some("nonexistent-id".to_string());
+    db.create_task(&task).unwrap();
+
+    // Missing refs are treated as satisfied (task may have been deleted)
+    assert!(db.deps_satisfied(&task));
+}
+
+#[test]
+fn test_deps_not_satisfied_dep_in_planning() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let mut dep = Task::new("Dep in planning", "claude", "proj");
+    dep.status = TaskStatus::Planning;
+    db.create_task(&dep).unwrap();
+
+    let mut task = Task::new("Blocked task", "claude", "proj");
+    task.referenced_tasks = Some(dep.id.clone());
+    db.create_task(&task).unwrap();
+
+    assert!(!db.deps_satisfied(&task));
+}


### PR DESCRIPTION
## Summary

- **Dependency gates**: Tasks with `referenced_tasks` not in Review/Done are blocked from advancing out of Backlog. Enforced at 5 points: TUI (`move_task_right`, `move_backlog_to_running_by_id`, `start_research`), orchestrator (`execute_transition_request`), and MCP (`move_task` eager validation).
- **Stacked PR support**: `base_branch` passed to `gh pr create --base` so PRs from dependent tasks target their parent branch instead of main.
- **MCP parity**: `deps_satisfied`, `blocking_tasks`, `referenced_tasks`, `base_branch`, and `escalation_note` exposed in `get_task`/`list_tasks` responses.
- **TUI indicator**: Blocked Backlog tasks show `⊘` icon in dimmed style.

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test --features test-mocks` — 607 tests pass
- [x] 5 new `deps_satisfied` tests covering: no refs, all satisfied, partial block, missing ref, planning block
- [x] 3 existing PR creation tests updated for new `base_branch` parameter