### PR TITLE
feat: add agtx Claude Code plugin and planner skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "agtx-marketplace",
+  "description": "Marketplace for agtx plugins",
+  "owner": {
+    "name": "fynnfluegge"
+  },
+  "plugins": [
+    {
+      "name": "agtx",
+      "description": "Manage and decompose work into feature-level tasks on the agtx kanban board",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "agtx",
+  "description": "Manage and decompose work into feature-level tasks on the agtx kanban board",
+  "version": "0.1.0",
+  "author": {
+    "name": "fynnfluegge"
+  },
+  "repository": "https://github.com/fynnfluegge/agtx",
+  "license": "MIT",
+  "keywords": [
+    "kanban",
+    "agents",
+    "worktrees",
+    "tasks",
+    "orchestration"
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,9 +3,9 @@
   "description": "Manage and decompose work into feature-level tasks on the agtx kanban board",
   "version": "0.1.0",
   "author": {
-    "name": "fynnfluegge"
+    "name": "fynnfluegge",
+    "url": "https://github.com/fynnfluegge/agtx"
   },
-  "repository": "https://github.com/fynnfluegge/agtx",
   "license": "MIT",
   "keywords": [
     "kanban",
@@ -13,5 +13,12 @@
     "worktrees",
     "tasks",
     "orchestration"
-  ]
+  ],
+  "mcpServers": {
+    "agtx": {
+      "type": "stdio",
+      "command": "agtx",
+      "args": ["mcp-serve", "."]
+    }
+  }
 }

--- a/skills/agtx/SKILL.md
+++ b/skills/agtx/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: agtx
+description: "Use when planning features, decomposing work into tasks, creating or managing tasks on a kanban board, or coordinating parallel coding agent sessions across git worktrees. Also use when asked about agtx setup, MCP configuration, or task workflow."
+---
+
+# agtx — Terminal Kanban for Coding Agents
+
+agtx is a kanban board that manages parallel coding agent sessions (Claude Code, Codex, Gemini, Copilot, OpenCode). Each task gets its own git worktree, branch, tmux window, and agent session — producing one reviewable PR per task.
+
+**You are an orchestrator.** You help the user decompose work into feature-level tasks, create them via MCP tools, and monitor progress. The user can enter any task's agent session via tmux to course-correct.
+
+## How It Works
+
+```
+You (orchestrator session, project root)
+├── create_tasks_batch → Task A (worktree, branch, agent session) → PR
+├── create_tasks_batch → Task B (worktree, branch, agent session) → PR
+└── create_tasks_batch → Task C (depends on A) → blocked until A in Review
+```
+
+**Tasks are like subagents, but with superpowers:**
+- Each runs in its own worktree with full git isolation
+- Each has a visible tmux session the user can enter anytime
+- Each persists across TUI restarts (tmux survives)
+- Each produces a reviewable, mergeable PR
+- Each can be a different agent (Claude, Codex, Gemini, etc.)
+
+The task agent handles its own internal planning — it can use `/plan`, spawn subagents, or use any workflow. You don't micromanage implementation details.
+
+## Task Lifecycle
+
+```
+Backlog → Planning → Running → Review → Done
+```
+
+| Phase | What happens |
+|-------|-------------|
+| **Backlog** | Created by you via MCP. Sits on the board until user is ready. |
+| **Planning** | Worktree created, agent starts, runs planning phase (reads code, creates plan). |
+| **Running** | Agent implements the feature. May use subagents internally. |
+| **Review** | PR created. User reviews. Can resume to address feedback. |
+| **Done** | Merged. Worktree cleaned up, branch kept. |
+
+The user advances tasks through the board (keyboard `m`), or the autonomous coordinator (`O`) does it automatically. You create and organize tasks — the board handles execution.
+
+## Decomposition Strategy
+
+When asked to plan or break down work:
+
+1. **Think in PRs** — each task = one reviewable, independently mergeable PR
+2. **Use dependencies** — if task B needs task A's code, wire it via `depends_on`
+3. **Keep tasks atomic** — "Add OAuth + rate limiting + caching" = 3 tasks, not 1
+4. **Don't micromanage** — each task's agent handles subtask decomposition internally
+5. **Group only if must ship together** — otherwise, separate PRs
+
+**Ask strategic questions** ("should auth come before the DB migration?"), not tactical ones ("should we use a factory pattern?"). The task agent handles tactical decisions.
+
+## MCP Tools
+
+You have access to these tools via the agtx MCP server. Tool parameters are self-documented — call any tool to see its schema.
+
+| Tool | Purpose |
+|------|---------|
+| `list_tasks` | List all tasks, optionally filter by status |
+| `get_task` | Get task details + `allowed_actions` |
+| `create_task` | Create a single backlog task |
+| `create_tasks_batch` | Batch create with index-based dependencies |
+| `update_task` | Modify backlog task (title, description, deps) |
+| `delete_task` | Delete backlog task |
+| `move_task` | Advance task (move_forward, escalate_to_user) |
+| `read_pane_content` | Read agent's tmux output (last N lines) |
+| `send_to_task` | Send message to agent's tmux pane |
+| `check_conflicts` | Check merge conflicts for Review tasks |
+
+### Batch Creation Example
+
+```json
+create_tasks_batch({
+  "tasks": [
+    { "title": "Add users table migration", "description": "Create users table with email, password_hash, created_at" },
+    { "title": "Add user API endpoints", "description": "CRUD endpoints for /api/users", "depends_on": [0] },
+    { "title": "Add auth middleware", "description": "JWT-based auth middleware", "depends_on": [0] },
+    { "title": "Add integration tests", "description": "Test auth flow end-to-end", "depends_on": [1, 2] }
+  ]
+})
+```
+
+Tasks 1 and 2 run in parallel (both depend on 0). Task 3 waits for both.
+
+## Setup Verification
+
+Before creating tasks, verify the MCP connection:
+
+1. Call `list_tasks` — if it works, you're connected
+2. If it fails, the user needs to install agtx and register the MCP server:
+   ```bash
+   claude mcp add agtx -- agtx serve
+   ```
+   See the [agtx README](https://github.com/fynnfluegge/agtx) for full installation instructions.
+
+## Rules
+
+- Only create tasks at the **feature/PR level** — not subtask level
+- Check `list_tasks` before creating to avoid duplicates
+- Always check `allowed_actions` via `get_task` before calling `move_task`
+- Include clear descriptions with enough context for the task agent to work independently
+- Reference relevant files, code paths, or architectural decisions in descriptions
+- Blocked tasks (unresolved dependencies) cannot be advanced — respect this


### PR DESCRIPTION
## Summary

Adds a Claude Code plugin and skill that turns any Claude Code session into an orchestrator for the agtx kanban board.

Complementary to #75 (sweep): while sweep harvests TODOs from a conversation, this skill actively decomposes features into PR-level tasks with dependencies. See [discussion on #75](https://github.com/fynnfluegge/agtx/pull/75#issuecomment-4238889369) — I believe these can be unified into a single skill with two modes.

### Files

- `skills/agtx/SKILL.md` — Planner/orchestrator skill. Explains the agtx workflow, decomposition strategy (think in PRs, use dependencies, don't micromanage subtasks), and guides task creation via MCP tools.
- `.claude-plugin/plugin.json` — Plugin metadata with inline MCP server registration (no manual `claude mcp add` needed)
- `.claude-plugin/marketplace.json` — Marketplace config

### How it works

The skill positions the Claude Code session as an **orchestrator**: it helps the user decompose work into feature-level tasks, creates them via MCP (`create_tasks_batch` with index-based deps), and the agtx board handles execution. Each task = 1 worktree = 1 branch = 1 PR.

Key ideas:
- **Tasks are like subagents but with superpowers** — visible tmux sessions, git isolation, persistent across restarts, reviewable PRs
- **Feature-level decomposition only** — don't micromanage subtasks, let each task's agent handle internal planning
- **Strategic questions, not tactical** — the orchestrator asks "should auth come before DB migration?", not "use a factory pattern?"
- MCP server wired inline in plugin.json — installing the plugin also registers the MCP
- Tool reference not duplicated — tools are self-describing via schema annotations
- Install instructions point to the README

### Install

```bash
/plugin marketplace add fynnfluegge/agtx
/plugin install agtx@agtx-marketplace
```