### PR TITLE
ci: block merging PRs that contain .agtx/*.md artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,23 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check-no-agtx-artifacts:
+    name: No .agtx artifacts in PR
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if .agtx/*.md files are tracked
+        run: |
+          files=$(git ls-files '.agtx/*.md')
+          if [ -n "$files" ]; then
+            while IFS= read -r f; do
+              echo "::error file=$f,title=agtx artifact must not be merged::Remove $f before merging (agtx agent artifact)"
+            done <<< "$files"
+            exit 1
+          fi
+          echo "OK: No .agtx/*.md files found"
+
   build:
     name: Build and Test
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

- Adds a new `check-no-agtx-artifacts` CI job to `.github/workflows/ci.yml`
- Uses `git ls-files '.agtx/*.md'` to detect any tracked agtx phase artifact files (research.md, plan.md, execute.md, review.md) in the PR branch
- Uses GitHub error annotations (`::error file=...`) to flag each offending file inline in the PR diff
- Runs only on `pull_request` events — skipped on push to main

## Test plan

- [ ] Open a PR that adds a `.agtx/*.md` file — check should fail with inline file annotations
- [ ] Open a clean PR — check should pass with `OK: No .agtx/*.md files found`
- [ ] Add `check-no-agtx-artifacts` to required status checks in branch protection settings to actually block merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)