### PR TITLE
fix: research running phase transition

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4325,10 +4325,7 @@ impl App {
         let (planning_agent, agent_switch) =
             needs_agent_switch(&self.state.config, task, "planning");
 
-        let has_live_session = task.session_name.as_ref().map_or(false, |s| {
-            self.state.tmux_ops.window_exists(s).unwrap_or(false)
-        });
-
+        let has_live_session = task_has_live_session(&task, self.state.tmux_ops.as_ref());
         if has_live_session {
             // Reuse existing session from research
             let target = task.session_name.clone().unwrap();
@@ -4956,6 +4953,43 @@ impl App {
             task.cycle,
         );
         let prompt_trigger = resolve_prompt_trigger(&plugin, "running");
+        let auto_dismiss = plugin
+            .as_ref()
+            .map_or_else(Vec::new, |p| p.auto_dismiss.clone());
+
+        // If a live session already exists (e.g. from a prior research/planning phase),
+        // reuse it instead of creating a duplicate tmux window.
+        let has_live_session = task_has_live_session(&task, self.state.tmux_ops.as_ref());
+        if has_live_session {
+            let target = task.session_name.clone().unwrap();
+            let (agent_switch_agent, agent_switch) =
+                needs_agent_switch(&self.state.config, &task, "running");
+            spawn_send_to_agent(
+                Arc::clone(&self.state.tmux_ops),
+                Arc::clone(&self.state.agent_registry),
+                target,
+                task.agent.clone(),
+                agent_switch_agent.clone(),
+                agent_switch,
+                skill_cmd,
+                prompt,
+                prompt_trigger,
+                task_content,
+                auto_dismiss,
+                task.worktree_path.clone(),
+                project_path.clone(),
+                plugin,
+            );
+            task.agent = agent_switch_agent;
+            task.status = TaskStatus::Running;
+            task.updated_at = chrono::Utc::now();
+            if let Some(db) = &self.state.db {
+                db.update_task(&task)?;
+            }
+            self.refresh_tasks()?;
+            return Ok(());
+        }
+
         let project_name = self.state.project_name.clone();
         let tmux_project_name = self.state.tmux_project_name.clone();
         let base_branch = task
@@ -4971,9 +5005,6 @@ impl App {
         let task_id = task.id.clone();
         let task_title = task.title.clone();
         let running_agent_clone = running_agent.clone();
-        let auto_dismiss = plugin
-            .as_ref()
-            .map_or_else(Vec::new, |p| p.auto_dismiss.clone());
 
         let (tx, rx) = mpsc::channel();
         self.state.setup_rx = Some(rx);
@@ -6343,6 +6374,14 @@ fn check_orchestrator_idle(
             _ => OrchestratorIdleResult::Waiting,
         }
     }
+}
+
+/// Returns true if the task already has a tmux window that is currently alive.
+/// Used to decide whether to reuse an existing session instead of creating a new one.
+fn task_has_live_session(task: &Task, tmux_ops: &dyn TmuxOperations) -> bool {
+    task.session_name
+        .as_ref()
+        .map_or(false, |s| tmux_ops.window_exists(s).unwrap_or(false))
 }
 
 fn ensure_project_tmux_session(

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -9008,3 +9008,63 @@ fn test_should_send_stuck_notification_other_plugins() {
     // No plugin set (None) should also produce notifications
     assert!(should_send_stuck_notification(None));
 }
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_task_has_live_session_returns_true_when_window_exists() {
+    let mut mock_tmux = crate::tmux::MockTmuxOperations::new();
+    mock_tmux
+        .expect_window_exists()
+        .with(mockall::predicate::eq("my-project:task-abc123"))
+        .times(1)
+        .returning(|_| Ok(true));
+
+    let mut task = crate::db::Task::new("my task", "claude", "my-project");
+    task.session_name = Some("my-project:task-abc123".to_string());
+
+    assert!(task_has_live_session(&task, &mock_tmux));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_task_has_live_session_returns_false_when_window_gone() {
+    let mut mock_tmux = crate::tmux::MockTmuxOperations::new();
+    mock_tmux
+        .expect_window_exists()
+        .with(mockall::predicate::eq("my-project:task-abc123"))
+        .times(1)
+        .returning(|_| Ok(false));
+
+    let mut task = crate::db::Task::new("my task", "claude", "my-project");
+    task.session_name = Some("my-project:task-abc123".to_string());
+
+    assert!(!task_has_live_session(&task, &mock_tmux));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_task_has_live_session_returns_false_when_no_session_name() {
+    // Task has never been assigned a tmux window — window_exists must not be called
+    let mock_tmux = crate::tmux::MockTmuxOperations::new();
+
+    let task = crate::db::Task::new("my task", "claude", "my-project");
+    // session_name is None by default
+
+    assert!(!task_has_live_session(&task, &mock_tmux));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_task_has_live_session_returns_false_on_tmux_error() {
+    // If window_exists returns an error, we conservatively treat it as no live session
+    let mut mock_tmux = crate::tmux::MockTmuxOperations::new();
+    mock_tmux
+        .expect_window_exists()
+        .times(1)
+        .returning(|_| Err(anyhow::anyhow!("tmux server not running")));
+
+    let mut task = crate::db::Task::new("my task", "claude", "my-project");
+    task.session_name = Some("my-project:task-abc123".to_string());
+
+    assert!(!task_has_live_session(&task, &mock_tmux));
+}


### PR DESCRIPTION
## Summary

  - `move_backlog_to_running_by_id` (`Shift+M`) unconditionally called `setup_task_worktree()`, which always creates a new tmux window — even when the task already had a live window from a prior research or planning
  phase. This produced duplicate windows with the same name in the tmux session.
  - `transition_to_planning` already had the correct guard for this (to handle the Research→Planning reuse case), but it was never applied to the Backlog→Running shortcut.

  ## Fix

  - Extracted the "does this task have a live tmux window?" check into a shared free function `task_has_live_session(task, tmux_ops)`
  - `move_backlog_to_running_by_id` now checks for a live session before spawning the setup thread — if one exists, it reuses it via `spawn_send_to_agent` (same path as Planning→Running) and skips
  `setup_task_worktree` entirely
  - Both `transition_to_planning` and `move_backlog_to_running_by_id` now share the same helper, making the behaviour consistent