### PR TITLE
Fix pasting in agent popup not recognized as paste

### DIFF
--- a/src/tmux/operations.rs
+++ b/src/tmux/operations.rs
@@ -29,6 +29,10 @@ pub trait TmuxOperations: Send + Sync {
     /// Send keys to a window without pressing Enter
     fn send_keys_literal(&self, target: &str, keys: &str) -> Result<()>;
 
+    /// Paste a block of text into a pane using tmux load-buffer + paste-buffer.
+    /// This sends proper bracketed paste sequences to the target pane.
+    fn paste_text(&self, target: &str, text: &str) -> Result<()>;
+
     /// Capture pane content
     fn capture_pane(&self, target: &str) -> Result<String>;
 
@@ -130,6 +134,24 @@ impl TmuxOperations for RealTmuxOps {
         std::process::Command::new("tmux")
             .args(["-L", super::AGENT_SERVER])
             .args(["send-keys", "-t", target, keys])
+            .output()?;
+        Ok(())
+    }
+
+    fn paste_text(&self, target: &str, text: &str) -> Result<()> {
+        use std::io::Write;
+        let mut child = std::process::Command::new("tmux")
+            .args(["-L", super::AGENT_SERVER])
+            .args(["load-buffer", "-"])
+            .stdin(std::process::Stdio::piped())
+            .spawn()?;
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(text.as_bytes())?;
+        }
+        child.wait()?;
+        std::process::Command::new("tmux")
+            .args(["-L", super::AGENT_SERVER])
+            .args(["paste-buffer", "-p", "-t", target])
             .output()?;
         Ok(())
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind},
+    event::{self, DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -525,7 +525,7 @@ impl App {
         // Setup terminal
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen)?;
+        execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
         let backend = CrosstermBackend::new(stdout);
         let terminal = ratatui::Terminal::new(AppBackend::Crossterm(backend))?;
 
@@ -921,10 +921,14 @@ impl App {
             self.process_transition_requests()?;
 
             if event::poll(std::time::Duration::from_millis(100))? {
-                if let Event::Key(key) = event::read()? {
-                    if key.kind == KeyEventKind::Press {
+                match event::read()? {
+                    Event::Key(key) if key.kind == KeyEventKind::Press => {
                         self.handle_key(key)?;
                     }
+                    Event::Paste(text) => {
+                        self.handle_paste(text)?;
+                    }
+                    _ => {}
                 }
             }
 
@@ -3146,6 +3150,29 @@ impl App {
                 }
             }
         }
+        Ok(())
+    }
+
+    fn handle_paste(&mut self, text: String) -> Result<()> {
+        // Shell popup open: forward paste to the tmux pane with proper bracketed paste sequences
+        if let Some(ref mut popup) = self.state.shell_popup {
+            let window_name = popup.window_name.clone();
+            let _ = self.state.tmux_ops.paste_text(&window_name, &text);
+            popup.cached_content = capture_tmux_pane_with_history(
+                &window_name,
+                500,
+                self.state.tmux_ops.as_ref(),
+            );
+            return Ok(());
+        }
+
+        // Description editor open: insert pasted text at cursor
+        if self.state.input_mode == InputMode::InputDescription {
+            let cursor = self.state.input_cursor;
+            self.state.input_buffer.insert_str(cursor, &text);
+            self.state.input_cursor += text.len();
+        }
+
         Ok(())
     }
 
@@ -6313,7 +6340,7 @@ impl Drop for App {
         match self.terminal.backend_mut() {
             AppBackend::Crossterm(backend) => {
                 let _ = disable_raw_mode();
-                let _ = execute!(backend, LeaveAlternateScreen);
+                let _ = execute!(backend, LeaveAlternateScreen, DisableBracketedPaste);
             }
             #[cfg(feature = "test-mocks")]
             AppBackend::Test(_) => {}

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -9068,3 +9068,128 @@ fn test_task_has_live_session_returns_false_on_tmux_error() {
 
     assert!(!task_has_live_session(&task, &mock_tmux));
 }
+
+// =============================================================================
+// Tests for handle_paste
+// =============================================================================
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_handle_paste_into_shell_popup_calls_paste_text() {
+    // When shell popup is open, handle_paste must call paste_text exactly once
+    // with the full pasted string (not send_keys_literal character by character).
+    let mut mock_tmux = MockTmuxOperations::new();
+    mock_tmux.expect_window_exists().returning(|_| Ok(false));
+    mock_tmux.expect_has_session().returning(|_| false);
+    mock_tmux.expect_get_cursor_info().returning(|_| None);
+
+    let received = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let received_c = received.clone();
+    mock_tmux
+        .expect_paste_text()
+        .times(1)
+        .returning(move |_, text| {
+            *received_c.lock().unwrap() = text.to_string();
+            Ok(())
+        });
+    mock_tmux
+        .expect_capture_pane_with_history()
+        .returning(|_, _| vec![]);
+
+    let mut app = App::new_for_test(
+        Some(PathBuf::from("/tmp/test-project")),
+        Arc::new(mock_tmux),
+        Arc::new(MockGitOperations::new()),
+        Arc::new(MockGitProviderOperations::new()),
+        Arc::new(MockAgentRegistry::new()),
+    )
+    .unwrap();
+
+    app.state.shell_popup = Some(ShellPopup::new(
+        "my task".to_string(),
+        "proj:my-task".to_string(),
+    ));
+
+    app.handle_paste("hello world".to_string()).unwrap();
+
+    assert_eq!(*received.lock().unwrap(), "hello world");
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_handle_paste_into_shell_popup_does_not_call_send_keys_literal() {
+    // Verify the old per-character path is not taken for paste events.
+    let mut mock_tmux = MockTmuxOperations::new();
+    mock_tmux.expect_window_exists().returning(|_| Ok(false));
+    mock_tmux.expect_has_session().returning(|_| false);
+    mock_tmux.expect_get_cursor_info().returning(|_| None);
+    mock_tmux
+        .expect_paste_text()
+        .times(1)
+        .returning(|_, _| Ok(()));
+    mock_tmux
+        .expect_capture_pane_with_history()
+        .returning(|_, _| vec![]);
+    // send_keys_literal must NOT be called — mockall panics if an unexpected call occurs
+    mock_tmux.expect_send_keys_literal().times(0);
+
+    let mut app = App::new_for_test(
+        Some(PathBuf::from("/tmp/test-project")),
+        Arc::new(mock_tmux),
+        Arc::new(MockGitOperations::new()),
+        Arc::new(MockGitProviderOperations::new()),
+        Arc::new(MockAgentRegistry::new()),
+    )
+    .unwrap();
+
+    app.state.shell_popup = Some(ShellPopup::new(
+        "my task".to_string(),
+        "proj:my-task".to_string(),
+    ));
+
+    app.handle_paste("some pasted text".to_string()).unwrap();
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_handle_paste_into_description_editor_at_end() {
+    // Paste appends at the current cursor position (end of buffer).
+    let mut app = make_test_app();
+    app.state.input_mode = InputMode::InputDescription;
+    app.state.input_buffer = "start ".to_string();
+    app.state.input_cursor = 6;
+
+    app.handle_paste("pasted text".to_string()).unwrap();
+
+    assert_eq!(app.state.input_buffer, "start pasted text");
+    assert_eq!(app.state.input_cursor, 17); // 6 + len("pasted text")
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_handle_paste_into_description_editor_at_mid_cursor() {
+    // Paste inserts at the cursor position, pushing subsequent text right.
+    let mut app = make_test_app();
+    app.state.input_mode = InputMode::InputDescription;
+    app.state.input_buffer = "ab".to_string();
+    app.state.input_cursor = 1; // between 'a' and 'b'
+
+    app.handle_paste("XY".to_string()).unwrap();
+
+    assert_eq!(app.state.input_buffer, "aXYb");
+    assert_eq!(app.state.input_cursor, 3); // 1 + len("XY")
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_handle_paste_noop_in_normal_mode() {
+    // In Normal mode with no popup open, paste is silently ignored.
+    let mut app = make_test_app();
+    // input_mode starts as Normal, shell_popup is None
+    assert_eq!(app.state.input_mode, InputMode::Normal);
+    assert!(app.state.shell_popup.is_none());
+
+    app.handle_paste("should be ignored".to_string()).unwrap();
+
+    assert!(app.state.input_buffer.is_empty());
+}


### PR DESCRIPTION
## Problem

When pasting text into the task popup (tmux view), each character was forwarded to the agent pane as a separate `tmux send-keys` call. The inter-keystroke latency from subprocess spawning (~10ms per character) meant agents never received a contiguous paste event — they saw individual keystrokes instead.

## Solution

- Enable crossterm `EnableBracketedPaste` on terminal setup (and `DisableBracketedPaste` on teardown), so the TUI receives `Event::Paste(text)` instead of per-character `Event::Key` events when the user pastes
- Handle `Event::Paste` in the main event loop, routing to a new `handle_paste()` method
- In `handle_paste`, forward to the agent pane via `tmux load-buffer -` (stdin) + `tmux paste-buffer -p -t <target>` — the `-p` flag injects the `\e[200~...\e[201~` bracketed paste escape sequences so the agent recognizes the content as a paste event
- Also handle paste in the task description editor by inserting at the cursor position

## Tests

5 new unit tests covering all paths: paste into popup calls `paste_text` exactly once (not `send_keys_literal`), paste into description editor at end/mid-cursor, and no-op in normal mode.