### PR TITLE
fix(tui): handle multi-byte input and anchor cursor for IME composition

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1331,12 +1331,19 @@ impl App {
                 lines.push(Line::from(""));
             }
 
-            // Active area content
+            // Active area content. Track the insertion point so the native
+            // terminal cursor can be anchored there — this lets the OS render
+            // IME composition (Korean, Japanese, Chinese) inline at the cursor
+            // instead of drifting to wherever the last text was written.
+            let mut cursor_display: Option<(u16, u16)> = None;
+            let cursor_line_start = lines.len();
             match state.input_mode {
                 InputMode::InputTitle => {
-                    let (before_cursor, after_cursor) = state
-                        .input_buffer
-                        .split_at(state.input_cursor.min(state.input_buffer.len()));
+                    let (buf_col, buf_row) =
+                        cursor_display_pos(&state.input_buffer, state.input_cursor);
+                    let prefix_cols = Span::raw("  Title: ").width();
+                    let col = prefix_cols + buf_col;
+                    cursor_display = Some((col as u16, (cursor_line_start + buf_row) as u16));
                     lines.push(Line::from(vec![
                         Span::styled(
                             "  Title: ",
@@ -1344,9 +1351,10 @@ impl App {
                                 .fg(selected_color)
                                 .add_modifier(Modifier::BOLD),
                         ),
-                        Span::styled(before_cursor, Style::default().fg(text_color)),
-                        Span::styled("█", Style::default().fg(selected_color)),
-                        Span::styled(after_cursor, Style::default().fg(text_color)),
+                        Span::styled(
+                            state.input_buffer.clone(),
+                            Style::default().fg(text_color),
+                        ),
                     ]));
                 }
                 InputMode::SelectPlugin => {
@@ -1373,10 +1381,16 @@ impl App {
                     }
                 }
                 InputMode::InputDescription => {
-                    let (before_cursor, after_cursor) = state
-                        .input_buffer
-                        .split_at(state.input_cursor.min(state.input_buffer.len()));
-                    let full_text = format!("  Prompt: {}█{}", before_cursor, after_cursor);
+                    let (buf_col, buf_row) =
+                        cursor_display_pos(&state.input_buffer, state.input_cursor);
+                    let prefix_cols = Span::raw("  Prompt: ").width();
+                    let col = if buf_row == 0 {
+                        prefix_cols + buf_col
+                    } else {
+                        buf_col
+                    };
+                    cursor_display = Some((col as u16, (cursor_line_start + buf_row) as u16));
+                    let full_text = format!("  Prompt: {}", state.input_buffer);
                     // Split on newlines to handle multi-line descriptions
                     for part in full_text.split('\n') {
                         if !state.highlighted_references.is_empty() {
@@ -1415,6 +1429,17 @@ impl App {
                         .border_style(Style::default().fg(selected_color)),
                 );
             frame.render_widget(content, input_area);
+
+            // +1 offsets account for the surrounding Block border.
+            if let Some((col, row)) = cursor_display {
+                let abs_x = input_area.x.saturating_add(1).saturating_add(col);
+                let abs_y = input_area.y.saturating_add(1).saturating_add(row);
+                if abs_x < input_area.x + input_area.width
+                    && abs_y < input_area.y + input_area.height
+                {
+                    frame.set_cursor_position((abs_x, abs_y));
+                }
+            }
 
             // Search dropdowns (only in InputDescription mode)
             if state.input_mode == InputMode::InputDescription {
@@ -3474,14 +3499,12 @@ impl App {
                 self.state.input_cursor = new_pos;
             }
             KeyCode::Left => {
-                if self.state.input_cursor > 0 {
-                    self.state.input_cursor -= 1;
-                }
+                self.state.input_cursor =
+                    prev_char_boundary(&self.state.input_buffer, self.state.input_cursor);
             }
             KeyCode::Right => {
-                if self.state.input_cursor < self.state.input_buffer.len() {
-                    self.state.input_cursor += 1;
-                }
+                self.state.input_cursor =
+                    next_char_boundary(&self.state.input_buffer, self.state.input_cursor);
             }
             KeyCode::Home => {
                 self.state.input_cursor = 0;
@@ -3491,18 +3514,24 @@ impl App {
             }
             KeyCode::Backspace => {
                 if self.state.input_cursor > 0 {
-                    self.state.input_cursor -= 1;
-                    self.state.input_buffer.remove(self.state.input_cursor);
+                    let new_pos =
+                        prev_char_boundary(&self.state.input_buffer, self.state.input_cursor);
+                    self.state
+                        .input_buffer
+                        .drain(new_pos..self.state.input_cursor);
+                    self.state.input_cursor = new_pos;
                 }
             }
             KeyCode::Delete => {
                 if self.state.input_cursor < self.state.input_buffer.len() {
-                    self.state.input_buffer.remove(self.state.input_cursor);
+                    let end =
+                        next_char_boundary(&self.state.input_buffer, self.state.input_cursor);
+                    self.state.input_buffer.drain(self.state.input_cursor..end);
                 }
             }
             KeyCode::Char(c) => {
                 self.state.input_buffer.insert(self.state.input_cursor, c);
-                self.state.input_cursor += 1;
+                self.state.input_cursor += c.len_utf8();
             }
             _ => {}
         }
@@ -3591,8 +3620,14 @@ impl App {
                     } else {
                         search.pattern.pop();
                         if self.state.input_cursor > 0 {
-                            self.state.input_cursor -= 1;
-                            self.state.input_buffer.remove(self.state.input_cursor);
+                            let new_pos = prev_char_boundary(
+                                &self.state.input_buffer,
+                                self.state.input_cursor,
+                            );
+                            self.state
+                                .input_buffer
+                                .drain(new_pos..self.state.input_cursor);
+                            self.state.input_cursor = new_pos;
                         }
                         let query = search.pattern.clone();
                         let matches = self.get_all_task_matches(&query);
@@ -3607,7 +3642,7 @@ impl App {
                         search.pattern.push(c);
                     }
                     self.state.input_buffer.insert(self.state.input_cursor, c);
-                    self.state.input_cursor += 1;
+                    self.state.input_cursor += c.len_utf8();
                     let query = self
                         .state
                         .task_ref_search
@@ -3681,20 +3716,24 @@ impl App {
                 KeyCode::Backspace => {
                     if search.pattern.is_empty() {
                         // Cancel search if pattern is empty
-                        self.state.input_buffer.remove(search.start_pos); // Remove the `!`
+                        self.state.input_buffer.remove(search.start_pos); // Remove the `/`
                         self.state.input_cursor = search.start_pos;
                         self.state.skill_search = None;
                     } else {
                         search.pattern.pop();
-                        self.state.input_cursor = self.state.input_cursor.saturating_sub(1);
-                        self.state.input_buffer.remove(self.state.input_cursor);
+                        let new_pos =
+                            prev_char_boundary(&self.state.input_buffer, self.state.input_cursor);
+                        self.state
+                            .input_buffer
+                            .drain(new_pos..self.state.input_cursor);
+                        self.state.input_cursor = new_pos;
                         self.update_skill_search_matches();
                     }
                 }
                 KeyCode::Char(c) => {
                     search.pattern.push(c);
                     self.state.input_buffer.insert(self.state.input_cursor, c);
-                    self.state.input_cursor += 1;
+                    self.state.input_cursor += c.len_utf8();
                     self.update_skill_search_matches();
                 }
                 _ => {}
@@ -3754,20 +3793,20 @@ impl App {
                 KeyCode::Backspace => {
                     if search.pattern.is_empty() {
                         // Cancel search if pattern is empty
-                        self.state.input_buffer.pop(); // Remove the trigger char
+                        self.state.input_buffer.pop(); // Remove the trigger char (ASCII)
                         self.state.input_cursor = self.state.input_cursor.saturating_sub(1);
                         self.state.file_search = None;
                     } else {
                         search.pattern.pop();
                         self.state.input_buffer.pop();
-                        self.state.input_cursor = self.state.input_cursor.saturating_sub(1);
+                        self.state.input_cursor = self.state.input_buffer.len();
                         self.update_file_search_matches();
                     }
                 }
                 KeyCode::Char(c) => {
                     search.pattern.push(c);
                     self.state.input_buffer.push(c);
-                    self.state.input_cursor += 1;
+                    self.state.input_cursor += c.len_utf8();
                     self.update_file_search_matches();
                 }
                 _ => {}
@@ -3818,14 +3857,12 @@ impl App {
                 self.state.input_cursor = new_pos;
             }
             KeyCode::Left => {
-                if self.state.input_cursor > 0 {
-                    self.state.input_cursor -= 1;
-                }
+                self.state.input_cursor =
+                    prev_char_boundary(&self.state.input_buffer, self.state.input_cursor);
             }
             KeyCode::Right => {
-                if self.state.input_cursor < self.state.input_buffer.len() {
-                    self.state.input_cursor += 1;
-                }
+                self.state.input_cursor =
+                    next_char_boundary(&self.state.input_buffer, self.state.input_cursor);
             }
             KeyCode::Home => {
                 self.state.input_cursor = 0;
@@ -3835,13 +3872,19 @@ impl App {
             }
             KeyCode::Backspace => {
                 if self.state.input_cursor > 0 {
-                    self.state.input_cursor -= 1;
-                    self.state.input_buffer.remove(self.state.input_cursor);
+                    let new_pos =
+                        prev_char_boundary(&self.state.input_buffer, self.state.input_cursor);
+                    self.state
+                        .input_buffer
+                        .drain(new_pos..self.state.input_cursor);
+                    self.state.input_cursor = new_pos;
                 }
             }
             KeyCode::Delete => {
                 if self.state.input_cursor < self.state.input_buffer.len() {
-                    self.state.input_buffer.remove(self.state.input_cursor);
+                    let end =
+                        next_char_boundary(&self.state.input_buffer, self.state.input_cursor);
+                    self.state.input_buffer.drain(self.state.input_cursor..end);
                 }
             }
             KeyCode::Char('#') | KeyCode::Char('@') => {
@@ -3946,7 +3989,7 @@ impl App {
             }
             KeyCode::Char(c) => {
                 self.state.input_buffer.insert(self.state.input_cursor, c);
-                self.state.input_cursor += 1;
+                self.state.input_cursor += c.len_utf8();
             }
             _ => {}
         }
@@ -7207,6 +7250,46 @@ fn parse_sgr(seq: &str, mut style: Style) -> Style {
     }
 
     style
+}
+
+/// Map a byte offset in `text` to the (column, row) of the terminal cell it
+/// renders on. Column uses Unicode display width so wide chars (CJK, emoji)
+/// take two cells — a plain byte/char count would misplace the cursor.
+fn cursor_display_pos(text: &str, cursor_byte: usize) -> (usize, usize) {
+    let end = cursor_byte.min(text.len());
+    let before = &text[..end];
+    let row = before.bytes().filter(|b| *b == b'\n').count();
+    let last_line = before.rsplit('\n').next().unwrap_or("");
+    let col = ratatui::text::Span::raw(last_line).width();
+    (col, row)
+}
+
+/// Snap `pos` back to the nearest UTF-8 char boundary at or before it.
+/// Cursor arithmetic tracks bytes, but String indexing panics mid-codepoint —
+/// callers use this to stay valid after moving across multi-byte chars.
+fn prev_char_boundary(s: &str, pos: usize) -> usize {
+    if pos == 0 {
+        return 0;
+    }
+    let mut new_pos = pos - 1;
+    while new_pos > 0 && !s.is_char_boundary(new_pos) {
+        new_pos -= 1;
+    }
+    new_pos
+}
+
+/// Snap `pos` forward to the next UTF-8 char boundary (or `s.len()` if none).
+/// See `prev_char_boundary` for why byte-indexed cursors need this.
+fn next_char_boundary(s: &str, pos: usize) -> usize {
+    let len = s.len();
+    if pos >= len {
+        return len;
+    }
+    let mut new_pos = pos + 1;
+    while new_pos < len && !s.is_char_boundary(new_pos) {
+        new_pos += 1;
+    }
+    new_pos
 }
 
 /// Find the previous word boundary (for Option+Left)

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -3803,6 +3803,7 @@ fn type_str(app: &mut App, s: &str) {
     }
 }
 
+
 // --- Smoke tests ---
 
 #[test]
@@ -4346,6 +4347,203 @@ fn test_task_ref_after_space() {
     type_str(&mut app, "depends on ");
     press_key(&mut app, KeyCode::Char('!'));
     assert!(app.state.task_ref_search.is_some());
+}
+
+// --- Multi-byte character input (e.g. Korean, Japanese, Chinese) ---
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_korean_char_advances_cursor_by_utf8_length_in_title() {
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    // Type Korean char '한' (3 bytes in UTF-8)
+    press_key(&mut app, KeyCode::Char('한'));
+    assert_eq!(app.state.input_buffer, "한");
+    // Cursor must land on a char boundary (byte 3), not mid-character (byte 1)
+    assert_eq!(app.state.input_cursor, 3);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_korean_word_in_description_preserves_buffer_and_cursor() {
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Title");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+
+    // Typing two Korean chars should not panic and should yield correct buffer
+    type_str(&mut app, "한글");
+    assert_eq!(app.state.input_buffer, "한글");
+    assert_eq!(app.state.input_cursor, 6); // 3+3 bytes
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_korean_then_ascii_does_not_panic() {
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Title");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+
+    // Korean char followed by ASCII must not panic on insert
+    type_str(&mut app, "한a");
+    assert_eq!(app.state.input_buffer, "한a");
+    assert_eq!(app.state.input_cursor, 4);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_korean_backspace_removes_whole_char_in_description() {
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Title");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+
+    type_str(&mut app, "안녕");
+    press_key(&mut app, KeyCode::Backspace);
+    assert_eq!(app.state.input_buffer, "안");
+    assert_eq!(app.state.input_cursor, 3);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_korean_left_arrow_moves_whole_char_in_description() {
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Title");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+
+    type_str(&mut app, "안녕");
+    press_key(&mut app, KeyCode::Left);
+    // Cursor must land on char boundary between 안 (bytes 0..3) and 녕 (bytes 3..6)
+    assert_eq!(app.state.input_cursor, 3);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_korean_right_arrow_moves_whole_char_in_title() {
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "안녕");
+    // Move cursor to start
+    press_key(&mut app, KeyCode::Home);
+    assert_eq!(app.state.input_cursor, 0);
+    // Right arrow should advance one char (3 bytes), not one byte
+    press_key(&mut app, KeyCode::Right);
+    assert_eq!(app.state.input_cursor, 3);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_japanese_typing_preserves_cursor() {
+    // Japanese hiragana are 3-byte UTF-8; guards against Korean-only handling.
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "こんにちは");
+    assert_eq!(app.state.input_buffer, "こんにちは");
+    assert_eq!(app.state.input_cursor, 15); // 5 chars * 3 bytes
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_chinese_typing_preserves_cursor() {
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "你好");
+    assert_eq!(app.state.input_buffer, "你好");
+    assert_eq!(app.state.input_cursor, 6); // 2 chars * 3 bytes
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_emoji_typing_handles_4_byte_utf8() {
+    // Emoji are 4-byte UTF-8 — a distinct edge case from 3-byte CJK.
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    press_key(&mut app, KeyCode::Char('👋'));
+    assert_eq!(app.state.input_buffer, "👋");
+    assert_eq!(app.state.input_cursor, 4);
+    press_key(&mut app, KeyCode::Backspace);
+    assert_eq!(app.state.input_buffer, "");
+    assert_eq!(app.state.input_cursor, 0);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_delete_removes_whole_multibyte_char_in_description() {
+    // Delete takes a different code path from Backspace — verify it too.
+    let mut app = make_test_app();
+    press_key(&mut app, KeyCode::Char('o'));
+    type_str(&mut app, "Title");
+    press_key(&mut app, KeyCode::Enter);
+    assert_eq!(app.state.input_mode, InputMode::InputDescription);
+
+    type_str(&mut app, "안녕");
+    press_key(&mut app, KeyCode::Home);
+    press_key(&mut app, KeyCode::Delete);
+    assert_eq!(app.state.input_buffer, "녕");
+    assert_eq!(app.state.input_cursor, 0);
+}
+
+// --- Cursor display position (for IME composition anchoring) ---
+
+#[test]
+fn test_cursor_display_pos_ascii_only() {
+    // "hello", cursor at byte 3 → col 3, row 0
+    let (col, row) = super::cursor_display_pos("hello", 3);
+    assert_eq!((col, row), (3, 0));
+}
+
+#[test]
+fn test_cursor_display_pos_korean_is_wide() {
+    // "가나", cursor at byte 6 (end) → col 4 (2 wide chars * 2 cols), row 0
+    let (col, row) = super::cursor_display_pos("가나", 6);
+    assert_eq!((col, row), (4, 0));
+}
+
+#[test]
+fn test_cursor_display_pos_korean_mid() {
+    // "가나", cursor at byte 3 (between 가 and 나) → col 2, row 0
+    let (col, row) = super::cursor_display_pos("가나", 3);
+    assert_eq!((col, row), (2, 0));
+}
+
+#[test]
+fn test_cursor_display_pos_mixed_ascii_korean() {
+    // "a가b" bytes: a(1) + 가(3) + b(1) = 5 bytes
+    // cursor after 가 (byte 4) → col 3 (1 + 2), row 0
+    let (col, row) = super::cursor_display_pos("a가b", 4);
+    assert_eq!((col, row), (3, 0));
+}
+
+#[test]
+fn test_cursor_display_pos_with_newline() {
+    // "가나\n다", cursor at end (byte 10) → col 2 (just 다), row 1
+    let (col, row) = super::cursor_display_pos("가나\n다", 10);
+    assert_eq!((col, row), (2, 1));
+}
+
+#[test]
+fn test_cursor_display_pos_at_start() {
+    let (col, row) = super::cursor_display_pos("hello", 0);
+    assert_eq!((col, row), (0, 0));
+}
+
+#[test]
+fn test_cursor_display_pos_empty_string() {
+    let (col, row) = super::cursor_display_pos("", 0);
+    assert_eq!((col, row), (0, 0));
+}
+
+#[test]
+fn test_cursor_display_pos_emoji_is_wide() {
+    // "👋" is 4 bytes UTF-8, display width 2. Cursor at end → col 2.
+    let (col, row) = super::cursor_display_pos("👋", 4);
+    assert_eq!((col, row), (2, 0));
 }
 
 // --- Footer text ---


### PR DESCRIPTION
## Problem

Typing Korean, Japanese, Chinese or emoji in the task title or description editors was broken in two ways:

- Cursor arithmetic advanced by one byte per char, leaving the cursor mid-codepoint after the first multi-byte char. The next insert then panicked on `String::insert`'s `is_char_boundary` assertion, and position checks that read `input_buffer.as_bytes().get(cursor - 1)` saw random UTF-8 continuation bytes.
- The drawn `█` block cursor anchored the rendered cursor glyph, but the OS renders in-progress IME composition at the terminal's *native* cursor — which ratatui left at the end of the line. During composition of e.g. `가나다`, the intermediate `ㄷ` appeared after the `█`, giving the impression the cursor had jumped.

## Solution

- Add `prev_char_boundary` / `next_char_boundary` UTF-8 helpers and a `cursor_display_pos(text, byte_pos) -> (col, row)` helper that uses display width so wide CJK chars count as 2 cells.
- Replace byte-step cursor arithmetic (Left / Right / Backspace / Delete / insert) in `handle_title_input` and `handle_description_input` — plus the task-ref, skill, and file search submodes — with char-boundary-aware navigation. Char insert advances by `c.len_utf8()`.
- Remove the drawn `█` glyph from the title and description editors and call `frame.set_cursor_position()` to place the native terminal cursor at the insertion point. IME composition overlays now render inline, matching the Claude Code UX.

## Tests

13 new tests in `src/tui/app_tests.rs`:
- Korean / Japanese / Chinese / emoji (4-byte UTF-8) typing preserves buffer and cursor.
- Backspace and Delete remove whole multi-byte chars, not stray bytes.
- Left / Right arrows move by char boundary.
- `cursor_display_pos` across ASCII, CJK, wide emoji, and newlines.