### PR TITLE
fix(tui): robust orchestrator lifecycle with multi-instance safety

### DIFF
--- a/src/agent/operations.rs
+++ b/src/agent/operations.rs
@@ -91,8 +91,13 @@ impl AgentOperations for CodingAgent {
 
     fn build_orchestrator_command(&self, mcp_json: &str, _agtx_bin: &str) -> String {
         match self.agent.name.as_str() {
+            // Pre-remove any stale `agtx` registration (last run crashed before
+            // its own `mcp remove`) so `add-json` doesn't fail with "already
+            // exists" and short-circuit the `&&` into an empty shell.
             "claude" => format!(
-                "claude mcp add-json agtx '{}' --scope local && {}; claude mcp remove agtx --scope local",
+                "claude mcp remove agtx --scope local 2>/dev/null || true; \
+                 claude mcp add-json agtx '{}' --scope local && {}; \
+                 claude mcp remove agtx --scope local",
                 mcp_json,
                 self.build_interactive_command("")
             ),

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -75,6 +75,16 @@ impl Database {
         Ok(db)
     }
 
+    /// Open a project DB at an arbitrary file path (for concurrency tests — in-memory is per-connection).
+    #[cfg(feature = "test-mocks")]
+    pub fn open_project_at_path(path: &Path) -> Result<Self> {
+        let conn = Connection::open(path)
+            .with_context(|| format!("Failed to open database at {:?}", path))?;
+        let db = Self { conn };
+        db.init_project_schema()?;
+        Ok(db)
+    }
+
     /// Open an in-memory global database (for testing only)
     #[cfg(feature = "test-mocks")]
     pub fn open_in_memory_global() -> Result<Self> {
@@ -160,6 +170,11 @@ impl Database {
         let _ = self
             .conn
             .execute("ALTER TABLE transition_requests ADD COLUMN reason TEXT", []);
+
+        let _ = self.conn.execute(
+            "ALTER TABLE transition_requests ADD COLUMN claimed_by TEXT",
+            [],
+        );
 
         Ok(())
     }
@@ -495,7 +510,9 @@ impl Database {
 
     pub fn get_pending_transition_requests(&self) -> Result<Vec<TransitionRequest>> {
         let mut stmt = self.conn.prepare(
-            "SELECT * FROM transition_requests WHERE processed_at IS NULL ORDER BY requested_at ASC",
+            "SELECT * FROM transition_requests
+             WHERE processed_at IS NULL AND claimed_by IS NULL
+             ORDER BY requested_at ASC",
         )?;
 
         let requests = stmt
@@ -514,10 +531,23 @@ impl Database {
         Ok(())
     }
 
+    /// Atomically claim a pending request. Returns true iff this caller won.
+    pub fn claim_transition_request(&self, id: &str, claimant: &str) -> Result<bool> {
+        let rows = self.conn.execute(
+            "UPDATE transition_requests
+             SET claimed_by = ?1
+             WHERE id = ?2 AND claimed_by IS NULL AND processed_at IS NULL",
+            params![claimant, id],
+        )?;
+        Ok(rows == 1)
+    }
+
     pub fn cleanup_old_transition_requests(&self) -> Result<()> {
         let cutoff = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
         self.conn.execute(
-            "DELETE FROM transition_requests WHERE processed_at IS NOT NULL AND processed_at < ?1",
+            "DELETE FROM transition_requests
+             WHERE (processed_at IS NOT NULL AND processed_at < ?1)
+                OR (processed_at IS NULL AND claimed_by IS NOT NULL AND requested_at < ?1)",
             params![cutoff],
         )?;
         Ok(())
@@ -529,6 +559,16 @@ impl Database {
         self.conn.execute(
             "UPDATE transition_requests SET processed_at = ?1 WHERE id = ?2",
             params![processed_at, id],
+        )?;
+        Ok(())
+    }
+
+    /// Directly set requested_at to an arbitrary timestamp (for testing cleanup logic only).
+    #[cfg(feature = "test-mocks")]
+    pub fn backdate_transition_requested_at(&self, id: &str, requested_at: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE transition_requests SET requested_at = ?1 WHERE id = ?2",
+            params![requested_at, id],
         )?;
         Ok(())
     }
@@ -587,13 +627,13 @@ impl Database {
         Ok(notifs)
     }
 
-    /// Fetch and delete all pending notifications (atomic consume).
+    /// Atomic fetch-and-delete via `DELETE ... RETURNING`.
     pub fn consume_notifications(&self) -> Result<Vec<Notification>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT * FROM notifications ORDER BY created_at ASC")?;
+            .prepare("DELETE FROM notifications RETURNING id, message, created_at")?;
 
-        let notifs: Vec<Notification> = stmt
+        let mut notifs: Vec<Notification> = stmt
             .query_map([], |row| {
                 Ok(Notification {
                     id: row.get("id")?,
@@ -608,8 +648,8 @@ impl Database {
             .filter_map(|r| r.ok())
             .collect();
 
-        self.conn.execute("DELETE FROM notifications", [])?;
-
+        // `RETURNING` doesn't guarantee any particular row order — sort in Rust.
+        notifs.sort_by(|a, b| a.created_at.cmp(&b.created_at));
         Ok(notifs)
     }
 }

--- a/src/tmux/operations.rs
+++ b/src/tmux/operations.rs
@@ -8,13 +8,16 @@ use mockall::automock;
 /// Operations for tmux window management
 #[cfg_attr(feature = "test-mocks", automock)]
 pub trait TmuxOperations: Send + Sync {
-    /// Create a new tmux window in a session with an optional command to run
+    /// Create a new tmux window. `keep_shell_on_exit=true` drops to a shell
+    /// after `command` exits (task panes); `false` lets tmux close the window
+    /// (orchestrator, where a leftover shell looks like a zombie).
     fn create_window(
         &self,
         session: &str,
         window_name: &str,
         working_dir: &str,
         command: Option<String>,
+        keep_shell_on_exit: bool,
     ) -> Result<()>;
 
     /// Kill a tmux window
@@ -65,6 +68,7 @@ impl TmuxOperations for RealTmuxOps {
         window_name: &str,
         working_dir: &str,
         command: Option<String>,
+        keep_shell_on_exit: bool,
     ) -> Result<()> {
         let mut cmd = std::process::Command::new("tmux");
         let target = format!("{}:", session);
@@ -73,9 +77,12 @@ impl TmuxOperations for RealTmuxOps {
             .args(["-c", working_dir]);
 
         if let Some(ref shell_cmd) = command {
-            // Wrap command so it drops to a shell after the agent exits
-            let wrapped = format!("{}; exec $SHELL", shell_cmd);
-            cmd.args(["sh", "-c", &wrapped]);
+            if keep_shell_on_exit {
+                let wrapped = format!("{}; exec $SHELL", shell_cmd);
+                cmd.args(["sh", "-c", &wrapped]);
+            } else {
+                cmd.args(["sh", "-c", shell_cmd]);
+            }
         }
 
         let output = cmd.output()?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -313,6 +313,7 @@ struct AppState {
     session_refresh_rx: Option<mpsc::Receiver<SessionRefreshResult>>,
     // Cache of dependency satisfaction per task ID (refreshed with tasks)
     deps_satisfied_cache: HashMap<String, bool>,
+    instance_id: String,
 }
 
 /// State for confirming move to Done
@@ -634,6 +635,7 @@ impl App {
                 orchestrator_last_check: Instant::now(),
                 session_refresh_rx: None,
                 deps_satisfied_cache: HashMap::new(),
+                instance_id: uuid::Uuid::new_v4().to_string(),
             },
         };
 
@@ -684,60 +686,22 @@ impl App {
             }
         }
 
-        // Detect existing orchestrator session (survives agtx restarts)
-        if app.state.flags.experimental {
-            let orch_target = format!("{}:orchestrator", app.state.tmux_project_name);
-            if app
-                .state
-                .tmux_ops
-                .window_exists(&orch_target)
-                .unwrap_or(false)
-            {
-                app.state.orchestrator_session = Some(orch_target);
-                app.state.orchestrator_ready.store(true, Ordering::Release);
-
-                // Catch up: notify orchestrator about tasks that completed while TUI was down
-                if let Some(ref db) = app.state.db {
-                    // Check existing notifications to avoid duplicates
-                    let existing: HashSet<String> = db
-                        .peek_notifications()
-                        .unwrap_or_default()
-                        .into_iter()
-                        .map(|n| n.message)
-                        .collect();
-
-                    for task in &app.state.board.tasks {
-                        if !matches!(task.status, TaskStatus::Planning | TaskStatus::Running) {
-                            continue;
-                        }
-                        let plugin = match &task.plugin {
-                            Some(name) => {
-                                WorkflowPlugin::load(name, app.state.project_path.as_deref()).ok()
-                            }
-                            None => skills::load_bundled_plugin("agtx"),
-                        };
-                        if let Some(ref wt) = task.worktree_path {
-                            if phase_artifact_exists(wt, task.status, &plugin, task.cycle) {
-                                let short_id = if task.id.len() >= 8 {
-                                    &task.id[..8]
-                                } else {
-                                    &task.id
-                                };
-                                let message = format!(
-                                    "Task \"{}\" ({}) completed phase: {}",
-                                    task.title,
-                                    short_id,
-                                    task.status.as_str()
-                                );
-                                if !existing.contains(&message) {
-                                    let notif = crate::db::Notification::new(message);
-                                    let _ = db.create_notification(&notif);
-                                }
-                            }
-                        }
-                    }
+        if let Some(orch_target) = detect_existing_orchestrator(
+            app.state.flags.experimental,
+            app.state.tmux_ops.as_ref(),
+            &app.state.tmux_project_name,
+            app.state.db.as_ref(),
+            &app.state.board.tasks,
+            app.state.project_path.as_deref(),
+        ) {
+            app.state.orchestrator_session = Some(orch_target.clone());
+            let tmux_ops = Arc::clone(&app.state.tmux_ops);
+            let ready_flag = Arc::clone(&app.state.orchestrator_ready);
+            std::thread::spawn(move || {
+                if wait_for_agent_ready(&tmux_ops, &orch_target).is_some() {
+                    ready_flag.store(true, Ordering::Release);
                 }
-            }
+            });
         }
 
         Ok(app)
@@ -846,6 +810,7 @@ impl App {
                 orchestrator_last_check: Instant::now(),
                 session_refresh_rx: None,
                 deps_satisfied_cache: HashMap::new(),
+                instance_id: uuid::Uuid::new_v4().to_string(),
             },
         })
     }
@@ -5326,25 +5291,36 @@ impl App {
 
     /// Poll the transition_requests table for unprocessed requests and execute them.
     fn process_transition_requests(&mut self) -> Result<()> {
-        let Some(db) = &self.state.db else {
-            return Ok(());
+        // `self.state.db` is re-borrowed per use site to avoid holding it across `&mut self`.
+        let pending = match self.state.db.as_ref() {
+            Some(db) => db.get_pending_transition_requests()?,
+            None => return Ok(()),
         };
-        let pending = db.get_pending_transition_requests()?;
         if pending.is_empty() {
             return Ok(());
         }
+        let instance_id = self.state.instance_id.clone();
 
         for req in pending {
+            let claimed = self
+                .state
+                .db
+                .as_ref()
+                .map(|db| db.claim_transition_request(&req.id, &instance_id))
+                .and_then(Result::ok)
+                .unwrap_or(false);
+            if !claimed {
+                continue;
+            }
+
             let result = self.execute_transition_request(&req);
             if let Some(db) = &self.state.db {
-                match &result {
-                    Ok(()) => {
-                        let _ = db.mark_transition_processed(&req.id, None);
-                    }
+                let _ = match &result {
+                    Ok(()) => db.mark_transition_processed(&req.id, None),
                     Err(e) => {
-                        let _ = db.mark_transition_processed(&req.id, Some(&e.to_string()));
+                        db.mark_transition_processed(&req.id, Some(&e.to_string()))
                     }
-                }
+                };
             }
             self.refresh_tasks()?;
         }
@@ -5570,38 +5546,66 @@ impl App {
         let orch_target = format!("{}:{}", tmux_project_name, window_name);
 
         // If orchestrator is running, open the popup to view it
-        if let Some(ref orch_target) = self.state.orchestrator_session {
-            if self
-                .state
-                .tmux_ops
-                .window_exists(orch_target)
-                .unwrap_or(false)
-            {
-                let mut popup = ShellPopup::new("Orchestrator".to_string(), orch_target.clone());
-                if let Ok((_term_width, term_height)) = crossterm::terminal::size() {
-                    let pane_width = SHELL_POPUP_CONTENT_WIDTH;
-                    let popup_height =
-                        (term_height as u32 * SHELL_POPUP_HEIGHT_PERCENT as u32 / 100) as u16;
-                    let pane_height = popup_height.saturating_sub(4);
-                    let _ = self
-                        .state
-                        .tmux_ops
-                        .resize_window(orch_target, pane_width, pane_height);
-                    popup.last_pane_size = Some((pane_width, pane_height));
-                    std::thread::sleep(std::time::Duration::from_millis(200));
-                }
-                popup.cached_content =
-                    capture_tmux_pane_with_history(orch_target, 500, self.state.tmux_ops.as_ref());
-                self.state.shell_popup = Some(popup);
-                return Ok(());
-            } else {
-                // Window gone, clear the session
-                self.state.orchestrator_session = None;
+        if is_orchestrator_live(self.state.tmux_ops.as_ref(), &orch_target) {
+            let first_time =
+                self.state.orchestrator_session.as_deref() != Some(&orch_target);
+            self.state.orchestrator_session = Some(orch_target.clone());
+
+            if first_time {
+                // Cross-instance reattach: verify ready, replay phase events (deduped).
                 self.state
                     .orchestrator_ready
                     .store(false, Ordering::Release);
+                if let Some(ref db) = self.state.db {
+                    run_orchestrator_catchup(
+                        db,
+                        &self.state.board.tasks,
+                        self.state.project_path.as_deref(),
+                    );
+                }
+                let tmux_ops = Arc::clone(&self.state.tmux_ops);
+                let ready_flag = Arc::clone(&self.state.orchestrator_ready);
+                let target = orch_target.clone();
+                std::thread::spawn(move || {
+                    if wait_for_agent_ready(&tmux_ops, &target).is_some() {
+                        ready_flag.store(true, Ordering::Release);
+                    }
+                });
             }
+
+            let mut popup = ShellPopup::new("Orchestrator".to_string(), orch_target.clone());
+            if let Ok((_term_width, term_height)) = crossterm::terminal::size() {
+                let pane_width = SHELL_POPUP_CONTENT_WIDTH;
+                let popup_height =
+                    (term_height as u32 * SHELL_POPUP_HEIGHT_PERCENT as u32 / 100) as u16;
+                let pane_height = popup_height.saturating_sub(4);
+                let _ = self
+                    .state
+                    .tmux_ops
+                    .resize_window(&orch_target, pane_width, pane_height);
+                popup.last_pane_size = Some((pane_width, pane_height));
+                std::thread::sleep(std::time::Duration::from_millis(200));
+            }
+            popup.cached_content =
+                capture_tmux_pane_with_history(&orch_target, 500, self.state.tmux_ops.as_ref());
+            self.state.shell_popup = Some(popup);
+            return Ok(());
         }
+
+        if !kill_windows_by_name(self.state.tmux_ops.as_ref(), &orch_target) {
+            self.state.warning_message = Some((
+                format!(
+                    "Could not clear lingering `{}` window; try `tmux -L agtx kill-window -t {}`",
+                    orch_target, orch_target,
+                ),
+                Instant::now(),
+            ));
+            return Ok(());
+        }
+        self.state.orchestrator_session = None;
+        self.state
+            .orchestrator_ready
+            .store(false, Ordering::Release);
 
         // Spawn new orchestrator
         let default_agent = self.state.config.default_agent.clone();
@@ -5635,6 +5639,7 @@ impl App {
             window_name,
             &project_path_str,
             Some(agent_cmd),
+            false,
         )?;
 
         self.state.orchestrator_session = Some(orch_target.clone());
@@ -5666,6 +5671,10 @@ impl App {
             skills::ORCHESTRATE_SKILL,
             &default_agent,
         );
+
+        if let Some(ref db) = self.state.db {
+            run_orchestrator_catchup(db, &self.state.board.tasks, self.state.project_path.as_deref());
+        }
 
         // Send the /agtx:orchestrate command once the agent is ready
         let skill_cmd = skills::transform_plugin_command("/agtx:orchestrate", &default_agent)
@@ -5888,12 +5897,9 @@ impl App {
         }
 
         // Check window still exists
-        if !self
-            .state
-            .tmux_ops
-            .window_exists(&orch_target)
-            .unwrap_or(false)
-        {
+        if !is_orchestrator_live(self.state.tmux_ops.as_ref(), &orch_target) {
+            self.state.orchestrator_session = None;
+            self.state.orchestrator_ready.store(false, Ordering::Release);
             return;
         }
 
@@ -6491,7 +6497,7 @@ fn recover_task_session(
 
     let resume_cmd = agent_ops.build_resume_command();
 
-    tmux_ops.create_window(session, window, worktree_path, Some(resume_cmd))?;
+    tmux_ops.create_window(session, window, worktree_path, Some(resume_cmd), true)?;
 
     Ok(target.clone())
 }
@@ -6815,6 +6821,7 @@ fn setup_task_worktree(
         &window_name,
         &worktree_path_str,
         Some(agent_cmd),
+        true,
     )?;
 
     task.session_name = Some(target.clone());
@@ -8053,6 +8060,89 @@ fn is_pane_at_shell(tmux_ops: &dyn TmuxOperations, target: &str) -> bool {
     }
 }
 
+/// Orchestrator is live iff its tmux window exists (no pane-command peeking).
+fn is_orchestrator_live(tmux_ops: &dyn TmuxOperations, target: &str) -> bool {
+    tmux_ops.window_exists(target).unwrap_or(false)
+}
+
+/// Startup reattach: returns the target if a window survives, replaying catch-up.
+fn detect_existing_orchestrator(
+    experimental: bool,
+    tmux_ops: &dyn TmuxOperations,
+    tmux_project_name: &str,
+    db: Option<&Database>,
+    tasks: &[Task],
+    project_path: Option<&Path>,
+) -> Option<String> {
+    if !experimental {
+        return None;
+    }
+    let target = format!("{}:orchestrator", tmux_project_name);
+    if !tmux_ops.window_exists(&target).unwrap_or(false) {
+        return None;
+    }
+    if let Some(db) = db {
+        run_orchestrator_catchup(db, tasks, project_path);
+    }
+    Some(target)
+}
+
+/// Kill all windows matching `target` (tmux allows duplicates); false if the 16-iter cap is hit.
+fn kill_windows_by_name(tmux_ops: &dyn TmuxOperations, target: &str) -> bool {
+    for _ in 0..16 {
+        if !tmux_ops.window_exists(target).unwrap_or(false) {
+            return true;
+        }
+        let _ = tmux_ops.kill_window(target);
+    }
+    !tmux_ops.window_exists(target).unwrap_or(false)
+}
+
+/// Replay "completed phase" notifications for tasks whose artifact is on disk.
+fn run_orchestrator_catchup(
+    db: &Database,
+    tasks: &[Task],
+    project_path: Option<&Path>,
+) {
+    let existing: HashSet<String> = db
+        .peek_notifications()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|n| n.message)
+        .collect();
+
+    for task in tasks {
+        if !matches!(task.status, TaskStatus::Planning | TaskStatus::Running) {
+            continue;
+        }
+        let plugin = match &task.plugin {
+            Some(name) => WorkflowPlugin::load(name, project_path).ok(),
+            None => skills::load_bundled_plugin("agtx"),
+        };
+        let Some(ref wt) = task.worktree_path else {
+            continue;
+        };
+        if !phase_artifact_exists(wt, task.status, &plugin, task.cycle) {
+            continue;
+        }
+        let short_id = if task.id.len() >= 8 {
+            &task.id[..8]
+        } else {
+            &task.id
+        };
+        let message = format!(
+            "Task \"{}\" ({}) completed phase: {}",
+            task.title,
+            short_id,
+            task.status.as_str()
+        );
+        if existing.contains(&message) {
+            continue;
+        }
+        let _ = db.create_notification(&crate::db::Notification::new(message));
+    }
+}
+
 /// Check if an agent is actively running in the pane.
 /// Uses both `pane_current_command` (works for Claude, Codex, Copilot) and
 /// pane content indicators (works for Gemini which runs inside bash).
@@ -8101,7 +8191,7 @@ fn ensure_window_or_recover(
         let _ = tmux_ops.create_session(session, wt_path);
     }
     let resume_cmd = agent_ops.build_resume_command();
-    let _ = tmux_ops.create_window(session, window, wt_path, Some(resume_cmd));
+    let _ = tmux_ops.create_window(session, window, wt_path, Some(resume_cmd), true);
 }
 
 /// Gracefully switch the agent running in a tmux window.

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -1523,7 +1523,7 @@ fn test_setup_task_worktree_success() {
 
     mock_tmux
         .expect_create_window()
-        .returning(|_, _, _, _| Ok(()));
+        .returning(|_, _, _, _, _| Ok(()));
 
     let mut task = Task::new("Add login feature", "claude", "project-1");
     task.status = TaskStatus::Backlog;
@@ -1577,7 +1577,7 @@ fn test_setup_task_worktree_sets_task_fields() {
     mock_tmux.expect_has_session().returning(|_| true);
     mock_tmux
         .expect_create_window()
-        .returning(|_, _, _, _| Ok(()));
+        .returning(|_, _, _, _, _| Ok(()));
 
     let mut task = Task::new("Fix bug", "claude", "project-1");
 
@@ -1638,7 +1638,7 @@ fn test_setup_task_worktree_worktree_creation_fails() {
     mock_tmux.expect_has_session().returning(|_| true);
     mock_tmux
         .expect_create_window()
-        .returning(|_, _, _, _| Ok(()));
+        .returning(|_, _, _, _, _| Ok(()));
 
     let mut task = Task::new("Test task", "claude", "project-1");
 
@@ -1694,7 +1694,7 @@ fn test_setup_task_worktree_tmux_window_fails() {
     // Tmux window creation fails
     mock_tmux
         .expect_create_window()
-        .returning(|_, _, _, _| Err(anyhow::anyhow!("tmux not running")));
+        .returning(|_, _, _, _, _| Err(anyhow::anyhow!("tmux not running")));
 
     let mut task = Task::new("Test task", "claude", "project-1");
 
@@ -1746,7 +1746,7 @@ fn test_setup_task_worktree_creates_session_when_missing() {
     mock_tmux.expect_create_session().returning(|_, _| Ok(()));
     mock_tmux
         .expect_create_window()
-        .returning(|_, _, _, _| Ok(()));
+        .returning(|_, _, _, _, _| Ok(()));
 
     let mut task = Task::new("New task", "claude", "project-1");
 
@@ -1801,7 +1801,7 @@ fn test_setup_task_worktree_passes_init_config() {
     mock_tmux.expect_has_session().returning(|_| true);
     mock_tmux
         .expect_create_window()
-        .returning(|_, _, _, _| Ok(()));
+        .returning(|_, _, _, _, _| Ok(()));
 
     let mut task = Task::new("Task with config", "claude", "project-1");
 
@@ -2981,6 +2981,65 @@ fn test_is_pane_at_shell_returns_false_when_none() {
         .returning(|_| None);
 
     assert!(!is_pane_at_shell(&mock, "sess:win"));
+}
+
+// === kill_windows_by_name tests ===
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_kill_windows_by_name_returns_true_when_cleared() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let mut mock = MockTmuxOperations::new();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_clone = Arc::clone(&calls);
+    mock.expect_window_exists()
+        .withf(|t| t == "proj:orchestrator")
+        .returning(move |_| Ok(calls_clone.fetch_add(1, Ordering::SeqCst) == 0));
+    mock.expect_kill_window()
+        .withf(|t| t == "proj:orchestrator")
+        .returning(|_| Ok(()));
+
+    assert!(kill_windows_by_name(&mock, "proj:orchestrator"));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_kill_windows_by_name_returns_false_when_cap_exhausted() {
+    // Pins the 16-iteration cap: lowering it regresses `.times(16)`.
+    let mut mock = MockTmuxOperations::new();
+    mock.expect_window_exists()
+        .withf(|t| t == "proj:orchestrator")
+        .returning(|_| Ok(true));
+    mock.expect_kill_window()
+        .withf(|t| t == "proj:orchestrator")
+        .times(16)
+        .returning(|_| Ok(()));
+
+    assert!(!kill_windows_by_name(&mock, "proj:orchestrator"));
+}
+
+// === is_orchestrator_live tests ===
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_is_orchestrator_live_false_when_window_missing() {
+    let mut mock = MockTmuxOperations::new();
+    mock.expect_window_exists()
+        .withf(|t| t == "proj:orchestrator")
+        .returning(|_| Ok(false));
+
+    assert!(!is_orchestrator_live(&mock, "proj:orchestrator"));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_is_orchestrator_live_ignores_pane_current_command() {
+    let mut mock = MockTmuxOperations::new();
+    mock.expect_window_exists()
+        .withf(|t| t == "proj:orchestrator")
+        .returning(|_| Ok(true));
+
+    assert!(is_orchestrator_live(&mock, "proj:orchestrator"));
 }
 
 // === switch_agent_in_tmux tests ===
@@ -6029,6 +6088,36 @@ fn test_process_transition_requests_empty_is_noop() {
 
 #[test]
 #[cfg(feature = "test-mocks")]
+fn test_process_transition_requests_skips_other_instance_claims() {
+    let mut app = make_test_app();
+    let db = app.state.db.as_ref().unwrap();
+
+    let req = crate::db::TransitionRequest::new("missing-task", "move_forward");
+    db.create_transition_request(&req).unwrap();
+
+    assert!(db
+        .claim_transition_request(&req.id, "other-instance")
+        .unwrap());
+
+    app.process_transition_requests().unwrap();
+
+    let fresh = app
+        .state
+        .db
+        .as_ref()
+        .unwrap()
+        .get_transition_request(&req.id)
+        .unwrap()
+        .unwrap();
+    assert!(
+        fresh.processed_at.is_none(),
+        "other-instance claim must keep this instance from touching the request"
+    );
+    assert!(fresh.error.is_none());
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
 fn test_execute_transition_request_unknown_action_errors() {
     let mut app = make_test_app();
     let db = app.state.db.as_ref().unwrap();
@@ -6697,14 +6786,16 @@ fn test_toggle_orchestrator_warns_in_dashboard_mode() {
 #[test]
 #[cfg(feature = "test-mocks")]
 fn test_toggle_orchestrator_spawns_new_session() {
-    // No existing orchestrator → creates window, sets orchestrator_session
     let mut mock_tmux = MockTmuxOperations::new();
     mock_tmux.expect_window_exists().returning(|_| Ok(false));
     mock_tmux.expect_has_session().returning(|_| false);
     mock_tmux.expect_create_session().returning(|_, _| Ok(()));
     mock_tmux
         .expect_create_window()
-        .returning(|_, _, _, _| Ok(()));
+        .withf(|_session, window_name, _dir, _cmd, keep_shell_on_exit: &bool| {
+            window_name == "orchestrator" && !keep_shell_on_exit
+        })
+        .returning(|_, _, _, _, _| Ok(()));
     mock_tmux.expect_resize_window().returning(|_, _, _| Ok(()));
     mock_tmux
         .expect_capture_pane_with_history()
@@ -6739,9 +6830,11 @@ fn test_toggle_orchestrator_spawns_new_session() {
 #[test]
 #[cfg(feature = "test-mocks")]
 fn test_toggle_orchestrator_opens_popup_when_already_running() {
-    // orchestrator_session is set AND window still exists → opens popup, no new spawn
     let mut mock_tmux = MockTmuxOperations::new();
     mock_tmux.expect_window_exists().returning(|_| Ok(true));
+    mock_tmux
+        .expect_pane_current_command()
+        .returning(|_| Some("claude".to_string()));
     mock_tmux.expect_resize_window().returning(|_, _, _| Ok(()));
     mock_tmux
         .expect_capture_pane_with_history()
@@ -6778,6 +6871,55 @@ fn test_toggle_orchestrator_opens_popup_when_already_running() {
 
 #[test]
 #[cfg(feature = "test-mocks")]
+fn test_toggle_orchestrator_reattaches_to_live_orchestrator_from_other_instance() {
+    let mut mock_tmux = MockTmuxOperations::new();
+    mock_tmux
+        .expect_window_exists()
+        .withf(|t| t == "test-project:orchestrator")
+        .returning(|_| Ok(true));
+    mock_tmux
+        .expect_pane_current_command()
+        .withf(|t| t == "test-project:orchestrator")
+        .returning(|_| Some("claude".to_string()));
+    mock_tmux
+        .expect_capture_pane()
+        .withf(|t| t == "test-project:orchestrator")
+        .returning(|_| Ok("Claude Code\n".to_string()));
+    mock_tmux
+        .expect_resize_window()
+        .returning(|_, _, _| Ok(()));
+    mock_tmux
+        .expect_capture_pane_with_history()
+        .returning(|_, _| vec![]);
+    mock_tmux.expect_get_cursor_info().returning(|_| None);
+
+    let mut mock_registry = MockAgentRegistry::new();
+    mock_registry
+        .expect_get()
+        .returning(|_| Arc::new(MockAgentOperations::new()));
+
+    let mut app = App::new_for_test(
+        Some(PathBuf::from("/tmp/test-project")),
+        Arc::new(mock_tmux),
+        Arc::new(MockGitOperations::new()),
+        Arc::new(MockGitProviderOperations::new()),
+        Arc::new(mock_registry),
+    )
+    .unwrap();
+
+    assert!(app.state.orchestrator_session.is_none());
+
+    app.toggle_orchestrator().unwrap();
+
+    assert!(app.state.shell_popup.is_some());
+    assert_eq!(
+        app.state.orchestrator_session.as_deref(),
+        Some("test-project:orchestrator")
+    );
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
 fn test_toggle_orchestrator_clears_stale_session_and_respawns() {
     // orchestrator_session set but window is GONE → clears session, spawns new one
     let mut mock_tmux = MockTmuxOperations::new();
@@ -6786,9 +6928,13 @@ fn test_toggle_orchestrator_clears_stale_session_and_respawns() {
     mock_tmux.expect_window_exists().returning(|_| Ok(false));
     mock_tmux.expect_has_session().returning(|_| false);
     mock_tmux.expect_create_session().returning(|_, _| Ok(()));
+    // Respawn must keep `keep_shell_on_exit=false` — else zombie shell on exit.
     mock_tmux
         .expect_create_window()
-        .returning(|_, _, _, _| Ok(()));
+        .withf(|_session, window_name, _dir, _cmd, keep_shell_on_exit: &bool| {
+            window_name == "orchestrator" && !keep_shell_on_exit
+        })
+        .returning(|_, _, _, _, _| Ok(()));
     mock_tmux.expect_resize_window().returning(|_, _, _| Ok(()));
     mock_tmux
         .expect_capture_pane_with_history()
@@ -6927,6 +7073,9 @@ fn test_deliver_orchestrator_notifications_busy_when_content_changed() {
     let mut mock_tmux = MockTmuxOperations::new();
     mock_tmux.expect_window_exists().returning(|_| Ok(true));
     mock_tmux
+        .expect_pane_current_command()
+        .returning(|_| Some("claude".to_string()));
+    mock_tmux
         .expect_capture_pane()
         .returning(|_| Ok("new content here".to_string()));
     // send_keys must NOT be called
@@ -6962,6 +7111,9 @@ fn test_deliver_orchestrator_notifications_delivers_when_idle_signal() {
     // Content changed AND has [agtx:idle] → sends combined notification
     let mut mock_tmux = MockTmuxOperations::new();
     mock_tmux.expect_window_exists().returning(|_| Ok(true));
+    mock_tmux
+        .expect_pane_current_command()
+        .returning(|_| Some("claude".to_string()));
     mock_tmux
         .expect_capture_pane()
         .returning(|_| Ok("stuff [agtx:idle]".to_string()));
@@ -7014,6 +7166,9 @@ fn test_deliver_orchestrator_notifications_delivers_via_stability_fallback() {
     let mut mock_tmux = MockTmuxOperations::new();
     mock_tmux.expect_window_exists().returning(|_| Ok(true));
     mock_tmux
+        .expect_pane_current_command()
+        .returning(|_| Some("claude".to_string()));
+    mock_tmux
         .expect_capture_pane()
         .returning(|_| Ok("same content".to_string()));
     mock_tmux
@@ -7063,6 +7218,9 @@ fn test_deliver_orchestrator_notifications_noop_when_no_notifications() {
     let mut mock_tmux = MockTmuxOperations::new();
     mock_tmux.expect_window_exists().returning(|_| Ok(true));
     mock_tmux
+        .expect_pane_current_command()
+        .returning(|_| Some("claude".to_string()));
+    mock_tmux
         .expect_capture_pane()
         .returning(|_| Ok("stuff [agtx:idle]".to_string()));
     // send_keys must NOT be called — mockall will panic if it is
@@ -7089,6 +7247,224 @@ fn test_deliver_orchestrator_notifications_noop_when_no_notifications() {
 
     app.deliver_orchestrator_notifications();
     // No panic = correct (send_keys not called)
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_deliver_orchestrator_notifications_clears_state_when_window_gone() {
+    let mut mock_tmux = MockTmuxOperations::new();
+    mock_tmux
+        .expect_window_exists()
+        .withf(|t| t == "proj:orchestrator")
+        .returning(|_| Ok(false));
+
+    let mut mock_registry = MockAgentRegistry::new();
+    mock_registry
+        .expect_get()
+        .returning(|_| Arc::new(MockAgentOperations::new()));
+
+    let mut app = App::new_for_test(
+        Some(PathBuf::from("/tmp/test-project")),
+        Arc::new(mock_tmux),
+        Arc::new(MockGitOperations::new()),
+        Arc::new(MockGitProviderOperations::new()),
+        Arc::new(mock_registry),
+    )
+    .unwrap();
+
+    let db = app.state.db.as_ref().unwrap();
+    db.create_notification(&crate::db::Notification::new(
+        "Task \"foo\" (deadbeef) completed phase: planning",
+    ))
+    .unwrap();
+
+    app.state.orchestrator_last_check = Instant::now() - std::time::Duration::from_secs(10);
+    app.state.orchestrator_session = Some("proj:orchestrator".to_string());
+    app.state.orchestrator_ready.store(true, Ordering::Release);
+
+    app.deliver_orchestrator_notifications();
+
+    assert!(app.state.orchestrator_session.is_none());
+    assert!(!app.state.orchestrator_ready.load(Ordering::Acquire));
+    let remaining = app
+        .state
+        .db
+        .as_ref()
+        .unwrap()
+        .peek_notifications()
+        .unwrap();
+    assert_eq!(remaining.len(), 1, "notifications preserved for next spawn");
+}
+
+// =============================================================================
+// Tests for run_orchestrator_catchup helper
+// =============================================================================
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_run_orchestrator_catchup_emits_for_planning_artifact() {
+    let tmp = std::env::temp_dir().join("agtx_test_catchup_planning");
+    let _ = std::fs::remove_dir_all(&tmp);
+    let agtx_dir = tmp.join(".agtx");
+    std::fs::create_dir_all(&agtx_dir).unwrap();
+    std::fs::write(agtx_dir.join("plan.md"), "# Plan").unwrap();
+
+    let db = crate::db::Database::open_in_memory_project().unwrap();
+
+    let mut task = Task::new("compose release notes", "claude", "proj");
+    task.id = "abcdef1234".to_string();
+    task.status = TaskStatus::Planning;
+    task.worktree_path = Some(tmp.to_string_lossy().to_string());
+    task.plugin = None; // None → bundled agtx plugin
+    db.create_task(&task).unwrap();
+
+    run_orchestrator_catchup(&db, &[task.clone()], None);
+
+    let notifs = db.peek_notifications().unwrap();
+    assert_eq!(notifs.len(), 1, "expected exactly one catch-up notification");
+    assert!(
+        notifs[0].message.contains("compose release notes"),
+        "message should include task title, got: {}",
+        notifs[0].message
+    );
+    assert!(
+        notifs[0].message.contains("planning"),
+        "message should include phase name, got: {}",
+        notifs[0].message
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_run_orchestrator_catchup_deduplicates_existing_notifications() {
+    let tmp = std::env::temp_dir().join("agtx_test_catchup_dedup");
+    let _ = std::fs::remove_dir_all(&tmp);
+    let agtx_dir = tmp.join(".agtx");
+    std::fs::create_dir_all(&agtx_dir).unwrap();
+    std::fs::write(agtx_dir.join("plan.md"), "# Plan").unwrap();
+
+    let db = crate::db::Database::open_in_memory_project().unwrap();
+
+    let mut task = Task::new("compose release notes", "claude", "proj");
+    task.id = "abcdef1234".to_string();
+    task.status = TaskStatus::Planning;
+    task.worktree_path = Some(tmp.to_string_lossy().to_string());
+    task.plugin = None;
+    db.create_task(&task).unwrap();
+
+    let expected = format!(
+        "Task \"{}\" ({}) completed phase: {}",
+        task.title,
+        &task.id[..8],
+        task.status.as_str()
+    );
+    db.create_notification(&crate::db::Notification::new(expected.clone()))
+        .unwrap();
+
+    run_orchestrator_catchup(&db, &[task.clone()], None);
+
+    let notifs = db.peek_notifications().unwrap();
+    assert_eq!(
+        notifs.len(),
+        1,
+        "helper must dedupe against existing notifications"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_run_orchestrator_catchup_skips_non_planning_or_running() {
+    let tmp = std::env::temp_dir().join("agtx_test_catchup_skip");
+    let _ = std::fs::remove_dir_all(&tmp);
+    let agtx_dir = tmp.join(".agtx");
+    std::fs::create_dir_all(&agtx_dir).unwrap();
+    std::fs::write(agtx_dir.join("plan.md"), "# Plan").unwrap();
+
+    let db = crate::db::Database::open_in_memory_project().unwrap();
+
+    let mut task = Task::new("done task", "claude", "proj");
+    task.id = "11111111ff".to_string();
+    task.status = TaskStatus::Backlog;
+    task.worktree_path = Some(tmp.to_string_lossy().to_string());
+    task.plugin = None;
+    db.create_task(&task).unwrap();
+
+    run_orchestrator_catchup(&db, &[task.clone()], None);
+
+    let notifs = db.peek_notifications().unwrap();
+    assert!(
+        notifs.is_empty(),
+        "Backlog tasks must be ignored by catch-up"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// =============================================================================
+// Tests for detect_existing_orchestrator helper (TUI-startup reattachment)
+// =============================================================================
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_detect_existing_orchestrator_returns_none_when_experimental_off() {
+    let mock = MockTmuxOperations::new();
+    let db = crate::db::Database::open_in_memory_project().unwrap();
+
+    let result = detect_existing_orchestrator(false, &mock, "proj", Some(&db), &[], None);
+    assert!(result.is_none());
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_detect_existing_orchestrator_reattaches_even_when_pane_is_bash() {
+    let mut mock = MockTmuxOperations::new();
+    mock.expect_window_exists()
+        .withf(|t| t == "proj:orchestrator")
+        .returning(|_| Ok(true));
+
+    let db = crate::db::Database::open_in_memory_project().unwrap();
+    let result = detect_existing_orchestrator(true, &mock, "proj", Some(&db), &[], None);
+    assert_eq!(
+        result.as_deref(),
+        Some("proj:orchestrator"),
+        "live window (regardless of pane command) must reattach, not respawn"
+    );
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_detect_existing_orchestrator_runs_catchup() {
+    let tmp = std::env::temp_dir().join("agtx_test_detect_catchup");
+    let _ = std::fs::remove_dir_all(&tmp);
+    let agtx_dir = tmp.join(".agtx");
+    std::fs::create_dir_all(&agtx_dir).unwrap();
+    std::fs::write(agtx_dir.join("plan.md"), "# Plan").unwrap();
+
+    let mut mock = MockTmuxOperations::new();
+    mock.expect_window_exists().returning(|_| Ok(true));
+    mock.expect_pane_current_command()
+        .returning(|_| Some("claude".to_string()));
+
+    let db = crate::db::Database::open_in_memory_project().unwrap();
+    let mut task = Task::new("compose release notes", "claude", "proj");
+    task.id = "abcdef1234".to_string();
+    task.status = TaskStatus::Planning;
+    task.worktree_path = Some(tmp.to_string_lossy().to_string());
+    task.plugin = None;
+    db.create_task(&task).unwrap();
+
+    let tasks = vec![task];
+    let result = detect_existing_orchestrator(true, &mock, "proj", Some(&db), &tasks, None);
+    assert!(result.is_some());
+
+    let notifs = db.peek_notifications().unwrap();
+    assert_eq!(notifs.len(), 1, "catch-up should have queued one notification");
+
+    let _ = std::fs::remove_dir_all(&tmp);
 }
 
 // =============================================================================

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -1,4 +1,4 @@
-use agtx::agent::{known_agents, parse_agent_selection};
+use agtx::agent::{known_agents, parse_agent_selection, AgentOperations, CodingAgent};
 use agtx::skills::{agent_native_skill_dir, transform_plugin_command};
 
 #[test]
@@ -154,6 +154,31 @@ fn test_build_resume_command_unknown_agent_falls_back_to_interactive() {
     let agent = Agent::new("custom-agent", "my-agent", "A custom agent", "Custom <noreply@example.com>");
     // Unknown agent should fall back to build_interactive_command("")
     assert_eq!(agent.build_resume_command(), agent.build_interactive_command(""));
+}
+
+// === build_orchestrator_command ===
+
+#[test]
+fn test_build_orchestrator_command_claude_is_idempotent() {
+    let agents = known_agents();
+    let claude = agents.iter().find(|a| a.name == "claude").unwrap().clone();
+    let ops = CodingAgent::new(claude);
+    let cmd = ops.build_orchestrator_command("{\"type\":\"stdio\"}", "/usr/bin/agtx");
+
+    let pre_remove_idx = cmd
+        .find("claude mcp remove agtx")
+        .expect("pre-remove stale registration");
+    let add_idx = cmd
+        .find("claude mcp add-json agtx")
+        .expect("register MCP");
+    assert!(pre_remove_idx < add_idx, "pre-remove must precede add-json:\n{cmd}");
+
+    let pre_section = &cmd[..add_idx];
+    assert!(
+        pre_section.contains("|| true") || pre_section.contains("2>/dev/null"),
+        "pre-remove must tolerate missing prior state:\n{cmd}"
+    );
+    assert!(cmd.contains("&& claude"), "&& must gate interactive claude:\n{cmd}");
 }
 
 // =============================================================================

--- a/tests/db_tests.rs
+++ b/tests/db_tests.rs
@@ -1,4 +1,4 @@
-use agtx::db::{Database, Notification, Project, Task, TaskStatus};
+use agtx::db::{Database, Notification, Project, Task, TaskStatus, TransitionRequest};
 
 // === TaskStatus Tests ===
 
@@ -305,4 +305,171 @@ fn test_deps_not_satisfied_dep_in_planning() {
     db.create_task(&task).unwrap();
 
     assert!(!db.deps_satisfied(&task));
+}
+
+// === transition_request claim tests ===
+
+#[test]
+fn test_claim_transition_request_first_claimant_wins() {
+    let db = Database::open_in_memory_project().unwrap();
+    let req = TransitionRequest::new("task-1", "move_forward");
+    db.create_transition_request(&req).unwrap();
+
+    assert!(db.claim_transition_request(&req.id, "agtx-A").unwrap());
+    assert!(!db.claim_transition_request(&req.id, "agtx-B").unwrap());
+    assert!(!db.claim_transition_request(&req.id, "agtx-A").unwrap());
+}
+
+#[test]
+fn test_claim_transition_request_fails_if_already_processed() {
+    let db = Database::open_in_memory_project().unwrap();
+    let req = TransitionRequest::new("task-1", "move_forward");
+    db.create_transition_request(&req).unwrap();
+    db.mark_transition_processed(&req.id, None).unwrap();
+
+    assert!(!db.claim_transition_request(&req.id, "agtx-A").unwrap());
+}
+
+#[test]
+fn test_claim_transition_request_fails_for_unknown_id() {
+    let db = Database::open_in_memory_project().unwrap();
+    assert!(!db.claim_transition_request("does-not-exist", "agtx-A").unwrap());
+}
+
+#[test]
+fn test_cleanup_old_transition_requests_sweeps_stale_claims() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let fresh_claim = TransitionRequest::new("task-fresh", "move_forward");
+    let stale_claim = TransitionRequest::new("task-stale", "move_forward");
+    let fresh_unclaimed = TransitionRequest::new("task-unclaimed", "move_forward");
+    db.create_transition_request(&fresh_claim).unwrap();
+    db.create_transition_request(&stale_claim).unwrap();
+    db.create_transition_request(&fresh_unclaimed).unwrap();
+
+    db.claim_transition_request(&fresh_claim.id, "agtx-A").unwrap();
+    db.claim_transition_request(&stale_claim.id, "agtx-A").unwrap();
+    let two_hours_ago = (chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339();
+    db.backdate_transition_requested_at(&stale_claim.id, &two_hours_ago).unwrap();
+
+    db.cleanup_old_transition_requests().unwrap();
+
+    assert!(db.get_transition_request(&stale_claim.id).unwrap().is_none());
+    assert!(db.get_transition_request(&fresh_claim.id).unwrap().is_some());
+    assert!(db.get_transition_request(&fresh_unclaimed.id).unwrap().is_some());
+}
+
+#[test]
+fn test_get_pending_transition_requests_excludes_claimed() {
+    let db = Database::open_in_memory_project().unwrap();
+
+    let req_a = TransitionRequest::new("task-a", "move_forward");
+    let req_b = TransitionRequest::new("task-b", "move_forward");
+    db.create_transition_request(&req_a).unwrap();
+    db.create_transition_request(&req_b).unwrap();
+    db.claim_transition_request(&req_a.id, "other-instance").unwrap();
+
+    let pending = db.get_pending_transition_requests().unwrap();
+    let ids: Vec<&str> = pending.iter().map(|r| r.id.as_str()).collect();
+
+    assert!(!ids.contains(&req_a.id.as_str()));
+    assert!(ids.contains(&req_b.id.as_str()));
+}
+
+// N threads race one claim → exactly one winner (read-then-update would allow multiple).
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_claim_transition_request_atomic_under_concurrent_claims() {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+
+    let setup = Database::open_project_at_path(&db_path).unwrap();
+    let req = TransitionRequest::new("task-race", "move_forward");
+    setup.create_transition_request(&req).unwrap();
+    drop(setup);
+
+    const THREADS: usize = 16;
+    let barrier = Arc::new(Barrier::new(THREADS));
+    let mut handles = Vec::with_capacity(THREADS);
+    for i in 0..THREADS {
+        let path = db_path.clone();
+        let req_id = req.id.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            let db = Database::open_project_at_path(&path).unwrap();
+            let claimant = format!("agtx-{}", i);
+            barrier.wait();
+            db.claim_transition_request(&req_id, &claimant).unwrap()
+        }));
+    }
+
+    let wins: usize = handles.into_iter().filter_map(|h| h.join().ok()).filter(|w| *w).count();
+    assert_eq!(wins, 1, "exactly one thread must win the claim; got {wins}");
+
+    // Row must now be excluded from pending — a late claim must also fail.
+    let followup = Database::open_project_at_path(&db_path).unwrap();
+    assert!(
+        followup.get_pending_transition_requests().unwrap().is_empty(),
+        "claimed request must be filtered from pending"
+    );
+    assert!(
+        !followup.claim_transition_request(&req.id, "late-comer").unwrap(),
+        "a later claim after the race must return false"
+    );
+}
+
+// N consumers drain the queue → each row returned exactly once (SELECT-then-DELETE would dupe).
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_consume_notifications_atomic_under_concurrent_consumers() {
+    use std::collections::HashSet;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+
+    const NOTIFS: usize = 64;
+    let setup = Database::open_project_at_path(&db_path).unwrap();
+    for i in 0..NOTIFS {
+        setup.create_notification(&Notification::new(format!("msg-{i}"))).unwrap();
+    }
+    drop(setup);
+
+    const THREADS: usize = 8;
+    let barrier = Arc::new(Barrier::new(THREADS));
+    let mut handles = Vec::with_capacity(THREADS);
+    for _ in 0..THREADS {
+        let path = db_path.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            let db = Database::open_project_at_path(&path).unwrap();
+            barrier.wait();
+            db.consume_notifications().unwrap()
+        }));
+    }
+
+    let mut seen: Vec<Notification> = Vec::new();
+    for h in handles {
+        seen.extend(h.join().unwrap());
+    }
+
+    assert_eq!(seen.len(), NOTIFS, "total consumed must equal total created");
+    let unique_ids: HashSet<&str> = seen.iter().map(|n| n.id.as_str()).collect();
+    assert_eq!(
+        unique_ids.len(),
+        NOTIFS,
+        "each notification must be consumed exactly once (no peer double-reads)"
+    );
+    assert!(
+        Database::open_project_at_path(&db_path)
+            .unwrap()
+            .peek_notifications()
+            .unwrap()
+            .is_empty(),
+        "DB must be drained after concurrent consume"
+    );
 }

--- a/tests/mock_infrastructure_tests.rs
+++ b/tests/mock_infrastructure_tests.rs
@@ -119,7 +119,7 @@ fn test_tmux_session_management() {
     mock_tmux
         .expect_create_window()
         .times(1)
-        .returning(|_, _, _, _| Ok(()));
+        .returning(|_, _, _, _, _| Ok(()));
 
     // Session exists after creation
     mock_tmux
@@ -139,6 +139,7 @@ fn test_tmux_session_management() {
             "task-1",
             "/home/user/project/.agtx/worktrees/task-1",
             None,
+            true,
         )
         .unwrap();
     assert!(mock_tmux.has_session("my-project"));


### PR DESCRIPTION
## Problem

The experimental orchestrator pane (`O`) produced "zombies":
- `; exec $SHELL` wrapper left a dead shell after claude exited.
- A prior run crashing before `claude mcp remove` made the next `add-json` fail "already exists" and short-circuit to an empty shell.
- Pane-command liveness heuristics misclassified claude's Bash tool, the spawn chain's `sh -c`, and asdf/nvm-hosted `node` as dead.
- A second agtx instance's `O` on the same project killed the first instance's live orchestrator.
- Peer instances double-executed transition requests.
- `consume_notifications`'s SELECT-then-DELETE let peer instances both observe and re-send the same notifications.
- Startup reattached to dead shells and immediately marked ready.

## Fix

Converge on a single invariant: an orchestrator window is alive iff tmux says it exists — no pane-command peeking.

1. `TmuxOperations::create_window` gains `keep_shell_on_exit`; the orchestrator passes `false` so tmux closes the window when the agent exits. Task windows keep `true`.
2. Orchestrator command prepends `claude mcp remove agtx --scope local 2>/dev/null || true;` so stale registrations can't block the fresh claude.
3. `is_orchestrator_live` = `window_exists`. Legacy `exec $SHELL` windows are a one-time upgrade annoyance, not a hot-path concern.
4. `toggle_orchestrator` reattaches to any live window — ours, a peer instance's, or a prior-run survivor. `kill_windows_by_name` returns `bool` and the spawn path bails with a warning when cleanup fails rather than stacking a duplicate.
5. `transition_requests` gains `claimed_by`; `claim_transition_request` atomically wins a single `UPDATE`. `get_pending_transition_requests` filters claimed rows so peers don't issue redundant claim UPDATEs. `cleanup_old_transition_requests` sweeps stale claims too.
6. `consume_notifications` uses `DELETE … RETURNING` so peers can't both observe the same rows.
7. Startup detect uses window-only liveness, defers `orchestrator_ready` until `wait_for_agent_ready` verifies, and invokes `run_orchestrator_catchup` on both reattach and spawn.

## Testing

`cargo test --features test-mocks` — 657 passed. New tests cover each helper (live/missing window, idempotent MCP command, multi-instance reattach), threaded races on `claim_transition_request` and `consume_notifications` that would fail on read-then-update or SELECT-then-DELETE regressions, the 16-iter cap on `kill_windows_by_name`, and the `keep_shell_on_exit=false` spawn invariant on both fresh and stale-session respawn paths.

## Deferred

`wait_for_agent_ready` cancellation on rapid retoggle, and the narrow startup-vs-peer-spawn catchup race — practical impact is minor; next `O` triggers catchup anyway.