### PR TITLE
feat(phase): clear Claude Code context on Planning -> Running

### DIFF
--- a/plugins/agtx/plugin.toml
+++ b/plugins/agtx/plugin.toml
@@ -1,5 +1,6 @@
 name = "agtx"
 description = "Built-in workflow with skills and prompts"
+clear_context_on_advance = true
 
 [artifacts]
 research = ".agtx/research.md"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -435,6 +435,11 @@ pub struct WorkflowPlugin {
     /// When true, enables Review → Planning transition for multi-phase workflows.
     #[serde(default)]
     pub cyclic: bool,
+    /// When true, send a "clear context" command (agent-specific) before the
+    /// phase skill and prompt on phase transitions. Currently honored only for
+    /// Claude Code (`/clear`); other agents fall through to normal send.
+    #[serde(default)]
+    pub clear_context_on_advance: bool,
     /// Files/dirs to copy from worktree back to project root after a phase completes.
     /// Keyed by phase name (e.g. { research = ["PROJECT.md", ".planning"] }).
     #[serde(default)]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4508,6 +4508,7 @@ impl App {
                             &task_content,
                             &planning_agent_clone,
                             &auto_dismiss,
+                            false,
                         );
                     }
                 }
@@ -4880,6 +4881,7 @@ impl App {
                             &task_content,
                             &agent_name,
                             &auto_dismiss,
+                            false,
                         );
                     }
                 }
@@ -4986,6 +4988,9 @@ impl App {
         let auto_dismiss = plugin
             .as_ref()
             .map_or_else(Vec::new, |p| p.auto_dismiss.clone());
+        let clear_context_on_advance = plugin
+            .as_ref()
+            .map_or(false, |p| p.clear_context_on_advance);
 
         // If a live session already exists (e.g. from a prior research/planning phase),
         // reuse it instead of creating a duplicate tmux window.
@@ -5085,6 +5090,7 @@ impl App {
                             &task_content,
                             &running_agent_clone,
                             &auto_dismiss,
+                            clear_context_on_advance,
                         );
                     }
                 }
@@ -5226,6 +5232,7 @@ impl App {
                             &task_content_clone,
                             &planning_agent_clone,
                             &auto_dismiss,
+                            false,
                         );
                     });
                 }
@@ -6267,6 +6274,7 @@ impl App {
                                             "",
                                             &agent_name,
                                             &[],
+                                            false,
                                         );
                                     }
                                     Ok(false) | Err(_) => {}
@@ -7653,6 +7661,7 @@ fn spawn_send_to_agent(
             &task_content,
             &target_agent,
             &auto_dismiss,
+            false,
         );
     });
 }
@@ -7670,7 +7679,35 @@ fn send_skill_and_prompt(
     task_content: &str,
     agent_name: &str,
     auto_dismiss: &[crate::config::AutoDismiss],
+    clear_context: bool,
 ) {
+    // Opt-in context clear on phase advance. Only Claude Code has a known
+    // clear command; other agents are tbd per issue #46 and fall through
+    // to normal send unchanged.
+    if clear_context && agent_name == "claude" {
+        let _ = tmux_ops.send_keys(target, "/clear");
+        // Wait for Claude to clear its buffer and return to idle prompt.
+        // Pattern mirrors the stability-poll loops used elsewhere in this
+        // function: poll until pane content stabilises (no changes for ~1s),
+        // capped at ~5s total.
+        let mut last_content = String::new();
+        let mut stable_ticks = 0u32;
+        for _ in 0..25 {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            if let Ok(content) = tmux_ops.capture_pane(target) {
+                if content != last_content {
+                    last_content = content;
+                    stable_ticks = 0;
+                } else {
+                    stable_ticks += 1;
+                    if stable_ticks >= 5 {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     // Gemini, Codex & OpenCode: always combine skill+prompt into a single message.
     // Gemini: sending separately causes it to execute the skill and queue the
     //   prompt, which gets lost or arrives too late.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7652,6 +7652,10 @@ fn spawn_send_to_agent(
             switch_agent_in_tmux(tmux_ops.as_ref(), &target, &current_agent, &new_cmd);
             let _ = wait_for_agent_ready(&tmux_ops, &target);
         }
+        let clear_context = plugin
+            .as_ref()
+            .map(|p| p.clear_context_on_advance)
+            .unwrap_or(false);
         send_skill_and_prompt(
             &tmux_ops,
             &target,
@@ -7661,7 +7665,7 @@ fn spawn_send_to_agent(
             &task_content,
             &target_agent,
             &auto_dismiss,
-            false,
+            clear_context,
         );
     });
 }

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -3419,6 +3419,7 @@ fn test_send_skill_and_prompt_gemini_combined() {
         "my task",
         "gemini",
         &[],
+        false,
     );
     let calls = literal_calls.lock().unwrap();
     assert!(calls
@@ -3451,6 +3452,7 @@ fn test_send_skill_and_prompt_codex_combined() {
         "do the thing",
         "codex",
         &[],
+        false,
     );
     let calls = literal_calls.lock().unwrap();
     assert!(calls
@@ -3485,6 +3487,7 @@ fn test_send_skill_and_prompt_claude_with_trigger() {
         "implement this",
         "claude",
         &[],
+        false,
     );
     let calls = keys_calls.lock().unwrap();
     assert!(
@@ -3519,6 +3522,7 @@ fn test_send_skill_and_prompt_prompt_only() {
         "just a prompt",
         "claude",
         &[],
+        false,
     );
     let calls = keys_calls.lock().unwrap();
     assert_eq!(calls.len(), 1);
@@ -3547,6 +3551,7 @@ fn test_send_skill_and_prompt_void_prefill() {
         "fix the login bug",
         "claude",
         &[],
+        false,
     );
     let calls = literal_calls.lock().unwrap();
     assert_eq!(calls.len(), 1);
@@ -8967,6 +8972,7 @@ fn test_send_skill_and_prompt_opencode_combined_with_double_enter() {
         "do the thing",
         "opencode",
         &[],
+        false,
     );
     let calls = literal_calls.lock().unwrap();
     // Combined message sent
@@ -9009,6 +9015,7 @@ fn test_send_skill_and_prompt_cursor_combined_single_enter() {
         "my task",
         "cursor",
         &[],
+        false,
     );
     let calls = literal_calls.lock().unwrap();
     assert!(

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -3502,6 +3502,87 @@ fn test_send_skill_and_prompt_claude_with_trigger() {
 
 #[test]
 #[cfg(feature = "test-mocks")]
+fn test_send_skill_and_prompt_clear_context_claude() {
+    // When clear_context=true and agent is Claude, /clear must be sent first,
+    // before the skill and then the task prompt.
+    let mut mock = MockTmuxOperations::new();
+    let keys_calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let keys_c = keys_calls.clone();
+
+    mock.expect_send_keys().returning(move |_, k| {
+        keys_c.lock().unwrap().push(k.to_string());
+        Ok(())
+    });
+    mock.expect_send_keys_literal().returning(|_, _| Ok(()));
+    // Simulate stable pane after /clear so the poll exits quickly.
+    mock.expect_capture_pane()
+        .returning(|_| Ok("✻ Welcome to Claude Code!".to_string()));
+
+    let tmux: std::sync::Arc<dyn TmuxOperations> = std::sync::Arc::new(mock);
+    send_skill_and_prompt(
+        &tmux,
+        "sess:win",
+        &Some("/agtx:plan".to_string()),
+        "do the thing",
+        &None,
+        "do the thing",
+        "claude",
+        &[],
+        true,
+    );
+    let calls = keys_calls.lock().unwrap();
+    // /clear must appear and must come before the skill command.
+    let clear_pos = calls.iter().position(|c| c == "/clear");
+    let skill_pos = calls.iter().position(|c| c == "/agtx:plan");
+    assert!(clear_pos.is_some(), "/clear should be sent");
+    assert!(skill_pos.is_some(), "skill should be sent");
+    assert!(
+        clear_pos.unwrap() < skill_pos.unwrap(),
+        "/clear must be sent before the skill command"
+    );
+    assert!(
+        calls.iter().any(|c| c == "do the thing"),
+        "task prompt should be sent"
+    );
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_send_skill_and_prompt_clear_context_ignored_for_non_claude() {
+    // When clear_context=true but agent is not Claude, /clear must NOT be sent.
+    let mut mock = MockTmuxOperations::new();
+    let keys_calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let keys_c = keys_calls.clone();
+
+    mock.expect_send_keys().returning(move |_, k| {
+        keys_c.lock().unwrap().push(k.to_string());
+        Ok(())
+    });
+    mock.expect_send_keys_literal().returning(|_, _| Ok(()));
+    mock.expect_capture_pane()
+        .returning(|_| Ok(String::new()));
+
+    let tmux: std::sync::Arc<dyn TmuxOperations> = std::sync::Arc::new(mock);
+    send_skill_and_prompt(
+        &tmux,
+        "sess:win",
+        &None,
+        "do the thing",
+        &None,
+        "do the thing",
+        "gemini",
+        &[],
+        true,
+    );
+    let calls = keys_calls.lock().unwrap();
+    assert!(
+        !calls.iter().any(|c| c == "/clear"),
+        "/clear must not be sent for non-Claude agents"
+    );
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
 fn test_send_skill_and_prompt_prompt_only() {
     let mut mock = MockTmuxOperations::new();
     let keys_calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -2177,6 +2177,7 @@ fn test_resolve_skill_command_with_plugin() {
         copy_dirs: vec![],
         copy_files: vec![],
         cyclic: false,
+        clear_context_on_advance: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
     });
@@ -2239,6 +2240,7 @@ fn test_plugin_supports_agent() {
         copy_dirs: vec![],
         copy_files: vec![],
         cyclic: false,
+        clear_context_on_advance: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
     };
@@ -2264,6 +2266,7 @@ fn test_plugin_supports_agent() {
         copy_dirs: vec![],
         copy_files: vec![],
         cyclic: false,
+        clear_context_on_advance: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
     };
@@ -2335,6 +2338,7 @@ fn test_phase_artifact_exists_with_glob() {
         copy_dirs: vec![],
         copy_files: vec![],
         cyclic: false,
+        clear_context_on_advance: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
     });
@@ -2656,6 +2660,7 @@ fn test_resolve_prompt_trigger_with_gsd() {
         copy_dirs: vec![],
         copy_files: vec![],
         cyclic: false,
+        clear_context_on_advance: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
     });
@@ -2694,6 +2699,7 @@ fn test_resolve_prompt_trigger_empty_string_filtered() {
         copy_dirs: vec![],
         copy_files: vec![],
         cyclic: false,
+        clear_context_on_advance: false,
         copy_back: std::collections::HashMap::new(),
         auto_dismiss: vec![],
     });


### PR DESCRIPTION
Fixes #46. Opt-in per-plugin flag that sends `/clear` to Claude Code before the phase skill + prompt on phase transitions, so the Running phase starts fresh instead of inheriting the full Planning conversation.

## Design

Only Claude Code has a known clear command per the issue; Gemini, OpenCode, Cursor, Codex, and Copilot are marked `tbd`. For now, those agents fall through to the normal send path unchanged when `clear_context` is true — the skill + prompt flow is preserved and no bogus command is sent.

## Changes

### `src/config/mod.rs` — WorkflowPlugin
Add `clear_context_on_advance: bool` with `#[serde(default)]`. Defaults to `false` so every existing plugin's behavior is unchanged unless its plugin.toml opts in.

### `src/tui/app.rs::send_skill_and_prompt`
New `clear_context: bool` final positional parameter. At the very top of the function body (before the `matches!(agent_name, "gemini" | ...)` combined-send branch):

```rust
if clear_context && agent_name == "claude" {
    let _ = tmux_ops.send_keys(target, "/clear");
    // Wait for Claude to clear its buffer and return to idle prompt.
    // Mirrors the stability-poll pattern used elsewhere in this fn.
    let mut last_content = String::new();
    let mut stable_ticks = 0u32;
    for _ in 0..25 {
        std::thread::sleep(std::time::Duration::from_millis(200));
        if let Ok(content) = tmux_ops.capture_pane(target) {
            if content != last_content {
                last_content = content;
                stable_ticks = 0;
            } else {
                stable_ticks += 1;
                if stable_ticks >= 5 { break; }
            }
        }
    }
}
```

The stability-poll pattern matches the existing post-Enter wait loops so Claude's prompt-redraw fully completes before the next message is sent.

### Call-site wiring
- 6 direct call sites in `app.rs`: 5 pass literal `false`, the Planning → Running call site reads `plugin.as_ref().map(|p| p.clear_context_on_advance).unwrap_or(false)`.
- `spawn_send_to_agent` (the reused-session transition path that covers Planning → Running and Running → Review when the tmux window already exists): it already takes `plugin: Option<WorkflowPlugin>`, so it reads the same flag and threads it into `send_skill_and_prompt`. This was caught during self-review on round one — otherwise the feature's primary code path would have silently no-op'd even with the plugin flag set.
- 7 test call sites in `src/tui/app_tests.rs`: updated to pass `false` so `cargo test --features test-mocks` builds cleanly.

### `plugins/agtx/plugin.toml`
Enabled for the built-in agtx plugin:
```toml
clear_context_on_advance = true
```

## Testing

- `cargo build`: clean (only pre-existing warnings unrelated to this change).
- `cargo test --features test-mocks --lib`: 460 passed, 0 failed.
- `cargo test --features test-mocks --no-run`: all test targets compile (this is the check Codex's self-review flagged in round one).

Pre-existing `db_tests` errors (`open_in_memory_project` missing on `Database`) reproduce on `upstream/main` without any changes from this branch and are unrelated.

## Scope boundaries (per issue)

- No new clear commands for gemini / opencode / cursor / codex / copilot — maintainer marked those `tbd`. They are covered by the fall-through path.
- Flag is per-plugin and defaults to `false`. No other plugin's behavior changes.
- Only Planning → Running was requested; other transitions (Setup → Planning, Review → Planning) continue to pass `false` explicitly.

Fixes #46

---

This contribution was developed with AI assistance (Codex).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
