### PR TITLE
feat: add agtx-terse token-efficient plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,9 @@ plugins/               # Bundled plugin configs (embedded at compile time)
 ├── agtx/
 │   ├── plugin.toml    # Default workflow with skills and prompts
 │   └── skills/orchestrate.md # Orchestrator agent skill (experimental)
+├── agtx-terse/
+│   ├── plugin.toml    # Token-efficient variant of agtx workflow
+│   └── skills/        # Terse skill overrides with brevity directive
 ├── gsd/plugin.toml    # Get Shit Done workflow
 ├── spec-kit/plugin.toml # GitHub spec-kit workflow
 ├── openspec/plugin.toml # OpenSpec specification framework

--- a/README.md
+++ b/README.md
@@ -330,12 +330,13 @@ running = "codex"
 
 Plug any spec-driven framework into the task lifecycle. Define commands, prompts, and artifacts — agtx handles phase gating, artifact polling, worktree sync, agent switching, and autonomous execution.
 
-Press `P` to switch plugins. Ships with 9 built-in:
+Press `P` to switch plugins. Ships with 10 built-in:
 
 | Plugin | Description |
 |--------|-------------|
 | **void** | Plain agent session - no prompting or skills, task description prefilled in input |
 | **agtx** (default) | Built-in workflow with skills and prompts for each phase |
+| **agtx-terse** | Token-efficient variant of agtx — same workflow with compressed output (~65% fewer tokens) |
 | **gsd** | [Get Shit Done](https://github.com/fynnfluegge/get-shit-done-cc) - structured spec-driven development with interactive planning |
 | **spec-kit** | [Spec-Driven Development](https://github.com/github/spec-kit) by GitHub - specifications become executable artifacts |
 | **openspec** | [OpenSpec](https://github.com/Fission-AI/OpenSpec) - lightweight AI-guided specification framework |

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Press `P` to switch plugins. Ships with 10 built-in:
 |--------|-------------|
 | **void** | Plain agent session - no prompting or skills, task description prefilled in input |
 | **agtx** (default) | Built-in workflow with skills and prompts for each phase |
-| **agtx-terse** | Token-efficient variant of agtx — same workflow with compressed output (~65% fewer tokens) |
+| **agtx-terse** | Token-efficient workflow - same workflow with compressed output and minimal tokens |
 | **gsd** | [Get Shit Done](https://github.com/fynnfluegge/get-shit-done-cc) - structured spec-driven development with interactive planning |
 | **spec-kit** | [Spec-Driven Development](https://github.com/github/spec-kit) by GitHub - specifications become executable artifacts |
 | **openspec** | [OpenSpec](https://github.com/Fission-AI/OpenSpec) - lightweight AI-guided specification framework |

--- a/plugins/agtx-terse/plugin.toml
+++ b/plugins/agtx-terse/plugin.toml
@@ -1,0 +1,15 @@
+name = "agtx-terse"
+description = "Token-efficient workflow — compressed output, ~65% fewer output tokens"
+clear_context_on_advance = true
+
+[artifacts]
+research = ".agtx/research.md"
+planning = ".agtx/plan.md"
+running = ".agtx/execute.md"
+review = ".agtx/review.md"
+
+[commands]
+research = "/agtx:research {task}"
+planning = "/agtx:plan {task}"
+running = "/agtx:execute {task}"
+review = "/agtx:review"

--- a/plugins/agtx-terse/plugin.toml
+++ b/plugins/agtx-terse/plugin.toml
@@ -1,5 +1,5 @@
 name = "agtx-terse"
-description = "Token-efficient workflow — compressed output, ~65% fewer output tokens"
+description = "Token-efficient workflow with compressed output and minimal token usage."
 clear_context_on_advance = true
 
 [artifacts]

--- a/plugins/agtx-terse/skills/agtx-execute/SKILL.md
+++ b/plugins/agtx-terse/skills/agtx-execute/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: agtx-execute
+description: Execute an approved implementation plan. Implement the changes, then write a summary to .agtx/execute.md and stop.
+---
+
+# Execution Phase
+
+You are in the **execution phase** of an agtx-managed task.
+
+## Input
+
+- **Task description** — provided inline with this command (when entering directly from Backlog)
+- **`.agtx/plan.md`** — approved implementation plan (when planning was completed first)
+
+## Instructions
+
+1. If `.agtx/plan.md` exists, read it for the approved plan
+2. Read and understand the task description
+3. Implement the changes
+4. Run relevant tests to verify your changes
+5. Fix any issues found during testing
+
+## Output
+
+When implementation is complete, write a summary to `.agtx/execute.md` with these sections:
+
+## Changes
+What files were modified/created and what was changed in each.
+
+## Testing
+How you verified the changes — tests run, results, manual checks.
+
+## CRITICAL: Stop After Writing
+
+After writing `.agtx/execute.md`:
+- Do NOT start new work beyond the plan
+- Say: "Implementation complete. Summary written to `.agtx/execute.md`."
+- Wait for further instructions
+
+## Output Style
+
+Terse. No pleasantries. Fragments OK. Short synonyms. Code exact.
+Status updates: one line. Pattern: [what] [why]. Done.

--- a/plugins/agtx-terse/skills/agtx-plan/SKILL.md
+++ b/plugins/agtx-terse/skills/agtx-plan/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: agtx-plan
+description: Plan a task implementation. Analyze the codebase, create a detailed plan, write it to .agtx/plan.md, then stop and wait for user approval before making any changes.
+---
+
+# Planning Phase
+
+You are in the **planning phase** of an agtx-managed task.
+
+## Input
+
+- **Task description** — provided inline with this command (when entering directly from Backlog)
+- **`.agtx/research.md`** — prior analysis from research phase (when research was completed first)
+
+## Instructions
+
+1. If `.agtx/research.md` exists, read it for prior analysis
+2. Read and understand the task description
+3. Explore the codebase to understand relevant files, patterns, and architecture
+4. Identify all files that need to be created or modified
+5. Create a detailed implementation plan
+
+## Output
+
+Write your plan to `.agtx/plan.md` with these sections:
+
+## Analysis
+What you found in the codebase — relevant files, patterns, dependencies.
+
+## Plan
+Step-by-step implementation plan — files to modify, approach, order of changes.
+
+## Risks
+What could go wrong — edge cases, breaking changes, areas needing extra care.
+
+## CRITICAL: Stop After Writing
+
+After writing `.agtx/plan.md`:
+- Do NOT start implementing
+- Do NOT modify any source files
+- Say: "Plan written to `.agtx/plan.md`. Waiting for approval."
+- Wait for explicit instructions to proceed
+
+## Output Style
+
+Terse. No pleasantries. Fragments OK. Short synonyms. Code exact.
+Status updates: one line. Pattern: [what] [why]. Done.

--- a/plugins/agtx-terse/skills/agtx-research/SKILL.md
+++ b/plugins/agtx-terse/skills/agtx-research/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: agtx-research
+description: Explore the codebase to understand a task before planning. Write findings to .agtx/research.md and stop. This is a read-only exploration — do not modify any files.
+---
+
+# Research Phase
+
+You are in the **research phase** of an agtx-managed task. This is a read-only exploration.
+
+## Input
+
+- **Task description** — provided inline with this command
+
+## Instructions
+
+1. Read and understand the task description
+2. Explore the codebase to find relevant files, patterns, and architecture
+4. Identify dependencies, related code, and potential complexity
+5. Assess feasibility and estimate scope
+
+## Output
+
+Write your findings to `.agtx/research.md`. Include:
+
+## Relevant Files
+Key files and their roles — what exists, what needs changing.
+
+## Architecture
+How the relevant parts of the codebase fit together.
+
+## Complexity
+Assessment of scope — simple change, moderate refactor, or major undertaking.
+
+## Open Questions
+Things that need clarification before planning can begin.
+
+## CRITICAL: Do Not Modify Code
+
+This is a **read-only** exploration:
+- Do NOT modify any source files
+- Do NOT create branches or worktrees
+- Do NOT start planning or implementing
+- Say: "Research complete. Findings written to .agtx/research.md."
+- Wait for further instructions
+
+## Output Style
+
+Terse. No pleasantries. Fragments OK. Short synonyms. Code exact.
+Status updates: one line. Pattern: [what] [why]. Done.

--- a/plugins/agtx-terse/skills/agtx-review/SKILL.md
+++ b/plugins/agtx-terse/skills/agtx-review/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: agtx-review
+description: Self-review completed work. Check for correctness, edge cases, and code quality. Write review to .agtx/review.md and stop.
+---
+
+# Review Phase
+
+You are in the **review phase** of an agtx-managed task.
+
+## Instructions
+
+1. Review all changes made during execution (use git diff)
+2. Check for:
+   - Correctness and edge cases
+   - Error handling
+   - Code style consistency with the existing codebase
+   - Test coverage
+   - Security issues (injection, XSS, etc.)
+3. Fix any issues you find
+
+## Output
+
+Write your review to `.agtx/review.md` with these sections:
+
+## Review
+Findings from your review — what looks good, what was fixed, any concerns.
+
+## Status
+Either `READY` (good to merge) or `NEEDS_WORK` (with explanation of remaining issues).
+
+## CRITICAL: Stop After Writing
+
+After writing `.agtx/review.md`:
+- Say: "Review written to `.agtx/review.md`."
+- Wait for further instructions
+
+## Output Style
+
+Terse. No pleasantries. Fragments OK. Short synonyms. Code exact.
+Status updates: one line. Pattern: [what] [why]. Done.

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -147,6 +147,11 @@ pub const BUNDLED_PLUGINS: &[(&str, &str, &str)] = &[
         include_str!("../plugins/agtx/plugin.toml"),
     ),
     (
+        "agtx-terse",
+        "Token-efficient workflow — compressed output, ~65% fewer output tokens",
+        include_str!("../plugins/agtx-terse/plugin.toml"),
+    ),
+    (
         "gsd",
         "Get Shit Done - structured spec-driven development",
         include_str!("../plugins/gsd/plugin.toml"),

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -148,7 +148,7 @@ pub const BUNDLED_PLUGINS: &[(&str, &str, &str)] = &[
     ),
     (
         "agtx-terse",
-        "Token-efficient workflow — compressed output, ~65% fewer output tokens",
+        "Token-efficient workflow - same workflow with compressed output and minimal tokens",
         include_str!("../plugins/agtx-terse/plugin.toml"),
     ),
     (

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -2392,6 +2392,7 @@ fn test_bundled_plugins_are_valid_toml() {
 #[test]
 fn test_bundled_plugins_list() {
     let names: Vec<&str> = skills::BUNDLED_PLUGINS.iter().map(|(n, _, _)| *n).collect();
+    assert!(names.contains(&"agtx-terse"));
     assert!(names.contains(&"agtx"));
     assert!(names.contains(&"gsd"));
     assert!(names.contains(&"spec-kit"));
@@ -2401,7 +2402,7 @@ fn test_bundled_plugins_list() {
     assert!(names.contains(&"superpowers"));
     assert!(names.contains(&"oh-my-claudecode"));
     assert!(names.contains(&"agent-skills"));
-    assert_eq!(names.len(), 9);
+    assert_eq!(names.len(), 10);
 }
 
 #[test]
@@ -2453,11 +2454,11 @@ fn test_plugin_select_popup_construction_gsd_active() {
         });
     }
     let selected = options.iter().position(|o| o.active).unwrap_or(0);
-    // gsd is the second option (index 1)
-    assert_eq!(selected, 1);
+    // gsd is the third option (index 2), after agtx-terse
+    assert_eq!(selected, 2);
     assert!(!options[0].active);
-    assert!(options[1].active);
-    assert_eq!(options[1].name, "gsd");
+    assert!(options[2].active);
+    assert_eq!(options[2].name, "gsd");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

  - Add `agtx-terse` plugin — a token-efficient variant of the default `agtx` workflow. Token-efficient workflow - same workflow with compressed output and minimal token usage.
  - Add `clear_context_on_advance = true` to `agtx-terse` (same as `agtx`) — artifacts capture phase output, so conversation history is redundant on phase transitions

  ## Details

  **New plugin: `agtx-terse`**

  Same commands, artifacts, and phase structure as `agtx`. Each skill appends an output style directive:

  > Terse. No pleasantries. Fragments OK. Short synonyms. Code exact.
  > Status updates: one line. Pattern: [what] [why]. Done.

  The four overridden skills: `agtx-research`, `agtx-plan`, `agtx-execute`, `agtx-review`. The `merge-conflicts` and `orchestrate` builtins are not overridden — they don't generate verbose prose.

  **Why this works**: Each phase writes a structured artifact (`.agtx/research.md`, `.agtx/plan.md`, etc.) that captures all necessary context. Combined with `clear_context_on_advance`, the agent starts each phase
  with a clean slate and reads the artifact — so no context is lost, only tokens saved.

  ## Test plan

  - [x] `cargo build --release` — compiles cleanly with new `include_str!` in `BUNDLED_PLUGINS`
  - [x] `cargo test --lib` — all tests pass (updated hardcoded plugin count 9→10 and `gsd` index 1→2 in plugin selector tests)
  - [ ] Manual: press `P` on the board — `agtx-terse` appears in plugin selector with correct description
  - [ ] Manual: advance a task with `agtx-terse` — verify terse skill files are deployed to `.agtx/skills/` and agent-native paths in the worktree
  - [ ] Manual: advance a task phase — verify `/clear` is sent before the next phase prompt (from `clear_context_on_advance`)