### PR TITLE
feat: add configurable branch prefix for worktrees

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -175,6 +175,10 @@ pub struct WorktreeConfig {
     /// Directory (relative to project root) where worktrees are created
     #[serde(default = "default_worktree_dir")]
     pub worktree_dir: String,
+
+    /// Prefix for branch names (e.g. "user/pablospe" → "user/pablospe/slug")
+    #[serde(default = "default_branch_prefix")]
+    pub branch_prefix: String,
 }
 
 impl Default for WorktreeConfig {
@@ -184,12 +188,17 @@ impl Default for WorktreeConfig {
             auto_cleanup: true,
             base_branch: String::new(),
             worktree_dir: default_worktree_dir(),
+            branch_prefix: default_branch_prefix(),
         }
     }
 }
 
 fn default_worktree_dir() -> String {
     crate::git::DEFAULT_WORKTREE_DIR.to_string()
+}
+
+fn default_branch_prefix() -> String {
+    "task".to_string()
 }
 
 fn default_true() -> bool {
@@ -225,6 +234,9 @@ pub struct ProjectConfig {
 
     /// Workflow plugin name (e.g. "gsd", "spec-kit")
     pub workflow_plugin: Option<String>,
+
+    /// Override branch prefix for this project (e.g. "user/pablospe")
+    pub branch_prefix: Option<String>,
 }
 
 impl GlobalConfig {
@@ -350,6 +362,7 @@ pub struct MergedConfig {
     pub cleanup_script: Option<String>,
     pub workflow_plugin: Option<String>,
     pub fullscreen_on_enter: bool,
+    pub branch_prefix: String,
 }
 
 impl MergedConfig {
@@ -384,6 +397,10 @@ impl MergedConfig {
             cleanup_script: project.cleanup_script.clone(),
             workflow_plugin: project.workflow_plugin.clone(),
             fullscreen_on_enter: global.fullscreen_on_enter,
+            branch_prefix: project
+                .branch_prefix
+                .clone()
+                .unwrap_or_else(|| global.worktree.branch_prefix.clone()),
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -235,7 +235,7 @@ pub struct ProjectConfig {
     /// Workflow plugin name (e.g. "gsd", "spec-kit")
     pub workflow_plugin: Option<String>,
 
-    /// Override branch prefix for this project (e.g. "user/pablospe")
+    /// Override branch prefix for this project (e.g. "user/name")
     pub branch_prefix: Option<String>,
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -176,7 +176,7 @@ pub struct WorktreeConfig {
     #[serde(default = "default_worktree_dir")]
     pub worktree_dir: String,
 
-    /// Prefix for branch names (e.g. "user/pablospe" → "user/pablospe/slug")
+    /// Prefix for branch names (e.g. "user/name" → "user/name/slug")
     #[serde(default = "default_branch_prefix")]
     pub branch_prefix: String,
 }

--- a/src/git/operations.rs
+++ b/src/git/operations.rs
@@ -16,6 +16,7 @@ pub trait GitOperations: Send + Sync {
         task_slug: &str,
         base_branch: &str,
         worktree_dir: &str,
+        branch_prefix: &str,
     ) -> Result<String>;
 
     /// Remove a worktree
@@ -84,9 +85,15 @@ impl GitOperations for RealGitOps {
         task_slug: &str,
         base_branch: &str,
         worktree_dir: &str,
+        branch_prefix: &str,
     ) -> Result<String> {
-        let path =
-            super::create_worktree_from_base(project_path, task_slug, base_branch, worktree_dir)?;
+        let path = super::create_worktree_with_prefix(
+            project_path,
+            task_slug,
+            base_branch,
+            worktree_dir,
+            branch_prefix,
+        )?;
         Ok(path.to_string_lossy().to_string())
     }
 

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -18,6 +18,17 @@ pub fn create_worktree_from_base(
     base_branch: &str,
     worktree_dir: &str,
 ) -> Result<PathBuf> {
+    create_worktree_with_prefix(project_path, task_slug, base_branch, worktree_dir, "task")
+}
+
+/// Create a new git worktree for a task with a configurable branch prefix.
+pub fn create_worktree_with_prefix(
+    project_path: &Path,
+    task_slug: &str,
+    base_branch: &str,
+    worktree_dir: &str,
+    branch_prefix: &str,
+) -> Result<PathBuf> {
     let worktree_path = project_path
         .join(worktree_dir)
         .join(task_slug);
@@ -40,7 +51,7 @@ pub fn create_worktree_from_base(
     let base_branch = resolve_base_branch(project_path, base_branch)?;
 
     // Create worktree with a new branch based on the requested base branch
-    let branch_name = format!("task/{}", task_slug);
+    let branch_name = format!("{}/{}", branch_prefix, task_slug);
 
     // First, try to delete the branch if it exists (from a previous failed attempt)
     let _ = Command::new("git")

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4538,6 +4538,7 @@ impl App {
             .clone()
             .unwrap_or_else(|| self.state.config.base_branch.clone());
         let worktree_dir = self.state.config.worktree_dir.clone();
+        let branch_prefix = self.state.config.branch_prefix.clone();
         let copy_files = self.state.config.copy_files.clone();
         let init_script = if self.state.flags.no_init_scripts {
             None
@@ -4595,6 +4596,7 @@ impl App {
                 &prompt,
                 &base_branch,
                 &worktree_dir,
+                &branch_prefix,
                 copy_files,
                 init_script,
                 &plugin,
@@ -4904,6 +4906,7 @@ impl App {
             .clone()
             .unwrap_or_else(|| self.state.config.base_branch.clone());
         let worktree_dir = self.state.config.worktree_dir.clone();
+        let branch_prefix = self.state.config.branch_prefix.clone();
         let copy_files = self.state.config.copy_files.clone();
         let init_script = if self.state.flags.no_init_scripts {
             None
@@ -4941,6 +4944,7 @@ impl App {
                 "",
                 &base_branch,
                 &worktree_dir,
+                &branch_prefix,
                 copy_files,
                 init_script,
                 &plugin,
@@ -5163,6 +5167,7 @@ impl App {
             .clone()
             .unwrap_or_else(|| self.state.config.base_branch.clone());
         let worktree_dir = self.state.config.worktree_dir.clone();
+        let branch_prefix = self.state.config.branch_prefix.clone();
         let copy_files = self.state.config.copy_files.clone();
         let init_script = if self.state.flags.no_init_scripts {
             None
@@ -5192,6 +5197,7 @@ impl App {
                 &prompt,
                 &base_branch,
                 &worktree_dir,
+                &branch_prefix,
                 copy_files,
                 init_script,
                 &plugin,
@@ -6754,7 +6760,7 @@ fn cleanup_task_for_done(
             let slug = task
                 .branch_name
                 .as_deref()
-                .and_then(|b| b.strip_prefix("task/"))
+                .and_then(|b| b.rsplit_once('/').map(|(_, s)| s))
                 .unwrap_or(&task.id);
             let archive_dir = project_path.join(".agtx").join("archive").join(slug);
             if let Ok(()) = std::fs::create_dir_all(&archive_dir) {
@@ -6802,7 +6808,7 @@ fn cleanup_task_resources(
         if artifacts_dir.exists() {
             let slug = branch_name
                 .as_deref()
-                .and_then(|b| b.strip_prefix("task/"))
+                .and_then(|b| b.rsplit_once('/').map(|(_, s)| s))
                 .unwrap_or(task_id);
             let archive_dir = project_path.join(".agtx").join("archive").join(slug);
             if let Ok(()) = std::fs::create_dir_all(&archive_dir) {
@@ -6842,6 +6848,7 @@ fn setup_task_worktree(
     prompt: &str,
     base_branch: &str,
     worktree_dir: &str,
+    branch_prefix: &str,
     copy_files: Option<String>,
     init_script: Option<String>,
     plugin: &Option<WorkflowPlugin>,
@@ -6859,7 +6866,7 @@ fn setup_task_worktree(
 
     // Create git worktree from the configured base branch
     let worktree_path_str =
-        match git_ops.create_worktree(project_path, &unique_slug, base_branch, worktree_dir) {
+        match git_ops.create_worktree(project_path, &unique_slug, base_branch, worktree_dir, branch_prefix) {
             Ok(path) => path,
             Err(e) => {
                 eprintln!("Failed to create worktree: {}", e);
@@ -7013,7 +7020,7 @@ fn setup_task_worktree(
 
     task.session_name = Some(target.clone());
     task.worktree_path = Some(worktree_path_str);
-    task.branch_name = Some(format!("task/{}", unique_slug));
+    task.branch_name = Some(format!("{}/{}", branch_prefix, unique_slug));
 
     Ok(target)
 }

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -1506,7 +1506,7 @@ fn test_setup_task_worktree_success() {
     // Expect worktree creation
     mock_git
         .expect_create_worktree()
-        .returning(|_, slug, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
+        .returning(|_, slug, _, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
 
     // Expect worktree initialization
     mock_git
@@ -1535,6 +1535,7 @@ fn test_setup_task_worktree_success() {
         "implement this",
         "main",
         ".agtx/worktrees",
+        "task",
         None,
         None,
         &None,
@@ -1568,7 +1569,7 @@ fn test_setup_task_worktree_sets_task_fields() {
 
     mock_git
         .expect_create_worktree()
-        .returning(|_, slug, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
+        .returning(|_, slug, _, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
     mock_git
         .expect_initialize_worktree()
         .returning(|_, _, _, _, _| vec![]);
@@ -1589,6 +1590,7 @@ fn test_setup_task_worktree_sets_task_fields() {
         "fix the bug",
         "main",
         ".agtx/worktrees",
+        "task",
         Some("CLAUDE.md".to_string()),
         Some("./init.sh".to_string()),
         &None,
@@ -1610,8 +1612,8 @@ fn test_setup_task_worktree_sets_task_fields() {
         .as_ref()
         .unwrap()
         .contains(".agtx/worktrees/"));
-    // branch_name should be task/{slug}
-    let slug = &task.branch_name.as_ref().unwrap()["task/".len()..];
+    // branch_name should be {prefix}/{slug}
+    let slug = task.branch_name.as_ref().unwrap().rsplit_once('/').unwrap().1;
     assert!(task.worktree_path.as_ref().unwrap().ends_with(slug));
 }
 
@@ -1628,7 +1630,7 @@ fn test_setup_task_worktree_worktree_creation_fails() {
     // Worktree creation fails
     mock_git
         .expect_create_worktree()
-        .returning(|_, _, _, _| Err(anyhow::anyhow!("worktree already exists")));
+        .returning(|_, _, _, _, _| Err(anyhow::anyhow!("worktree already exists")));
 
     // Should still initialize and create window with fallback path
     mock_git
@@ -1651,6 +1653,7 @@ fn test_setup_task_worktree_worktree_creation_fails() {
         "do something",
         "main",
         ".agtx/worktrees",
+        "task",
         None,
         None,
         &None,
@@ -1685,7 +1688,7 @@ fn test_setup_task_worktree_tmux_window_fails() {
 
     mock_git
         .expect_create_worktree()
-        .returning(|_, slug, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
+        .returning(|_, slug, _, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
     mock_git
         .expect_initialize_worktree()
         .returning(|_, _, _, _, _| vec![]);
@@ -1708,6 +1711,7 @@ fn test_setup_task_worktree_tmux_window_fails() {
         "do something",
         "main",
         ".agtx/worktrees",
+        "task",
         None,
         None,
         &None,
@@ -1737,7 +1741,7 @@ fn test_setup_task_worktree_creates_session_when_missing() {
 
     mock_git
         .expect_create_worktree()
-        .returning(|_, slug, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
+        .returning(|_, slug, _, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
     mock_git
         .expect_initialize_worktree()
         .returning(|_, _, _, _, _| vec![]);
@@ -1761,6 +1765,7 @@ fn test_setup_task_worktree_creates_session_when_missing() {
         "do work",
         "main",
         ".agtx/worktrees",
+        "task",
         None,
         None,
         &None,
@@ -1788,8 +1793,8 @@ fn test_setup_task_worktree_passes_init_config() {
 
     mock_git
         .expect_create_worktree()
-        .withf(|_, _, base_branch, _| base_branch == "development")
-        .returning(|_, slug, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
+        .withf(|_, _, base_branch, _, _| base_branch == "development")
+        .returning(|_, slug, _, _, _| Ok(format!("/project/.agtx/worktrees/{}", slug)));
 
     // Verify copy_files and init_script are passed through
     mock_git
@@ -1817,6 +1822,7 @@ fn test_setup_task_worktree_passes_init_config() {
         "implement feature",
         "development",
         ".agtx/worktrees",
+        "task",
         Some("CLAUDE.md,.env".to_string()),
         Some("./setup.sh".to_string()),
         &None,

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -112,6 +112,7 @@ fn test_merged_config_project_overrides() {
         copy_files: Some(".env, .env.local".to_string()),
         init_script: Some("npm install".to_string()),
         cleanup_script: Some("scripts/cleanup.sh".to_string()),
+        branch_prefix: None,
         workflow_plugin: None,
     };
 
@@ -127,6 +128,8 @@ fn test_merged_config_project_overrides() {
     assert_eq!(merged.init_script, Some("npm install".to_string()));
     // worktree_dir not overridden, uses global default
     assert_eq!(merged.worktree_dir, ".agtx/worktrees");
+    // branch_prefix not overridden, uses global default
+    assert_eq!(merged.branch_prefix, "task");
     assert_eq!(
         merged.cleanup_script,
         Some("scripts/cleanup.sh".to_string())


### PR DESCRIPTION
## Summary
- Add `branch_prefix` config field (default `"task"`) to replace the hardcoded `task/` prefix in worktree branch names
- Configurable globally via `[worktree] branch_prefix = "user/pablospe"` or per-project override
- Fix archive slug extraction to use `rsplit_once('/')` so any prefix depth works (e.g. `user/pablospe/slug`)

## Test plan
- [x] All 657 tests pass (`cargo test --features test-mocks`)
- [x] Build clean (`cargo build`)
- [ ] Manual: set `branch_prefix = "custom"` in config.toml, create a task, verify branch is `custom/{slug}`
- [ ] Manual: verify archive still works with custom prefix on Done transition