### PR TITLE
feat: add Docker sandbox for isolated agent execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,28 @@ tmux -L agtx attach
 - **Worktrees**: `.agtx/worktrees/` in each project
 - **Tmux**: Dedicated server `agtx` with per-project sessions
 
+## Docker Sandbox
+
+Run agtx in an isolated Docker container so agents can only touch the project you pass in — no access to the rest of your home directory, credentials are read-only, and any files the agent creates in the project are owned by your host user.
+
+```bash
+# Run agtx on a project
+./docker/sandbox.sh path/to/your-project
+
+# Or from inside the project directory
+./docker/sandbox.sh
+```
+
+The sandbox:
+- Mounts only the target project as writable; everything else on the host is inaccessible
+- Copies `~/.claude` credentials read-only at startup so they are never written back to the host
+- Runs as a non-root user whose UID/GID matches your host user (files created inside the container appear correctly owned on the host)
+- Stores agtx state in named Docker volumes (persists across runs, isolated from your host's agtx data)
+- Pre-accepts the bypass permissions prompt, which is appropriate in an isolated container
+
+> [!NOTE]
+> Requires [Docker Engine](https://docs.docker.com/engine/install/) (Linux) or [Docker Desktop](https://docs.docker.com/desktop/) (macOS/Windows). The image is built automatically on first run and cached for subsequent runs.
+
 ## MCP Server
 
 The agtx MCP server (`agtx mcp-serve`) exposes the board to any coding agent session via the [Model Context Protocol](https://modelcontextprotocol.io). Used by the orchestrator agent and the brainstorm & sweep skills.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG NODE_MAJOR=22
+
+# System dependencies + Node.js via NodeSource (handles arch automatically)
+RUN apt-get update && apt-get install -y \
+    curl git tmux ca-certificates \
+    && curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code globally
+RUN npm install -g @anthropic-ai/claude-code
+
+# Install agtx
+RUN curl -fsSL https://raw.githubusercontent.com/fynnfluegge/agtx/main/install.sh \
+    | AGTX_INSTALL_DIR=/usr/local/bin bash
+
+# Non-root user — UID/GID match the host user so bind-mounted files stay correctly owned
+ARG UID=1000
+ARG GID=1000
+RUN userdel -r ubuntu 2>/dev/null || true && \
+    groupdel ubuntu 2>/dev/null || true && \
+    groupadd -g "${GID}" sandbox && \
+    useradd -m -u "${UID}" -g "${GID}" -s /bin/bash sandbox
+
+COPY --chown=root:root entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER sandbox
+WORKDIR /home/sandbox
+
+# Create agtx dirs as sandbox user so named volume mounts inherit correct ownership
+RUN mkdir -p \
+    /home/sandbox/.config/agtx \
+    /home/sandbox/.local/share/agtx \
+    /home/sandbox/.claude
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["agtx"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# Copy host ~/.claude credentials into the writable sandbox home at startup.
+# The host directory is mounted read-only at /claude-host so Claude Code can
+# read credentials without the container ever writing back to the host.
+if [ -d /claude-host ]; then
+    cp -rp /claude-host/. /home/sandbox/.claude/ 2>/dev/null || true
+fi
+
+# Pre-accept the bypass permissions prompt — appropriate because we are inside
+# an isolated container with no access to the host filesystem beyond the
+# project directory.
+settings=/home/sandbox/.claude/settings.json
+if [ -f "$settings" ]; then
+    node -e "
+        const fs = require('fs');
+        const s = JSON.parse(fs.readFileSync('$settings', 'utf8'));
+        s.skipDangerousModePermissionPrompt = true;
+        fs.writeFileSync('$settings', JSON.stringify(s, null, 2));
+    "
+else
+    echo '{"skipDangerousModePermissionPrompt":true}' > "$settings"
+fi
+
+exec "$@"

--- a/docker/sandbox.sh
+++ b/docker/sandbox.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -e
+
+# agtx Docker sandbox
+# Usage: ./docker/sandbox.sh [path/to/project]  (defaults to current directory)
+
+DOCKER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}==>${NC} $1"; }
+success() { echo -e "${GREEN}==>${NC} $1"; }
+warn()    { echo -e "${YELLOW}==>${NC} $1"; }
+error()   { echo -e "${RED}==>${NC} $1"; exit 1; }
+
+# Resolve project path portably (realpath not available on all macOS versions)
+resolve_path() {
+    cd "$1" && pwd -P
+}
+
+# Checks
+if ! command -v docker &>/dev/null; then
+    error "docker not found — install Docker Desktop (macOS/Windows) or Docker Engine (Linux)"
+fi
+
+RAW_PROJECT="${1:-$(pwd)}"
+
+if [ ! -d "$RAW_PROJECT" ]; then
+    error "Directory not found: $RAW_PROJECT"
+fi
+
+PROJECT="$(resolve_path "$RAW_PROJECT")"
+
+echo ""
+echo "  ╭──────────────────────────────────────────╮"
+echo "  │           agtx docker sandbox            │"
+echo "  ╰──────────────────────────────────────────╯"
+echo ""
+
+info "Project : $PROJECT"
+info "User    : sandbox (non-root, uid=$(id -u))"
+
+if [ ! -d "$PROJECT/.git" ]; then
+    warn "$PROJECT is not a git repository"
+    read -rp "  Continue anyway? [y/N] " ans
+    [[ "$ans" =~ ^[Yy]$ ]] || exit 0
+    echo ""
+fi
+
+# Build image with host UID/GID so files created in the container are owned correctly
+info "Building image..."
+docker build -q \
+    --build-arg UID="$(id -u)" \
+    --build-arg GID="$(id -g)" \
+    -t agtx-sandbox \
+    "$DOCKER_DIR"
+
+success "Image ready"
+echo ""
+
+# agtx state lives in named volumes — isolated from the host, persists across runs
+exec docker run --rm -it \
+    --security-opt no-new-privileges:true \
+    --cap-drop ALL \
+    --cap-add CHOWN \
+    --cap-add DAC_OVERRIDE \
+    --cap-add SETUID \
+    --cap-add SETGID \
+    -v "${PROJECT}:/home/sandbox/workspace" \
+    -v agtx-data:/home/sandbox/.local/share/agtx \
+    -v agtx-config:/home/sandbox/.config/agtx \
+    -v "${HOME}/.claude:/claude-host:ro" \
+    -w /home/sandbox/workspace \
+    agtx-sandbox \
+    agtx /home/sandbox/workspace


### PR DESCRIPTION
## Summary

Adds a `docker/` directory with everything needed to run agtx in an isolated container, addressing the security concern raised in #106.

- **`docker/Dockerfile`** — Ubuntu 24.04 + Node.js 22 LTS (via NodeSource, multi-arch) + Claude Code + agtx. Non-root `sandbox` user whose UID/GID matches the host user at build time.
- **`docker/entrypoint.sh`** — Copies `~/.claude` credentials read-only into the container home at startup; pre-accepts the bypass permissions prompt (appropriate in an isolated container).
- **`docker/sandbox.sh`** — Launch script. Builds the image, then runs the container with only the target project mounted writable. agtx state lives in named Docker volumes (isolated from the host, persists across runs).

## Isolation model

| Surface | Treatment |
|---|---|
| Project directory | Bind-mounted writable — agent can read/write freely |
| `~/.claude` credentials | Mounted read-only, copied to isolated home — never written back to host |
| Rest of host filesystem | Not mounted — inaccessible to the agent |
| agtx state (DB, config) | Named Docker volumes — isolated from host's agtx data |
| File ownership | Container user UID/GID matches host user — files created inside appear correctly owned on host |

## Usage

```bash
# From the repo root
./docker/sandbox.sh path/to/your-project

# Or from inside the project
./docker/sandbox.sh
```

Requires Docker Engine (Linux) or Docker Desktop (macOS/Windows). Image is built on first run and cached.

Closes #106