### PR TITLE
feat(tui): surface custom plugins in board and wizard pickers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,8 @@ Phase gating is derived from the config: if a phase's command or prompt contains
 
 Plugin resolution: project-local `.agtx/plugins/{name}/` → global `~/.config/agtx/plugins/{name}/` → bundled. `load_task_plugin` falls back to bundled plugins when disk load fails, so tasks always resolve their plugin correctly even if the on-disk copy is missing.
 
+Plugin discovery for pickers: `discover_custom_plugins` (in `src/skills.rs`) scans the global then project-local plugins directories and surfaces on-disk plugins alongside `BUNDLED_PLUGINS` in both the board selector (`P`) and the task creation wizard. Project-local plugins shadow global ones by name; names colliding with a bundled plugin are skipped (the bundled entry already represents them, and `load` resolves the on-disk copy). Both pickers filter discovered plugins by `supported_agents` against the default agent.
+
 Each task stores its plugin name explicitly in the database at creation time (e.g. `Some("agtx")`, `Some("gsd")`). Switching the project plugin only affects new tasks.
 
 ### Skill System

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -581,27 +581,36 @@ impl WorkflowPlugin {
         Ok(())
     }
 
+    /// Directory holding global (user-level) plugins: `~/.config/agtx/plugins`.
+    pub fn global_plugins_dir() -> Option<PathBuf> {
+        let home = std::env::var("HOME").ok()?;
+        Some(
+            PathBuf::from(home)
+                .join(".config")
+                .join("agtx")
+                .join("plugins"),
+        )
+    }
+
+    /// Directory holding a project's local plugins: `{project}/.agtx/plugins`.
+    pub fn project_plugins_dir(project_path: &Path) -> PathBuf {
+        project_path.join(".agtx").join("plugins")
+    }
+
     /// Load a plugin by name, checking project-local then global directories
     pub fn load(name: &str, project_path: Option<&Path>) -> Result<Self> {
         Self::validate_plugin_name(name)?;
         // 1. Check project-local
         if let Some(pp) = project_path {
-            let local_path = pp
-                .join(".agtx")
-                .join("plugins")
-                .join(name)
-                .join("plugin.toml");
+            let local_path = Self::project_plugins_dir(pp).join(name).join("plugin.toml");
             if local_path.exists() {
                 let content = std::fs::read_to_string(&local_path)?;
                 return toml::from_str(&content).context("Failed to parse plugin.toml");
             }
         }
         // 2. Check global
-        let home = std::env::var("HOME").context("Could not determine home directory")?;
-        let global_path = PathBuf::from(home)
-            .join(".config")
-            .join("agtx")
-            .join("plugins")
+        let global_path = Self::global_plugins_dir()
+            .context("Could not determine home directory")?
             .join(name)
             .join("plugin.toml");
         if global_path.exists() {
@@ -618,17 +627,12 @@ impl WorkflowPlugin {
         }
         // Same lookup order: project-local first, then global
         if let Some(pp) = project_path {
-            let local = pp.join(".agtx").join("plugins").join(name);
+            let local = Self::project_plugins_dir(pp).join(name);
             if local.join("plugin.toml").exists() {
                 return Some(local);
             }
         }
-        let home = std::env::var("HOME").ok()?;
-        let global = PathBuf::from(home)
-            .join(".config")
-            .join("agtx")
-            .join("plugins")
-            .join(name);
+        let global = Self::global_plugins_dir()?.join(name);
         if global.join("plugin.toml").exists() {
             return Some(global);
         }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -28,6 +28,78 @@ pub fn load_bundled_plugin(name: &str) -> Option<crate::config::WorkflowPlugin> 
         .and_then(|(_, _, content)| toml::from_str(content).ok())
 }
 
+/// A custom (on-disk) workflow plugin discovered in a plugins directory.
+pub struct CustomPlugin {
+    pub name: String,
+    pub description: String,
+    pub plugin: crate::config::WorkflowPlugin,
+}
+
+/// Discover custom plugins on disk that are not shipped as bundled plugins.
+///
+/// Scans the global plugins directory (`~/.config/agtx/plugins/`) then the
+/// project-local one (`{project}/.agtx/plugins/`). A project-local plugin
+/// shadows a global one of the same name, matching [`crate::config::WorkflowPlugin::load`].
+/// Names matching a bundled plugin are skipped: the bundled entry already
+/// represents them in pickers, and `load` resolves the on-disk copy transparently.
+pub fn discover_custom_plugins(project_path: Option<&std::path::Path>) -> Vec<CustomPlugin> {
+    use crate::config::WorkflowPlugin;
+    let mut dirs: Vec<std::path::PathBuf> = Vec::new();
+    if let Some(dir) = WorkflowPlugin::global_plugins_dir() {
+        dirs.push(dir);
+    }
+    if let Some(pp) = project_path {
+        dirs.push(WorkflowPlugin::project_plugins_dir(pp));
+    }
+    discover_custom_plugins_in(&dirs)
+}
+
+/// Discover custom plugins across the given plugins directories, in order of
+/// increasing precedence (later directories shadow earlier ones by name).
+fn discover_custom_plugins_in(dirs: &[std::path::PathBuf]) -> Vec<CustomPlugin> {
+    use std::collections::BTreeMap;
+    let mut found: BTreeMap<String, CustomPlugin> = BTreeMap::new();
+    for dir in dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if BUNDLED_PLUGINS.iter().any(|(n, _, _)| *n == name) {
+                continue;
+            }
+            if crate::config::WorkflowPlugin::validate_plugin_name(name).is_err() {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(path.join("plugin.toml")) else {
+                continue;
+            };
+            let Ok(plugin) = toml::from_str::<crate::config::WorkflowPlugin>(&content) else {
+                continue;
+            };
+            let description = plugin
+                .description
+                .clone()
+                .unwrap_or_else(|| "Custom workflow plugin".to_string());
+            found.insert(
+                name.to_string(),
+                CustomPlugin {
+                    name: name.to_string(),
+                    description,
+                    plugin,
+                },
+            );
+        }
+    }
+    found.into_values().collect()
+}
+
 /// Agent-native command/skill directory paths.
 /// Returns (base_dir_relative_to_worktree, namespace_subdir) or None if agent has no native discovery.
 /// Returns (base_dir_relative_to_worktree, namespace_subdir) or None if agent has no native discovery.
@@ -405,4 +477,103 @@ pub fn scan_agent_skills(
 
     results.sort_by(|a, b| a.0.cmp(&b.0));
     results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn write_plugin(dir: &std::path::Path, name: &str, body: &str) {
+        let plugin_dir = dir.join(name);
+        fs::create_dir_all(&plugin_dir).unwrap();
+        let content = format!("name = \"{}\"\n{}", name, body);
+        fs::write(plugin_dir.join("plugin.toml"), content).unwrap();
+    }
+
+    #[test]
+    fn discovers_custom_plugin_with_description() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin(tmp.path(), "my-flow", "description = \"My custom flow\"\n");
+
+        let found = discover_custom_plugins_in(&[tmp.path().to_path_buf()]);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "my-flow");
+        assert_eq!(found[0].description, "My custom flow");
+    }
+
+    #[test]
+    fn falls_back_to_default_description_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin(tmp.path(), "no-desc", "");
+
+        let found = discover_custom_plugins_in(&[tmp.path().to_path_buf()]);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].description, "Custom workflow plugin");
+    }
+
+    #[test]
+    fn skips_names_colliding_with_bundled_plugins() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin(tmp.path(), "gsd", "description = \"shadow\"\n");
+        write_plugin(tmp.path(), "mine", "description = \"mine\"\n");
+
+        let found = discover_custom_plugins_in(&[tmp.path().to_path_buf()]);
+        let names: Vec<&str> = found.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["mine"]);
+    }
+
+    #[test]
+    fn ignores_dirs_without_plugin_toml_and_invalid_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("empty-dir")).unwrap();
+        fs::write(tmp.path().join("loose-file.toml"), "x").unwrap();
+        write_plugin(tmp.path(), "valid", "description = \"ok\"\n");
+
+        let found = discover_custom_plugins_in(&[tmp.path().to_path_buf()]);
+        let names: Vec<&str> = found.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["valid"]);
+    }
+
+    #[test]
+    fn project_local_shadows_global_by_name() {
+        let global = tempfile::tempdir().unwrap();
+        let local = tempfile::tempdir().unwrap();
+        write_plugin(global.path(), "shared", "description = \"global\"\n");
+        write_plugin(local.path(), "shared", "description = \"local\"\n");
+
+        let dirs: Vec<PathBuf> = vec![global.path().to_path_buf(), local.path().to_path_buf()];
+        let found = discover_custom_plugins_in(&dirs);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].description, "local");
+    }
+
+    #[test]
+    fn skips_bundled_name_in_global_keeps_local_custom() {
+        let global = tempfile::tempdir().unwrap();
+        let local = tempfile::tempdir().unwrap();
+        write_plugin(global.path(), "gsd", "description = \"shadow\"\n");
+        write_plugin(local.path(), "mine", "description = \"mine\"\n");
+
+        let dirs: Vec<PathBuf> = vec![global.path().to_path_buf(), local.path().to_path_buf()];
+        let found = discover_custom_plugins_in(&dirs);
+        let names: Vec<&str> = found.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["mine"]);
+    }
+
+    #[test]
+    fn discovered_plugin_carries_supported_agents_for_wizard_filter() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin(
+            tmp.path(),
+            "claude-only",
+            "description = \"c\"\nsupported_agents = [\"claude\"]\n",
+        );
+
+        let found = discover_custom_plugins_in(&[tmp.path().to_path_buf()]);
+        assert_eq!(found.len(), 1);
+        assert!(found[0].plugin.supports_agent("claude"));
+        assert!(!found[0].plugin.supports_agent("codex"));
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2789,6 +2789,18 @@ impl App {
                 active: current == *name,
             });
         }
+        let agent_name = &self.state.config.default_agent;
+        for custom in skills::discover_custom_plugins(self.state.project_path.as_deref()) {
+            if !custom.plugin.supports_agent(agent_name) {
+                continue;
+            }
+            options.push(PluginOption {
+                name: custom.name.clone(),
+                label: custom.name.clone(),
+                description: custom.description,
+                active: current == custom.name,
+            });
+        }
         let selected = options.iter().position(|o| o.active).unwrap_or(0);
         self.state.plugin_select_popup = Some(PluginSelectPopup { selected, options });
     }
@@ -4261,6 +4273,17 @@ impl App {
                 label: name.to_string(),
                 description: desc.to_string(),
                 active: current == *name,
+            });
+        }
+        for custom in skills::discover_custom_plugins(self.state.project_path.as_deref()) {
+            if !custom.plugin.supports_agent(selected_agent_name) {
+                continue;
+            }
+            options.push(PluginOption {
+                name: custom.name.clone(),
+                label: custom.name.clone(),
+                description: custom.description,
+                active: current == custom.name,
             });
         }
         let selected = options.iter().position(|o| o.active).unwrap_or(0);


### PR DESCRIPTION
## Problem

Custom plugins placed in `.agtx/plugins/{name}/` or `~/.config/agtx/plugins/{name}/` were already loadable by name (via the project-local → global → bundled fallback in `WorkflowPlugin::load`), but nothing enumerated them. They never appeared in either picker, so they only worked if you hand-edited `workflow_plugin` in config.

## Change

Adds `discover_custom_plugins` (in `src/skills.rs`) to scan both plugin directories and merge on-disk plugins into the board selector (`P`) and the task creation wizard, alongside the bundled set.

- Project-local plugins shadow global ones by name.
- Names colliding with a bundled plugin are skipped — the bundled entry already represents them, and `load` still resolves the on-disk copy.
- Both pickers filter discovered plugins by `supported_agents` against the default agent, so a custom plugin locked to a different agent can't be selected and then silently downgraded to `agtx` in the wizard.

Also extracts `WorkflowPlugin::global_plugins_dir`/`project_plugins_dir` so the plugin-dir layout is single-sourced across `load`, `plugin_dir`, and the new discovery path instead of duplicated.

No schema or DB changes — tasks already store the plugin name as a free string. Loading and resolution are untouched.

## Tests

`cargo test --features test-mocks` — 722 pass. Adds 7 unit tests for discovery: description handling + fallback, bundled-name collision skip (single- and two-dir), invalid-name/missing-toml filtering, project-shadows-global, and that discovered plugins carry `supported_agents` through for the picker filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)