### PR TITLE
fix(bmad): use --yes for bmad install

### DIFF
--- a/plugins/bmad/plugin.toml
+++ b/plugins/bmad/plugin.toml
@@ -1,6 +1,6 @@
 name = "bmad"
 description = "BMAD Method - AI-driven agile development with structured phases"
-init_script = "npx bmad-method install --non-interactive"
+init_script = "npx bmad-method install --yes"
 copy_dirs = ["_bmad", "_bmad-output"]
 
 [artifacts]


### PR DESCRIPTION
## Summary

- replace the removed `--non-interactive` flag in the BMAD install command
- use `--yes` to keep the install step non-blocking in worktrees