### PR TITLE
fix(codex): replace --full-auto with workspace-write sandbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,7 @@ Plugin defaults to the project's active plugin (set via `P` on the board).
 
 ### Agent Integration
 - Agents spawned via `build_interactive_command()` in `src/agent/mod.rs`
-- Each agent has its own flags: Claude (`--dangerously-skip-permissions`), Codex (`--full-auto`), Gemini (`--approval-mode yolo`), Copilot (`--allow-all-tools`)
+- Each agent has its own flags: Claude (`--dangerously-skip-permissions`), Codex (`--sandbox workspace-write`), Gemini (`--approval-mode yolo`), Copilot (`--allow-all-tools`)
 - Skills deployed to agent-native paths via `write_skills_to_worktree()` in app.rs
 - Commands resolved per-task via `resolve_skill_command()` (plugin command + agent transform)
 - Prompts resolved per-task via `resolve_prompt()` (pure template substitution, agent-agnostic)

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -54,7 +54,7 @@ impl Agent {
         if prompt.is_empty() {
             return match self.name.as_str() {
                 "claude" => "claude --dangerously-skip-permissions".to_string(),
-                "codex" => "codex --full-auto".to_string(),
+                "codex" => "codex --sandbox workspace-write".to_string(),
                 "copilot" => "copilot --allow-all-tools".to_string(),
                 "gemini" => "GEMINI_TRUST_WORKSPACE=true gemini --approval-mode yolo".to_string(),
                 "opencode" => "opencode".to_string(),
@@ -66,7 +66,7 @@ impl Agent {
         let escaped_prompt = prompt.replace('\'', "'\"'\"'");
         match self.name.as_str() {
             "claude" => format!("claude --dangerously-skip-permissions '{}'", escaped_prompt),
-            "codex" => format!("codex --full-auto '{}'", escaped_prompt),
+            "codex" => format!("codex --sandbox workspace-write '{}'", escaped_prompt),
             "copilot" => format!("copilot --allow-all-tools -p '{}'", escaped_prompt),
             "gemini" => format!("GEMINI_TRUST_WORKSPACE=true gemini --approval-mode yolo -i '{}'", escaped_prompt),
             "opencode" => format!("opencode -p '{}'", escaped_prompt),

--- a/src/agent/operations.rs
+++ b/src/agent/operations.rs
@@ -57,7 +57,7 @@ impl AgentOperations for CodingAgent {
         // Build the command based on agent type
         let (cmd, args) = match self.agent.name.as_str() {
             "claude" => ("claude", vec!["--print", prompt]),
-            "codex" => ("codex", vec!["exec", "--full-auto", prompt]),
+            "codex" => ("codex", vec!["exec", "--sandbox", "workspace-write", prompt]),
             "copilot" => ("copilot", vec!["-p", prompt]),
             "gemini" => ("gemini", vec!["-p", prompt]),
             "cursor" => ("agent", vec!["--print", "--yolo", prompt]),

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -8850,11 +8850,11 @@ fn test_switch_agent_codex_sends_ctrl_c_not_exit() {
         .returning(|_| Ok(String::new()));
     mock_tmux
         .expect_send_keys()
-        .withf(|_, cmd: &str| cmd == "env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT codex --full-auto")
+        .withf(|_, cmd: &str| cmd == "env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT codex --sandbox workspace-write")
         .times(1)
         .returning(|_, _| Ok(()));
 
-    switch_agent_in_tmux(&mock_tmux, "proj:task", "codex", "codex --full-auto");
+    switch_agent_in_tmux(&mock_tmux, "proj:task", "codex", "codex --sandbox workspace-write");
 }
 
 #[test]

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -101,7 +101,7 @@ fn test_build_interactive_command_existing_agents_unchanged() {
     );
     assert_eq!(
         by_name("codex").build_interactive_command(""),
-        "codex --full-auto"
+        "codex --sandbox workspace-write"
     );
     assert_eq!(
         by_name("gemini").build_interactive_command(""),


### PR DESCRIPTION
## Summary

- Replace Codex `--full-auto` invocation with `--sandbox workspace-write` (`full-auto` deprecated and not recognized as a valid flag in the latest `codex` cli): https://developers.openai.com/codex/cli/reference#codex-exec
- Update docs and tests to match the new Codex command