### PR TITLE
fix(orchestrator): start reliably by fixing MCP registration quoting and name

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,9 @@
 {
-  "agtx": {
-    "type": "stdio",
-    "command": "agtx",
-    "args": ["mcp-serve"]
+  "mcpServers": {
+    "agtx": {
+      "type": "stdio",
+      "command": "agtx",
+      "args": ["mcp-serve"]
+    }
   }
 }

--- a/src/agent/operations.rs
+++ b/src/agent/operations.rs
@@ -91,13 +91,28 @@ impl AgentOperations for CodingAgent {
 
     fn build_orchestrator_command(&self, mcp_json: &str, _agtx_bin: &str) -> String {
         match self.agent.name.as_str() {
-            // Pre-remove any stale `agtx` registration (last run crashed before
-            // its own `mcp remove`) so `add-json` doesn't fail with "already
-            // exists" and short-circuit the `&&` into an empty shell.
+            // Register under a unique name (`agtx-orchestrator`) rather than
+            // `agtx` to avoid colliding with an `agtx` server already defined in
+            // another scope (the Claude Code plugin's `plugin:agtx:agtx`, a
+            // user-scope entry in ~/.claude.json, or the repo's .mcp.json).
+            // A same-named server across scopes with different endpoints makes
+            // Claude Code report a configuration conflict and refuse to connect.
+            //
+            // Pre-remove any stale registration (last run crashed before its own
+            // `mcp remove`) so `add-json` doesn't fail with "already exists" and
+            // short-circuit the `&&` into an empty shell.
+            //
+            // The JSON must be single-quoted for `add-json`, but this whole
+            // command is itself wrapped in `sh -c '...'` by create_window. A bare
+            // `'{json}'` would close that outer quote and let the shell mangle the
+            // JSON (yielding "Invalid configuration: Invalid input"). Escape the
+            // wrapping quotes as `'\''` (the POSIX single-quote-in-single-quote
+            // idiom, same convention build_interactive_command uses for prompts)
+            // so they survive the outer `sh -c` layer intact.
             "claude" => format!(
-                "claude mcp remove agtx --scope local 2>/dev/null || true; \
-                 claude mcp add-json agtx '{}' --scope local && {}; \
-                 claude mcp remove agtx --scope local",
+                "claude mcp remove agtx-orchestrator --scope local 2>/dev/null || true; \
+                 claude mcp add-json agtx-orchestrator '\\''{}'\\'' --scope local && {}; \
+                 claude mcp remove agtx-orchestrator --scope local",
                 mcp_json,
                 self.build_interactive_command("")
             ),

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -166,12 +166,28 @@ fn test_build_orchestrator_command_claude_is_idempotent() {
     let cmd = ops.build_orchestrator_command("{\"type\":\"stdio\"}", "/usr/bin/agtx");
 
     let pre_remove_idx = cmd
-        .find("claude mcp remove agtx")
+        .find("claude mcp remove agtx-orchestrator")
         .expect("pre-remove stale registration");
     let add_idx = cmd
-        .find("claude mcp add-json agtx")
+        .find("claude mcp add-json agtx-orchestrator")
         .expect("register MCP");
     assert!(pre_remove_idx < add_idx, "pre-remove must precede add-json:\n{cmd}");
+
+    // Must NOT register under the bare `agtx` name: that collides with an `agtx`
+    // server defined in another scope (plugin / user / .mcp.json) and makes
+    // Claude Code report a configuration conflict and refuse to connect.
+    assert!(
+        !cmd.contains("add-json agtx "),
+        "must register under a unique name, not bare `agtx`:\n{cmd}"
+    );
+
+    // The JSON's wrapping single quotes must be escaped (`'\''`) so the command
+    // survives create_window's outer `sh -c '...'` layer. A bare `'{json}'` would
+    // break out of that wrapper and mangle the JSON.
+    assert!(
+        cmd.contains(r"'\''"),
+        "JSON quotes must be escaped for the outer sh -c wrapper:\n{cmd}"
+    );
 
     let pre_section = &cmd[..add_idx];
     assert!(


### PR DESCRIPTION
## Summary

The experimental orchestrator agent (`agtx --experimental`, toggled with `O`) failed to start: it showed **`Invalid configuration: Invalid input`** and the orchestrator tmux window died immediately. This PR fixes the three independent issues responsible.

## Root causes & fixes

### 1. Shell quoting collision — the actual blocker
`create_window` ([`src/tmux/operations.rs`](https://github.com/fynnfluegge/agtx/blob/main/src/tmux/operations.rs)) wraps **every** agent command in `sh -c '...'`. The orchestrator command embeds the MCP server JSON in its *own* single quotes:

```
claude mcp add-json agtx '{"type":"stdio",...}' --scope local
```

When that command is placed inside `sh -c '...'`, the inner single quotes around the JSON **close the outer wrapper early**, so the shell mangles the JSON before `claude` ever sees it. `claude mcp add-json` then receives garbage and prints `Invalid configuration: Invalid input`. Because `add-json` fails, the `&&` short-circuits, the interactive agent never launches, and the window dies.

**Fix:** escape the JSON's wrapping single quotes as `'\''` (the POSIX single-quote-in-single-quote idiom — the same convention `build_interactive_command` already uses for prompts) so they survive the outer `sh -c` layer intact.

### 2. MCP server name collision across scopes
The orchestrator registered its server under the bare name `agtx` at local scope. That collides with an `agtx` server already defined in another scope — the Claude Code plugin's `plugin:agtx:agtx`, a user-scope entry in `~/.claude.json`, or the repo's `.mcp.json`. Claude Code reports a *"conflicting scopes"* configuration error when the same name exists in multiple scopes with different endpoints.

**Fix:** register under the unique name `agtx-orchestrator`. The orchestrate skill references MCP tools by bare name (`list_tasks`, `move_task`, …), so no skill changes are needed.

### 3. Malformed repo `.mcp.json`
The committed `.mcp.json` placed the server at the top level instead of under the required `mcpServers` key, so Claude Code reported `mcpServers: Invalid input: expected record, received undefined` whenever any agent ran in the repo root.

**Fix:** wrap the server definition in `mcpServers`.

## Verification

Tested **end-to-end** in a real project:
- Launched `agtx --experimental`, pressed `O`
- The orchestrator window now **stays alive** (previously died within ~6s)
- Claude Code launches, auto-runs `/agtx:orchestrate`, and **successfully calls the agtx MCP tools** (`Calling agtx…` → board state loaded)

Also confirmed via `claude mcp list` that `agtx-orchestrator` shows `✔ Connected` with no conflict diagnostics, and the previously double-wrapped command now passes the JSON to `claude` intact.

`cargo test --test agent_tests` → **19 passed**. The orchestrator command test was strengthened to assert the unique name, forbid the bare `agtx` name, and require the escaped quoting.

## Files changed
- `src/agent/operations.rs` — escape JSON quotes + unique `agtx-orchestrator` name
- `tests/agent_tests.rs` — strengthened `test_build_orchestrator_command_claude_is_idempotent`
- `.mcp.json` — add required `mcpServers` wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)