### PR TITLE
feat: add Grok Build (xAI) as a supported agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # AGTX - Terminal Kanban for Coding Agents
 
-A terminal-native kanban board for managing multiple coding agent sessions (Claude Code, Codex, Gemini, Copilot, OpenCode) with isolated git worktrees.
+A terminal-native kanban board for managing multiple coding agent sessions (Claude Code, Codex, Gemini, Copilot, OpenCode, Cursor, Grok) with isolated git worktrees.
 
 ## Quick Start
 
@@ -16,7 +16,18 @@ cargo build --release
 
 # Enable experimental features (orchestrator agent)
 ./target/release/agtx --experimental
+
+# Never run init_script / cleanup_script from project or plugin config
+./target/release/agtx --no-init-scripts
+
+# Trust the current project's config (enables its scripts and copy_files)
+./target/release/agtx trust
+
+# Run the MCP server (global mode, or project-scoped with a path)
+./target/release/agtx mcp-serve [path]
 ```
+
+Logs are written as JSON to `~/.config/agtx/logs/agtx.log` (daily rotation, `RUST_LOG` respected).
 
 ## Architecture
 
@@ -30,17 +41,20 @@ src/
 │   ├── app.rs        # Main App struct, event loop, rendering (largest file)
 │   ├── app_tests.rs  # Unit tests for app.rs (included via #[path])
 │   ├── board.rs      # BoardState - kanban column/row navigation
+│   ├── dep_graph.rs  # Pure dependency-graph model (topological levels, unblocked nodes)
 │   ├── input.rs      # InputMode enum for UI states
 │   └── shell_popup.rs # Shell popup state, rendering, content trimming
 ├── db/
 │   ├── mod.rs        # Re-exports
 │   ├── schema.rs     # Database struct, SQLite operations
-│   └── models.rs     # Task, Project, TaskStatus, Notification enums
+│   └── models.rs     # Task, Project, TaskStatus, PhaseStatus, TransitionRequest,
+│                     # Notification, RunningAgent, AgentStatus
 ├── tmux/
 │   ├── mod.rs        # Tmux server "agtx", session management
 │   └── operations.rs # TmuxOperations trait (mockable for testing)
 ├── git/
-│   ├── mod.rs        # is_git_repo helper
+│   ├── mod.rs        # is_git_repo, repo_root, current_branch, diff_stat/diff_full,
+│                     # merge_branch, check_merge_conflicts, delete_branch
 │   ├── worktree.rs   # Git worktree create/remove/list
 │   ├── operations.rs # GitOperations trait (mockable for testing)
 │   └── provider.rs   # GitProviderOperations trait (GitHub PR ops)
@@ -51,7 +65,8 @@ src/
 │   ├── mod.rs        # Re-exports
 │   └── server.rs     # MCP server (JSON-RPC over stdio) — global and project-scoped modes
 └── config/
-    └── mod.rs        # GlobalConfig, ProjectConfig, ThemeConfig, WorkflowPlugin
+    └── mod.rs        # GlobalConfig, ProjectConfig, MergedConfig, PhaseAgentsConfig,
+                      # WorktreeConfig, ThemeConfig, WorkflowPlugin, TrustStore
 
 skills/                # Plugin skill files — auto-discovered as /agtx:* (Claude) or @agtx:* (Codex)
 ├── sweep/SKILL.md     # Sweep skill — push any conversation to the board (/agtx:sweep)
@@ -69,7 +84,10 @@ skills/                # Plugin skill files — auto-discovered as /agtx:* (Clau
 plugins/               # Bundled plugin configs (embedded at compile time)
 ├── agtx/
 │   ├── plugin.toml    # Default workflow with skills and prompts
-│   └── skills/orchestrate.md # Orchestrator agent skill (experimental)
+│   └── skills/        # Builtin skills embedded via include_str! in src/skills.rs:
+│       ├── research.md, plan.md, execute.md, review.md
+│       ├── orchestrate.md      # Orchestrator agent skill (experimental)
+│       └── merge-conflicts.md  # Auto merge-conflict resolution skill
 ├── agtx-terse/
 │   ├── plugin.toml    # Token-efficient variant of agtx workflow
 │   └── skills/        # Terse skill overrides with brevity directive
@@ -78,10 +96,12 @@ plugins/               # Bundled plugin configs (embedded at compile time)
 ├── openspec/plugin.toml # OpenSpec specification framework
 ├── bmad/plugin.toml   # BMAD Method - AI-driven agile development
 ├── superpowers/plugin.toml # Superpowers - brainstorming, plans, TDD, subagent-driven dev
+├── oh-my-claudecode/plugin.toml # oh-my-claudecode - multi-agent orchestration
+├── agent-skills/plugin.toml # Agent Skills - spec-to-ship engineering skills
 └── void/plugin.toml   # Plain agent session, no prompting
 
 tests/
-├── db_tests.rs        # Database and model tests
+├── db_tests.rs        # Database, model, and dependency-graph tests
 ├── config_tests.rs    # Configuration tests
 ├── board_tests.rs     # Board navigation tests
 ├── git_tests.rs       # Git worktree tests
@@ -89,6 +109,9 @@ tests/
 ├── mcp_tests.rs       # MCP server tests
 ├── mock_infrastructure_tests.rs # Mock infrastructure tests
 └── shell_popup_tests.rs         # Shell popup logic tests
+
+benchmark/             # SWE-bench harness
+docker/                # Container images for sandboxed runs
 ```
 
 ## Key Concepts
@@ -102,11 +125,13 @@ Backlog → Planning → Running → Review → Done
          planning              (resume)   branch)
 ```
 
-- **Backlog**: Task ideas, not started
+- **Backlog**: Task ideas, not started. Also hosts the optional **Research** phase (`R`) — the research session runs in place, so a Backlog task can already have a worktree and tmux window. There is no separate `Research` status: `TaskStatus` is `Backlog | Planning | Running | Review | Done`, and Backlog's display name is `backlog/research`.
 - **Planning**: Creates git worktree at `{worktree_dir}/{slug}` (default `.agtx/worktrees/{slug}`, configurable via `worktree_dir`), copies configured files, runs init script, deploys skills, starts agent in planning mode
 - **Running**: Agent is implementing (sends execute command/prompt)
 - **Review**: Optionally create PR. Tmux window stays open. Can resume to address feedback
-- **Done**: Cleanup worktree + tmux window (branch kept locally)
+- **Done**: Cleanup worktree + tmux window (branch kept locally). Runs the project `cleanup_script` before removal
+
+Backlog tasks can also skip straight to Running (`M`), and Running can be sent back to Planning (`r`).
 
 ### Workflow Plugins
 Plugins customize the task lifecycle per phase. A plugin is a TOML file (`plugin.toml`) that defines:
@@ -118,7 +143,8 @@ Plugins customize the task lifecycle per phase. A plugin is a TOML file (`plugin
 - **copy_dirs**: Extra directories to copy from project root into worktrees
 - **copy_files**: Individual files to copy from project root into worktrees (merged with project-level `copy_files`)
 - **copy_back**: Files/dirs to copy from worktree back to project root when a phase completes
-- **cyclic**: When true, enables Review → Planning transition with incrementing phase counter
+- **cyclic**: When true, enables Review → Planning transition with incrementing phase counter (`p` on the board)
+- **clear_context_on_advance**: When true, send an agent-specific clear-context command before the phase skill/prompt on transitions (only Claude Code's `/clear` is honored today)
 - **supported_agents**: Agent whitelist (empty = all supported)
 - **auto_dismiss**: Rules to auto-dismiss interactive prompts before sending the task prompt
 
@@ -136,16 +162,39 @@ Skills are markdown files with YAML frontmatter deployed to agent-native discove
 - Gemini: `.gemini/commands/agtx/plan.toml` (converted to TOML format)
 - Codex: `.codex/skills/agtx-plan/SKILL.md`
 - Cursor: `.cursor/skills/agtx-plan/SKILL.md`
+- Grok: `.grok/skills/agtx-plan/SKILL.md`
 - OpenCode: `.opencode/command/agtx-plan.md` (frontmatter stripped)
 - Copilot: `.github/agents/agtx/plan.md`
 
 Canonical copy always at `.agtx/skills/agtx-plan/SKILL.md`.
 
+`write_skills_to_worktree()` also drops a **per-agent MCP config** into the worktree so the task's agent can reach the project-scoped MCP server (`agtx mcp-serve <project>`). Both the filename and the format vary:
+
+| Agent | File | Format |
+|-------|------|--------|
+| claude | `.mcp.json` | JSON, `mcpServers` |
+| codex | `.codex/config.toml` | TOML, `[mcp_servers.agtx]` |
+| gemini | `.gemini/settings.json` | JSON, `mcpServers` + `trust: true` |
+| cursor | `.cursor/mcp.json` | JSON, `mcpServers` |
+| grok | `.grok/config.toml` | TOML, `[mcp_servers.agtx]` |
+| opencode | opencode config | JSON, `mcp` |
+
+Two agents need an extra trust side-effect to avoid an interactive dialog on first open: Claude gets `.claude/settings.local.json` with `enableAllProjectMcpServers: true`, and Codex gets a `[projects."<worktree>"] trust_level = "trusted"` entry appended to the user's global `~/.codex/config.toml`.
+
 Commands are written once in canonical format (`/ns:command`) and auto-translated:
 - Claude/Gemini: `/ns:command` (unchanged)
-- OpenCode/Cursor: `/ns-command` (colon → hyphen)
+- OpenCode/Cursor/Grok: `/ns-command` (colon → hyphen, slash kept)
 - Codex: `$ns-command` (slash → dollar, colon → hyphen)
 - Copilot: no interactive skill invocation (prompt only, no commands sent)
+
+### Sending Skills & Prompts to Agents
+`send_skill_and_prompt()` has **three** send paths, because agent TUIs disagree about how a slash command plus arguments must arrive. Getting this wrong is the usual cause of "the agent started but never got the task":
+
+1. **opencode** — its picker strips arguments if the whole string is typed at once. So: send the bare command name → wait for the picker → Enter (inserts it) → send the args → Enter
+2. **gemini / codex / cursor** — always combine skill + prompt into a *single* message via `send_keys_literal`, then poll the pane until the text renders before pressing Enter (Ink TUIs drop keys sent too early). Gemini executes-and-loses a separately sent prompt; Codex's `$skill` mentions are inline references that do nothing when sent standalone. Codex additionally needs a second Enter to dismiss its command picker
+3. **everything else** (claude, copilot, grok) — the generic `match (skill_cmd, prompt_trigger)` path using `send_keys`, waiting on `prompt_triggers` between the command and the prompt when configured
+
+`clear_context_on_advance` is applied before all three, and only for Claude (`/clear`, then poll until the pane stabilises).
 
 ### Session Persistence
 - Tmux window stays open when moving Running → Review
@@ -153,9 +202,15 @@ Commands are written once in canonical format (`/ns:command`) and auto-translate
 - No special resume logic needed - the session just stays alive in tmux
 
 ### Database Storage
-All databases stored centrally (not in project directories):
+All databases stored centrally (not in project directories), in the platform data dir (`GlobalConfig::data_dir`, via the `directories` crate):
 - macOS: `~/Library/Application Support/agtx/`
-- Linux: `~/.config/agtx/`
+- Linux: `~/.local/share/agtx/`
+
+Config paths are split across two roots — watch out when adding new files:
+- `GlobalConfig::config_path()` / `WorkflowPlugin::global_plugins_dir()` build from `$HOME` directly, so `config.toml`, `plugins/`, and `logs/` are always at `$HOME/.config/agtx/` on **every** platform
+- `TrustStore::path()` uses `directories`' `config_dir()`, so `trusted_projects.toml` lands in `~/Library/Application Support/agtx/` on macOS and `~/.config/agtx/` on Linux
+
+On first run, a `config.toml` at the old `directories`-derived location is migrated to `$HOME/.config/agtx/` automatically.
 
 Structure:
 - `index.db` - Global project index
@@ -196,7 +251,7 @@ A dedicated Claude Code agent that autonomously manages the kanban board. Enable
 ```
 ┌─────────────┐     MCP (stdio)     ┌──────────────┐     SQLite     ┌─────┐
 │ Orchestrator │ ←──────────────────→ │  MCP Server  │ ←────────────→ │ DB  │
-│ (Claude Code)│                     │ (agtx serve) │               └──┬──┘
+│ (Claude Code)│                     │(agtx mcp-serve)│             └──┬──┘
 └──────┬───────┘                     └──────────────┘                  │
        │  send_keys (push-when-idle)                                   │
 ┌──────┴───────┐                                                       │
@@ -206,13 +261,18 @@ A dedicated Claude Code agent that autonomously manages the kanban board. Enable
 
 - **Orchestrator → TUI**: `transition_requests` DB table (commands like "move task X forward")
 - **TUI → Orchestrator**: `notifications` DB table, pushed via `send_keys` when orchestrator is idle
-- MCP registered per-session via `claude mcp add-json --scope local`, cleaned up on exit
+- MCP registered per-session via `claude mcp add-json --scope local`, cleaned up on exit. It registers as **`agtx-orchestrator`**, not `agtx`, so it can't collide with an `agtx` server defined in another scope (the Claude Code plugin, `~/.claude.json`, or the repo's `.mcp.json`) — a same-named server with a different endpoint makes Claude Code report a config conflict and refuse to connect. A stale registration is removed first so `add-json` can't fail with "already exists" and short-circuit the `&&`
+- Only Claude implements `build_orchestrator_command()`; every other agent falls through to a plain interactive session with no MCP wiring
 - Orchestrator only manages Planning and Running phases; the user triages Backlog/Research manually and handles merging in Review/Done
 - Orchestrator is a coordinator, not a reviewer — it moves tasks forward immediately when phases complete, without inspecting output
 - Only "completed phase" notifications are sent (no "entered phase" notifications)
 - On startup, if an orchestrator tmux session already exists, it is detected and reconnected; catch-up notifications are created for tasks that completed phases while the TUI was down (deduplicated via `peek_notifications`)
 
-**MCP tools**: `list_tasks`, `get_task` (includes `allowed_actions`), `move_task`, `get_transition_status`, `check_conflicts`, `get_notifications`
+**MCP tools**:
+- Discovery: `list_projects` (global mode only)
+- Read: `list_tasks`, `get_task` (includes `allowed_actions`), `get_transition_status`, `check_conflicts`, `get_notifications`, `read_pane_content`
+- Write: `move_task` (queues a transition request; actions `research`, `move_forward`, `move_to_planning`, `move_to_running`, `move_to_review`, `move_to_done`, `resume`, `escalate_to_user`), `send_to_task` (Planning/Running only, 4096-byte cap)
+- CRUD (Backlog only for update/delete): `create_task`, `create_tasks_batch` (max 50, index-based `depends_on` wiring), `update_task`, `delete_task`
 
 ### MCP Server Modes
 
@@ -228,10 +288,49 @@ In global mode all CRUD tools (`list_tasks`, `create_task`, etc.) require a `pro
 `ServerMode` enum in `src/mcp/server.rs`. Path resolution via `resolve_project_path(project_id)` helper.
 
 ### General Configuration
-Configurable via `~/.config/agtx/config.toml`:
+Global config lives at `~/.config/agtx/config.toml` (`GlobalConfig`):
 ```toml
+default_agent = "claude"
 fullscreen_on_enter = false  # When true, Enter on a task attaches to tmux directly instead of opening the in-TUI popup
+
+[agents]                     # Per-phase agent overrides (PhaseAgentsConfig)
+research = "claude"
+planning = "claude"
+running = "codex"
+review = "claude"
+
+[worktree]                   # WorktreeConfig
+enabled = true
+auto_cleanup = true
+base_branch = ""             # empty = auto-detect main/master
+worktree_dir = ".agtx/worktrees"
+branch_prefix = "task"       # "task" → task/{slug}
 ```
+
+### Project Configuration
+Per-project overrides live in `{project}/.agtx/config.toml` (`ProjectConfig`) and are merged over the global config via `MergedConfig::merge`:
+
+| Field | Purpose |
+|-------|---------|
+| `default_agent`, `agents` | Agent / per-phase agent overrides |
+| `base_branch` | Branch worktrees are cut from |
+| `github_url` | Repo URL for PR operations |
+| `worktree_dir` | Where worktrees are created |
+| `copy_files` | Comma-separated files copied from project root into worktrees |
+| `init_script` | Shell command run in the worktree after creation |
+| `cleanup_script` | Shell command run in the worktree before removal |
+| `workflow_plugin` | Active plugin for new tasks |
+| `branch_prefix` | Branch name prefix |
+| `skip_worktree` | Work directly in the project root (e.g. already-isolated Docker repos) |
+
+### Project Trust
+Project config can execute shell commands (`init_script`, `cleanup_script`) and copy files, so those three fields are stripped from an untrusted project's config at startup (`App::new`), with a warning banner.
+
+- Trust is a **canonical path → SHA-256 of `.agtx/config.toml`** map in `TrustStore` (`trusted_projects.toml`, see path note above). Editing the project config invalidates trust and re-prompts
+- A project with no `.agtx/config.toml` is trusted by default (nothing to distrust)
+- An untrusted project also forces `flags.no_init_scripts = true`, which additionally suppresses **plugin** `init_script`s
+- Approve via the in-TUI trust confirmation popup (any key) or `agtx trust` in the project directory
+- `--no-init-scripts` suppresses `init_script` and `cleanup_script` execution regardless of trust
 
 ### Theme Configuration
 Colors configurable via `~/.config/agtx/config.toml`:
@@ -260,29 +359,56 @@ color_popup_header = "#69fae7"  # Popup headers (light cyan)
 | `x` | Delete task (with confirmation) |
 | `Ctrl+f` | Fullscreen attach to task's tmux session |
 | `d` | Show git diff for task |
+| `D` | Open dependency-graph overlay |
 | `m` | Move task forward (advance workflow) |
-| `r` | Resume task (Review → Running) |
+| `M` | Move Backlog task straight to Running |
+| `R` | Start research for a Backlog task (in place, no column change) |
+| `r` | Resume: Review → Running, or Running → Planning |
+| `p` | Cyclic plugins only: Review → Planning (next phase) |
 | `/` | Search tasks (jumps to and opens task) |
 | `P` | Select workflow plugin |
 | `O` | Toggle orchestrator agent (experimental) |
-| `e` | Toggle project sidebar |
+| `e` | Toggle project sidebar (`h`/`Left` from the Backlog column focuses it) |
 | `q` | Quit |
+
+### Dashboard Mode (`agtx -g`, or launched outside a git repo)
+| Key | Action |
+|-----|--------|
+| `p` | Open the indexed-project list |
+| `n` | Adopt the current directory as a project (must be a git repo) and open it |
+| `j/k` or arrows | Navigate the project list |
+| `Enter` | Open the selected project |
+| `Esc` | Close the project list |
+| `q` | Quit |
+
+### Dependency Graph Overlay (`D`)
+| Key | Action |
+|-----|--------|
+| `h/j/k/l` or arrows | Move between nodes / levels |
+| `Space` | Toggle mark on an unblocked node |
+| `a` | Mark all unblocked nodes |
+| `c` | Clear marks |
+| `Enter` | Batch-move marked (or selected) unblocked tasks forward |
+| `Esc` or `q` | Close |
 
 ### Task Popup (tmux view)
 | Key | Action |
 |-----|--------|
 | `Ctrl+j/k` or `Ctrl+n/p` | Scroll up/down |
-| `Ctrl+d/u` | Page down/up |
+| `Ctrl+d/u` or `PageDown/PageUp` | Page down/up |
 | `Ctrl+g` | Jump to bottom |
 | `Ctrl+f` | Fullscreen attach to tmux session |
-| `Ctrl+q` or `Esc` | Close popup |
-| Other keys | Forwarded to tmux/agent |
+| `Ctrl+q` | Close popup |
+| Other keys | Forwarded to tmux/agent (including `Esc`) |
+
+When an escalation note is present, the first keypress only dismisses the banner and is not forwarded.
 
 ### PR Creation Popup
 | Key | Action |
 |-----|--------|
 | `Tab` | Switch between title/description |
-| `Ctrl+s` | Create PR and move to Review |
+| `Enter` | In title: move to description. In description: newline |
+| `Ctrl+s` | Create PR and move to Review (ignored while the description is still generating) |
 | `Esc` | Cancel |
 
 ### Task Creation Wizard
@@ -335,19 +461,22 @@ Plugin defaults to the project's active plugin (set via `P` on the board).
 - Loading spinners shown during async operations
 
 ### Phase Status Polling
-- `maybe_spawn_session_refresh()` spawns a background thread with 2-second cache TTL per task
+- `maybe_spawn_session_refresh()` spawns a background thread with 2-second cache TTL per task, covering Planning/Running/Review tasks plus Backlog tasks with an active research session
 - Overlap guard: only one refresh thread runs at a time (`session_refresh_rx.is_some()`)
 - Thread does all expensive work: plugin TOML loading, artifact file checks, `tmux capture-pane`, copy-back side effects
 - `apply_session_refresh()` applies results on main thread (non-blocking `try_recv`)
 - Idle detection (Working → Idle) handled on main thread using `pane_content_hashes` timestamps
-- Four states: Working (spinner), Idle (pause icon, 15s no output), Ready (checkmark), Exited (no window)
+- Four states (`PhaseStatus` in `src/db/models.rs`): Working (spinner), Idle (pause icon, 15s no output), Ready (checkmark), Exited (no window)
 - Phase artifact paths come from the task's plugin or agtx defaults
 - Plugin instances cached per task in `HashMap<Option<String>, Option<WorkflowPlugin>>` to avoid repeated disk reads
 
-### Task References
+### Task References & Dependencies
 - In description input, type `!` (at start of line or after space) to search existing tasks
 - Selecting a task inserts `![task-title]` and tracks the reference ID
 - Referenced task IDs stored as comma-separated string in `task.referenced_tasks`
+- References double as **dependencies**: `Database::deps_satisfied` returns true only when every referenced task is in Review or Done. Starting research or moving a Backlog task forward is blocked until then (a warning is shown instead)
+- `src/tui/dep_graph.rs` builds a topologically-leveled `DepGraph` from `referenced_tasks` — level 0 = no in-graph deps, and a node is `unblocked` when it is in Backlog with satisfied deps. The `D` overlay renders it and can batch-move unblocked tasks. The module is free of ratatui/DB types (the caller passes a `deps_satisfied` closure), so it is unit-testable in isolation
+- MCP `create_tasks_batch` wires the same dependencies via 0-based `depends_on` indices
 - At worktree setup, referenced tasks' artifacts are copied to `.agtx/references/`:
   - Git diffs (`{slug}.diff`) from `git diff main..{branch}`
   - Worktree files (`.agtx/skills/`, `.planning/`) if the referenced worktree still exists
@@ -363,7 +492,8 @@ Plugin defaults to the project's active plugin (set via `P` on the board).
 
 ### Agent Integration
 - Agents spawned via `build_interactive_command()` in `src/agent/mod.rs`
-- Each agent has its own flags: Claude (`--dangerously-skip-permissions`), Codex (`--sandbox workspace-write`), Gemini (`--approval-mode yolo`), Copilot (`--allow-all-tools`)
+- Each agent has its own flags: Claude (`--dangerously-skip-permissions`), Codex (`--sandbox workspace-write`), Gemini (`GEMINI_TRUST_WORKSPACE=true` + `--approval-mode yolo`), Copilot (`--allow-all-tools`), Cursor (`agent --yolo`), Grok (`--yolo --trust`, where `--trust` also ungates the repo-local `.grok/config.toml` MCP server and suppresses the directory-trust dialog)
+- `build_resume_command()` is the recovery variant used after a tmux/server restart — mostly `--continue`, but Gemini uses `--resume` and Codex uses `codex resume --last`
 - Skills deployed to agent-native paths via `write_skills_to_worktree()` in app.rs
 - Commands resolved per-task via `resolve_skill_command()` (plugin command + agent transform)
 - Prompts resolved per-task via `resolve_prompt()` (pure template substitution, agent-agnostic)
@@ -382,7 +512,7 @@ cargo test --features test-mocks
 ```
 
 Dependencies require:
-- Rust 1.70+
+- A recent stable Rust (CI builds on `stable`; no MSRV is pinned in `Cargo.toml`)
 - SQLite (bundled via rusqlite)
 - tmux (runtime dependency)
 - git (runtime dependency)
@@ -402,13 +532,32 @@ Dependencies require:
 3. Use `hex_to_color(&state.config.theme.color_*)` in app.rs
 
 ### Adding a new agent
-1. Add to `known_agents()` in `src/agent/mod.rs`
-2. Add `build_interactive_command()` match arm in `src/agent/mod.rs`
-3. Add agent-native skill dir in `agent_native_skill_dir()` in `src/skills.rs`
-4. Add plugin command transform in `transform_plugin_command()` in `src/skills.rs`
-5. Add exit command handling in `switch_agent_in_tmux()` in `src/tui/app.rs` (graceful exit cmd or Ctrl+C)
-6. Add activity indicator string to `AGENT_ACTIVE_INDICATORS` in `src/tui/app.rs` if the agent is an Ink/Node TUI (runs inside bash)
-7. If Ink/Node TUI: add to combined-send branch `matches!(agent_name, "gemini" | "codex" | ...)` in `send_skill_and_prompt()`; add double-Enter handling if the agent has a command picker popup
+Adding grok touched every one of these — use `git log -p` for that change as a worked example. Required:
+
+**`src/agent/mod.rs`**
+1. Add to `known_agents()` (name, binary, description, git co-author)
+2. Add a `build_interactive_command()` match arm (with and without a prompt)
+3. Add a `build_resume_command()` match arm (usually `--continue`)
+
+**`src/agent/operations.rs`**
+4. Add a `generate_text()` match arm — the headless/print invocation used for PR descriptions
+
+**`src/skills.rs`**
+5. Add the agent-native skill dir to `agent_native_skill_dir()`
+6. Add the plugin command transform to `transform_plugin_command()`
+7. Add a `scan_agent_skills()` branch so the agent's existing skills show up in the `/` skill picker
+
+**`src/tui/app.rs`**
+8. Add the binary to `AGENT_COMMANDS` (pane process detection)
+9. Add an activity indicator to `AGENT_ACTIVE_INDICATORS` if the agent is an Ink/Node TUI (runs inside bash)
+10. Add exit command handling in `switch_agent_in_tmux()` (graceful exit cmd or Ctrl+C)
+11. Add the skill-deploy branch in **both** `write_skills_to_worktree()` and `deploy_skill()` (e.g. `"codex" | "cursor" | "grok"` for SKILL.md subdirectories)
+12. Add the per-agent MCP config writer in `write_skills_to_worktree()` — note the format varies (JSON vs TOML, `mcpServers` vs `mcp_servers`)
+13. Add an agent label color in the task-card footer `match task.agent.as_str()`
+14. If Ink/Node TUI: add to the combined-send branch `matches!(agent_name, "gemini" | "codex" | ...)` in `send_skill_and_prompt()`; add double-Enter handling if the agent has a command picker popup
+
+**Plugins**
+15. Add the agent to `supported_agents` in any `plugins/*/plugin.toml` that whitelists agents
 
 ### Adding a keyboard shortcut
 1. Find the appropriate `handle_*_key` function in `src/tui/app.rs`
@@ -441,9 +590,13 @@ Detected automatically via `known_agents()` in order of preference:
 3. **copilot** - GitHub Copilot CLI
 4. **gemini** - Google Gemini CLI
 5. **opencode** - AI-powered coding assistant
+6. **cursor** - Cursor Agent CLI (binary is `agent`)
+7. **grok** - xAI's Grok Build CLI
 
 ## Future Enhancements
 - Reopen Done tasks (recreate worktree from preserved branch)
 - Orchestrator: support non-Claude agents as orchestrator
 - Orchestrator: task deletion notifications
-- Orchestrator: multi-project support (see `docs/planning/multi-project-orchestrator.md`)
+- Orchestrator: multi-project support
+
+Design notes for in-flight work live in `docs/planning/` (untracked).

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ With the orchestrator, you don't even manage the board yourself. **An AI agent p
 - **Parallel execution**: Every task gets its own git worktree and tmux window — run as many agents as needed, simultaneously
 - **Spec-driven plugins**: Plug in [GSD](https://github.com/fynnfluegge/get-shit-done-cc), [Spec-kit](https://github.com/github/spec-kit), [OpenSpec](https://github.com/Fission-AI/OpenSpec), [BMAD](https://github.com/bmad-code-org/BMAD-METHOD), [Superpowers](https://github.com/obra/superpowers) — or define your own with a single TOML file
 - **Multi-project dashboard**: Manage agent sessions across all projects via a single TUI
-- **Works with**: [Claude Code](https://github.com/anthropics/claude-code) | [Codex](https://github.com/openai/codex) | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | [OpenCode](https://github.com/sst/opencode)  | [Cursor Agent](https://cursor.com/docs/cli/overview) | [Copilot](https://github.com/github/copilot-cli)
+- **Works with**: [Claude Code](https://github.com/anthropics/claude-code) | [Codex](https://github.com/openai/codex) | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | [OpenCode](https://github.com/sst/opencode)  | [Cursor Agent](https://cursor.com/docs/cli/overview) | [Copilot](https://github.com/github/copilot-cli) | [Grok Build](https://docs.x.ai/build/overview)
 
 > [!NOTE]
 > Just need a plain coding agent session manager with **full human-in-the-loop control** and **no automatic spec-driven skill execution and orchestration** on advancing tasks?
@@ -252,6 +252,16 @@ cp skills/sweep/SKILL.md ~/.cursor/rules/agtx-sweep.md
 </details>
 
 <details>
+<summary><strong>Grok Build</strong></summary>
+
+```bash
+grok mcp add agtx -- agtx mcp-serve
+mkdir -p ~/.grok/skills/agtx-sweep && cp skills/sweep/SKILL.md ~/.grok/skills/agtx-sweep/SKILL.md
+```
+
+</details>
+
+<details>
 <summary><strong>Other</strong></summary>
 
 Register `agtx mcp-serve` as an MCP server, then copy `skills/sweep/SKILL.md` into your agent's context.
@@ -352,21 +362,21 @@ Press `P` to switch plugins. Ships with 10 built-in:
 
 Commands are written once in canonical format and automatically translated per agent:
 
-| Canonical (plugin.toml) | Claude / Gemini | Codex | OpenCode | Cursor |
-|--------------------------|-----------------|-------|----------|--------|
-| `/agtx:plan` | `/agtx:plan` | `$agtx-plan` | `/agtx-plan` | `/agtx-plan` |
+| Canonical (plugin.toml) | Claude / Gemini | Codex | OpenCode | Cursor | Grok |
+|--------------------------|-----------------|-------|----------|--------|------|
+| `/agtx:plan` | `/agtx:plan` | `$agtx-plan` | `/agtx-plan` | `/agtx-plan` | `/agtx-plan` |
 
-|  | Claude | Codex | Gemini | OpenCode | Cursor | Copilot |
-|--|:------:|:-----:|:------:|:--------:|:------:|:-------:|
-| **agtx** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| **gsd** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| **spec-kit** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| **openspec** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| **bmad** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| **superpowers** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **oh-my-claudecode** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **agent-skills** | ✅ | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 |
-| **void** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+|  | Claude | Codex | Gemini | OpenCode | Cursor | Copilot | Grok |
+|--|:------:|:-----:|:------:|:--------:|:------:|:-------:|:----:|
+| **agtx** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ |
+| **gsd** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| **spec-kit** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ |
+| **openspec** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ |
+| **bmad** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ |
+| **superpowers** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **oh-my-claudecode** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **agent-skills** | ✅ | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 |
+| **void** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ✅ Skills, commands, and prompts fully supported · 🟡 Prompt only, no interactive skill support · ❌ Not supported
 
@@ -438,6 +448,7 @@ review = ".my-plugin/{phase}/review.md"
 #   Claude/Gemini: /my-plugin:plan (unchanged)
 #   OpenCode:      /my-plugin-plan (colon -> hyphen)
 #   Codex:         $my-plugin-plan (slash -> dollar, colon -> hyphen)
+#   Cursor/Grok:   /my-plugin-plan (colon -> hyphen)
 # Omitted phases fall back to agent-native agtx skill invocation
 # (e.g. /agtx:plan for Claude, $agtx-plan for Codex).
 # Set to "" to skip sending a command for that phase.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -24,7 +24,7 @@ specific Python versions and C extensions that aren't available outside the cont
 ```bash
 cd swebench
 
-# Build the tools image (tmux + Node.js + Claude Code)
+# Build the tools image (tmux + Node.js + Claude Code + Grok)
 python prebake_images.py --verbose
 
 # Build the Linux agtx binary (Ubuntu 22.04 / glibc 2.35)
@@ -33,14 +33,18 @@ bash build_linux_binary.sh
 
 The tools image is the base for the shared Docker named volume `agtx-swebench-tools`.
 On the **first benchmark run**, this volume is created automatically and populated from the
-tools image — tmux, Node.js, Claude Code, and their shared libraries are copied in once and
+tools image — tmux, Node.js, Claude Code, Grok, and their shared libraries are copied in once and
 then mounted read-only into every instance container. Subsequent runs skip this step.
 
-To force a refresh (e.g. after updating Claude Code):
+To force a refresh (e.g. after updating Claude Code or Grok):
 ```bash
 docker volume rm agtx-swebench-tools
 python prebake_images.py --force --verbose
 ```
+
+**Agent credentials** are copied into each container as snapshots (host files are never modified):
+Claude reads `~/.claude/` + `~/.claude.json`, Grok reads `~/.grok/auth.json` + `~/.grok/config.toml`
+(or `XAI_API_KEY` from the host environment, passed through to the container's tmux env).
 
 **Run in sandbox mode** (Linux binary required — agents run inside Ubuntu 22.04 containers):
 ```bash
@@ -88,7 +92,9 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```bash
 npm install -g tokscale
 ```
-If not installed, `cost_usd` and token fields will be `null` in results.
+If not installed, `cost_usd` and token fields will be `null` in results. tokscale filters by agent
+for Claude, Codex, Gemini, Copilot and OpenCode; for agents it has no filter for (Cursor, Grok) the
+fields are `null` in sandbox runs and unfiltered — summed across all agents — in host-mode runs.
 
 **tmux** (required — agtx runs agent sessions inside tmux):
 ```bash
@@ -103,6 +109,7 @@ At least one coding agent CLI must be installed and authenticated:
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — `npm install -g @anthropic-ai/claude-code`
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) — `npm install -g @google/gemini-cli`
 - [Codex CLI](https://github.com/openai/codex) — `npm install -g @openai/codex`
+- [Grok Build](https://docs.x.ai/build/overview) — `npm install -g @xai-official/grok`, then `grok login`
 
 ---
 
@@ -158,6 +165,12 @@ review   = "codex"
 ```
 
 Available plugins: `void`, `agtx`, `agtx-terse`, `gsd`, `spec-kit`, `bmad`, `openspec`, `superpowers`, `agent-skills`
+
+> [!WARNING]
+> `void` is for interactive use, not benchmark runs. With no phase command or prompt, agtx prefills
+> the task in the agent's input box and waits for a human to press Enter, so an automated run stalls
+> with "Pane stable but no finish marker". Use a plugin with artifacts (`agtx`, `agtx-terse`, …)
+> for benchmarks.
 
 Pre-built configs for common single-agent and multi-agent combinations are in [`swebench/configs/`](swebench/configs/).
 
@@ -397,9 +410,9 @@ PY
 > the rendered pane** — `tmux capture-pane` will never show them. You must read the JSONL to see
 > whether the model actually emitted them.
 
-> **`void` quirk:** with the `void` plugin the phase prompt is *pasted* into the input box but not
-> always submitted (no artifact/finish-marker to drive it), which shows as "Pane stable but no finish
-> marker". If a run stalls there, submit it manually:
+> **`void` quirk:** with the `void` plugin the phase prompt is *pasted* into the input box and never
+> submitted — agtx prefills it and waits for a human Enter — which shows as "Pane stable but no
+> finish marker". To unstick a run you are capturing from:
 > `docker exec $C tmux -L agtx send-keys -t testbed:1 Enter`.
 
 ---

--- a/benchmark/swebench/benchmark.py
+++ b/benchmark/swebench/benchmark.py
@@ -35,6 +35,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -592,7 +593,7 @@ def setup_container(
     extra_dirs: list[tuple[Path, str]] | None = None,
     sandbox_init: list[str] | None = None,
 ) -> None:
-    """Write agtx config into the container and install tmux + Node + Claude Code.
+    """Write agtx config into the container and install tmux + Node + Claude Code + Grok.
 
     If tools_container_id is provided, binaries are copied from the shared tools
     container instead of being installed from the network (~3-5 min saved).
@@ -643,6 +644,23 @@ def setup_container(
             ["docker", "cp", str(claude_json), f"{container_id}:/home/bench/.claude.json"],
             check=True, capture_output=not verbose,
         )
+
+    # Copy Grok credentials as snapshots so `grok` can authenticate inside the
+    # container without a browser login. Only the small auth/config files are copied —
+    # ~/.grok/sessions/ and friends are skipped. No-op unless the host has ~/.grok.
+    grok_home = home / ".grok"
+    if grok_home.exists():
+        subprocess.run(
+            ["docker", "exec", container_id, "/bin/bash", "-c", "mkdir -p /home/bench/.grok"],
+            check=True, capture_output=not verbose,
+        )
+        for name in ("auth.json", "config.toml"):
+            item = grok_home / name
+            if item.exists():
+                subprocess.run(
+                    ["docker", "cp", str(item), f"{container_id}:/home/bench/.grok/{name}"],
+                    check=True, capture_output=not verbose,
+                )
 
     # Copy extra directories into the container (e.g. third-party plugin skill dirs).
     for src, dst in (extra_dirs or []):
@@ -736,6 +754,9 @@ def setup_container(
              " && ln -sf /tools/node_modules/@anthropic-ai /usr/lib/node_modules/@anthropic-ai"
              " && ln -sf /tools/node_modules/npm /usr/lib/node_modules/npm"
              " && test -f /tools/node_modules/.bin/caveman && ln -sf /tools/node_modules/.bin/caveman /usr/bin/caveman || true"
+             " && test -e /tools/node_modules/@xai-official/grok/bin/grok"
+             " && ln -sf /tools/node_modules/@xai-official/grok/bin/grok /usr/bin/grok"
+             " && ln -sf /tools/node_modules/@xai-official /usr/lib/node_modules/@xai-official || true"
              " && mkdir -p /usr/lib/x86_64-linux-gnu"
              " && ln -sf /tools/lib/x86_64-linux-gnu/libutempter.so.0 /usr/lib/x86_64-linux-gnu/libutempter.so.0"
              " && ln -sf /tools/lib/x86_64-linux-gnu/libutempter.so.1.2.1 /usr/lib/x86_64-linux-gnu/libutempter.so.1.2.1"
@@ -744,14 +765,14 @@ def setup_container(
         )
     else:
         if verbose:
-            print(f"  [docker] Installing tmux, Node.js 22, Claude Code...", file=sys.stderr)
+            print(f"  [docker] Installing tmux, Node.js 22, Claude Code, Grok...", file=sys.stderr)
         subprocess.run(
             ["docker", "exec", container_id,
              "/bin/bash", "-c",
              "apt-get update -qq && apt-get install -y -qq tmux curl ca-certificates "
              "&& curl -fsSL https://deb.nodesource.com/setup_22.x | bash - "
              "&& apt-get install -y -qq nodejs "
-             "&& npm install -g @anthropic-ai/claude-code"],
+             "&& npm install -g @anthropic-ai/claude-code @xai-official/grok"],
             check=True,
             capture_output=not verbose,
         )
@@ -786,6 +807,13 @@ def start_tui_in_container(slug: str, container_id: str, verbose: bool = False) 
         f"CONDA_PREFIX=/opt/miniconda3/envs/testbed "
         f"PATH={testbed_bin}:/opt/miniconda3/bin:/home/bench/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     )
+    # Pass through API keys that agents read from the environment (only when set
+    # on the host). Grok uses XAI_API_KEY when ~/.grok/auth.json is absent.
+    passthrough_env = {
+        k: v for k in ("XAI_API_KEY",) if (v := os.environ.get(k))
+    }
+    for key, val in passthrough_env.items():
+        env_prefix += f" {key}={shlex.quote(val)}"
     subprocess.run(
         ["docker", "exec", "-d", container_id,
          "tmux", "new-session", "-d", "-s", slug,
@@ -802,7 +830,7 @@ def start_tui_in_container(slug: str, container_id: str, verbose: bool = False) 
         ("CONDA_DEFAULT_ENV", "testbed"),
         ("CONDA_PREFIX", "/opt/miniconda3/envs/testbed"),
         ("PATH", f"{testbed_bin}:/opt/miniconda3/bin:/home/bench/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"),
-    ]:
+    ] + list(passthrough_env.items()):
         subprocess.run(
             ["docker", "exec", container_id,
              "tmux", "-L", "agtx", "set-environment", "-g", key, val],

--- a/benchmark/swebench/configs/grok-agtx-terse.toml
+++ b/benchmark/swebench/configs/grok-agtx-terse.toml
@@ -1,0 +1,9 @@
+default_agent = "grok"
+workflow_plugin = "agtx-terse"
+worktree_dir = ".agtx/worktrees"
+skip_worktree = true
+
+[agents]
+planning = "grok"
+running  = "grok"
+review   = "grok"

--- a/benchmark/swebench/configs/grok-agtx.toml
+++ b/benchmark/swebench/configs/grok-agtx.toml
@@ -1,0 +1,9 @@
+default_agent = "grok"
+workflow_plugin = "agtx"
+worktree_dir = ".agtx/worktrees"
+skip_worktree = true
+
+[agents]
+planning = "grok"
+running  = "grok"
+review   = "grok"

--- a/benchmark/swebench/configs/grok-void.toml
+++ b/benchmark/swebench/configs/grok-void.toml
@@ -1,0 +1,13 @@
+# Plain Grok session: no skills, no phase prompting.
+# Interactive use only — in an automated benchmark run agtx prefills the task in
+# the input box and waits for a human Enter, so the run stalls. Use grok-agtx.toml
+# for benchmarks.
+default_agent = "grok"
+workflow_plugin = "void"
+worktree_dir = ".agtx/worktrees"
+skip_worktree = true
+
+[agents]
+planning = "grok"
+running  = "grok"
+review   = "grok"

--- a/benchmark/swebench/prebake_images.py
+++ b/benchmark/swebench/prebake_images.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Build the shared agtx/swebench-tools:latest image with tmux, Node.js, and Claude Code.
+Build the shared agtx/swebench-tools:latest image with tmux, Node.js, Claude Code, and Grok.
 
 This single image is used by all benchmark sandbox runs — the benchmark runner copies
 the installed binaries from a running tools container into each SWE-bench instance
@@ -10,7 +10,7 @@ The tools image is based on Ubuntu 22.04 (matching SWE-bench images) and contain
 the agent tooling layer. SWE-bench instance images are used as-is from Docker Hub.
 
 Usage:
-    # Build the tools image (run once, or after updating Claude Code)
+    # Build the tools image (run once, or after updating Claude Code / Grok)
     python prebake_images.py
 
     # Force rebuild even if image already exists
@@ -35,7 +35,7 @@ RUN apt-get update -qq \\
     && apt-get install -y -qq tmux curl ca-certificates \\
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \\
     && apt-get install -y -qq nodejs \\
-    && npm install -g @anthropic-ai/claude-code \\
+    && npm install -g @anthropic-ai/claude-code @xai-official/grok \\
     && apt-get clean \\
     && rm -rf /var/lib/apt/lists/*
 """

--- a/plugins/gsd/plugin.toml
+++ b/plugins/gsd/plugin.toml
@@ -1,7 +1,7 @@
 name = "gsd"
 description = "Get Shit Done - structured spec-driven development framework"
 init_script = "npx get-shit-done-cc@latest --{agent} --local --non-interactive"
-supported_agents = ["claude", "codex", "gemini", "opencode"]
+supported_agents = ["claude", "codex", "gemini", "opencode", "grok"]
 cyclic = true
 copy_files = [".planning/config.json", ".planning/PROJECT.md", ".planning/REQUIREMENTS.md", ".planning/ROADMAP.md", ".planning/STATE.md"]
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -43,6 +43,7 @@ impl Agent {
             "gemini" => "GEMINI_TRUST_WORKSPACE=true gemini --approval-mode yolo --resume".to_string(),
             "opencode" => "opencode --continue".to_string(),
             "cursor" => "agent --yolo --continue".to_string(),
+            "grok" => "grok --yolo --trust --continue".to_string(),
             _ => self.build_interactive_command(""),
         }
     }
@@ -59,6 +60,7 @@ impl Agent {
                 "gemini" => "GEMINI_TRUST_WORKSPACE=true gemini --approval-mode yolo".to_string(),
                 "opencode" => "opencode".to_string(),
                 "cursor" => "agent --yolo".to_string(),
+                "grok" => "grok --yolo --trust".to_string(),
                 _ => self.command.clone(),
             };
         }
@@ -71,6 +73,7 @@ impl Agent {
             "gemini" => format!("GEMINI_TRUST_WORKSPACE=true gemini --approval-mode yolo -i '{}'", escaped_prompt),
             "opencode" => format!("opencode -p '{}'", escaped_prompt),
             "cursor" => format!("agent --yolo '{}'", escaped_prompt),
+            "grok" => format!("grok --yolo --trust '{}'", escaped_prompt),
             _ => format!("{} '{}'", self.command, escaped_prompt),
         }
     }
@@ -114,6 +117,12 @@ pub fn known_agents() -> Vec<Agent> {
             "agent",
             "Cursor Agent CLI",
             "Cursor Agent <noreply@cursor.com>",
+        ),
+        Agent::new(
+            "grok",
+            "grok",
+            "xAI's Grok Build CLI",
+            "Grok <noreply@x.ai>",
         ),
         // TODO: investigate CLI usage before enabling
         // Agent::new("aider", "aider", "AI pair programming in your terminal", "Aider <noreply@aider.chat>"),

--- a/src/agent/operations.rs
+++ b/src/agent/operations.rs
@@ -61,6 +61,7 @@ impl AgentOperations for CodingAgent {
             "copilot" => ("copilot", vec!["-p", prompt]),
             "gemini" => ("gemini", vec!["-p", prompt]),
             "cursor" => ("agent", vec!["--print", "--yolo", prompt]),
+            "grok" => ("grok", vec!["-p", prompt]),
             _ => (self.agent.command.as_str(), vec![prompt]),
         };
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -111,6 +111,7 @@ pub fn agent_native_skill_dir(agent_name: &str) -> Option<(&'static str, &'stati
         "opencode" => Some((".opencode/command", "")),
         "codex" => Some((".codex/skills", "")),
         "cursor" => Some((".cursor/skills", "")),
+        "grok" => Some((".grok/skills", "")),
         "copilot" => Some((".github/agents", "agtx")),
         _ => None,
     }
@@ -161,6 +162,7 @@ pub fn skill_dir_to_filename(skill_dir_name: &str, agent_name: &str) -> String {
 /// - Claude/Gemini: unchanged (`/gsd:plan-phase 1`)
 /// - OpenCode: colon → hyphen (`/gsd-plan-phase 1`)
 /// - Codex: slash → dollar + colon → hyphen (`$gsd-plan-phase 1`)
+/// - Cursor/Grok: colon → hyphen, slash kept (`/gsd-plan-phase 1`)
 /// - Unsupported agents: None (will fall back to file-path reference)
 pub fn transform_plugin_command(canonical_cmd: &str, agent_name: &str) -> Option<String> {
     match agent_name {
@@ -178,7 +180,7 @@ pub fn transform_plugin_command(canonical_cmd: &str, agent_name: &str) -> Option
                 Some(transformed)
             }
         }
-        "cursor" => {
+        "cursor" | "grok" => {
             // /agtx:plan → /agtx-plan (slash kept, colon → hyphen)
             Some(canonical_cmd.replacen(':', "-", 1))
         }
@@ -430,9 +432,13 @@ pub fn scan_agent_skills(
                 }
             }
         }
-        "cursor" => {
+        "cursor" | "grok" => {
             // Skill subdirectories with SKILL.md, invoked as /skill-name
-            let base = project_path.join(".cursor/skills");
+            let base_dir = match agent_native_skill_dir(agent_name) {
+                Some((dir, _)) => dir,
+                None => return results,
+            };
+            let base = project_path.join(base_dir);
             let entries = match std::fs::read_dir(&base) {
                 Ok(e) => e,
                 Err(_) => return results,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2685,6 +2685,7 @@ impl App {
                 "gemini" => Style::default().fg(Color::Rgb(234, 130, 180)), // pink
                 "opencode" => Style::default().fg(Color::White).bg(Color::Rgb(80, 80, 80)), // white on grey
                 "codex" => Style::default().fg(Color::White).bg(Color::Rgb(20, 20, 20)), // white on black
+                "grok" => Style::default().fg(Color::Rgb(20, 20, 20)).bg(Color::White), // black on white
                 _ => Style::default().fg(Color::White),
             };
             let agent_label = Paragraph::new(format!(" {} ", task.agent))
@@ -9112,12 +9113,14 @@ fn collect_phase_agents(config: &MergedConfig) -> Vec<String> {
 /// Note: on systems where agents are installed via asdf/nvm, all agents run as `node`
 /// and Check 1 never fires — AGENT_ACTIVE_INDICATORS is the only reliable signal there.
 const AGENT_COMMANDS: &[&str] = &[
-    "claude", "codex", "gemini", "copilot", "opencode", "agent", "python3", "python",
+    "claude", "codex", "gemini", "copilot", "opencode", "agent", "grok", "python3", "python",
 ];
 
-/// Strings in pane content that indicate a Node/Ink agent TUI is active and ready.
-/// Used by `is_agent_active` to detect agents like Gemini and Cursor that run
-/// inside bash/node and don't change `pane_current_command` to their own name.
+/// Strings in pane content that indicate an agent TUI is active and ready.
+/// Used by `is_agent_active` to detect agents like Gemini, Cursor and Grok that
+/// run inside bash/node and don't change `pane_current_command` to their own name.
+/// (Grok is a native binary, but the npm package launches it through a wrapper,
+/// so the pane still reports `bash`.)
 /// Also used by `wait_for_agent_ready` (Check 2) to detect readiness for these agents.
 const AGENT_ACTIVE_INDICATORS: &[&str] = &[
     "Claude Code",       // Claude
@@ -9125,6 +9128,8 @@ const AGENT_ACTIVE_INDICATORS: &[&str] = &[
     "Ask anything",      // OpenCode
     "Cursor Agent",      // Cursor
     "OpenAI Codex",      // Codex
+    "Grok Build",        // Grok — splash/footer
+    "Shift+Tab:mode",    // Grok — session footer once a turn has run
 ];
 
 /// Check if the pane is running a shell (i.e. the agent has exited).
@@ -9294,6 +9299,7 @@ fn switch_agent_in_tmux(
         "codex" => None, // Codex has no exit command — Ctrl+C is the only way
         "gemini" => Some("/quit"),
         "cursor" => None,   // Ink/Node TUI — Ctrl+C is the only reliable exit
+        "grok" => Some("/quit"),
         _ => Some("/exit"), // claude, opencode, and others
     };
 
@@ -9688,6 +9694,30 @@ fn write_skills_to_worktree(
                     serde_json::to_string_pretty(&cfg).unwrap_or_default(),
                 );
             }
+            "grok" => {
+                // Grok reads project-scoped MCP servers from .grok/config.toml (TOML, not JSON),
+                // walking from the worktree up to the git root.
+                let esc = |v: &str| v.replace('\\', "\\\\").replace('"', "\\\"");
+                let cfg = format!(
+                    "[mcp_servers.agtx]\ncommand = \"{}\"\nargs = [\"mcp-serve\", \"{}\"]\n",
+                    esc(&agtx_bin),
+                    esc(&project_path_str)
+                );
+                let dir = Path::new(worktree_path).join(".grok");
+                let _ = std::fs::create_dir_all(&dir);
+                // A repo may already ship a .grok/config.toml — append the agtx table
+                // instead of clobbering the project's own settings.
+                let path = dir.join("config.toml");
+                let existing = std::fs::read_to_string(&path).unwrap_or_default();
+                if !existing.contains("[mcp_servers.agtx]") {
+                    let merged = if existing.trim().is_empty() {
+                        cfg
+                    } else {
+                        format!("{}\n\n{}", existing.trim_end(), cfg)
+                    };
+                    let _ = std::fs::write(&path, merged);
+                }
+            }
             "opencode" => {
                 let cfg = serde_json::json!({
                     "mcp": {
@@ -9730,8 +9760,8 @@ fn write_skills_to_worktree(
                         let filename = skills::skill_dir_to_filename(skill_dir_name, agent_name);
                         let _ = std::fs::write(native_dir.join(&filename), toml_content);
                     }
-                    "codex" | "cursor" => {
-                        // Codex/Cursor use SKILL.md in skill-name/ subdirectories
+                    "codex" | "cursor" | "grok" => {
+                        // Codex/Cursor/Grok use SKILL.md in skill-name/ subdirectories
                         let skill_subdir = native_dir.join(skill_dir_name);
                         let _ = std::fs::create_dir_all(&skill_subdir);
                         let _ = std::fs::write(skill_subdir.join("SKILL.md"), &content);
@@ -9785,7 +9815,7 @@ fn deploy_skill(target_dir: &Path, skill_name: &str, content: &str, agent_name: 
                 let filename = skills::skill_dir_to_filename(skill_name, agent_name);
                 let _ = std::fs::write(native_dir.join(&filename), toml_content);
             }
-            "codex" | "cursor" => {
+            "codex" | "cursor" | "grok" => {
                 let skill_subdir = native_dir.join(skill_name);
                 let _ = std::fs::create_dir_all(&skill_subdir);
                 let _ = std::fs::write(skill_subdir.join("SKILL.md"), content);

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -3900,6 +3900,57 @@ fn test_write_skills_to_worktree_mcp_cursor() {
 }
 
 #[test]
+fn test_write_skills_to_worktree_mcp_grok() {
+    let dir = tempfile::tempdir().unwrap();
+    let wt = dir.path().to_string_lossy().to_string();
+
+    write_skills_to_worktree(&wt, dir.path(), &None, &["grok"]);
+
+    let cfg = dir.path().join(".grok/config.toml");
+    assert!(cfg.exists(), ".grok/config.toml should be written for grok");
+    let content = std::fs::read_to_string(&cfg).unwrap();
+    assert!(content.contains("[mcp_servers.agtx]"));
+    assert!(content.contains("mcp-serve"));
+}
+
+#[test]
+fn test_write_skills_to_worktree_mcp_grok_preserves_existing_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let wt = dir.path().to_string_lossy().to_string();
+    let grok_dir = dir.path().join(".grok");
+    std::fs::create_dir_all(&grok_dir).unwrap();
+    std::fs::write(
+        grok_dir.join("config.toml"),
+        "[mcp_servers.other]\ncommand = \"other\"\n",
+    )
+    .unwrap();
+
+    write_skills_to_worktree(&wt, dir.path(), &None, &["grok"]);
+
+    let content = std::fs::read_to_string(grok_dir.join("config.toml")).unwrap();
+    assert!(
+        content.contains("[mcp_servers.other]"),
+        "a project's own .grok/config.toml must not be clobbered: {content}"
+    );
+    assert!(content.contains("[mcp_servers.agtx]"));
+}
+
+#[test]
+fn test_write_skills_to_worktree_grok_skills() {
+    let dir = tempfile::tempdir().unwrap();
+    let wt = dir.path().to_string_lossy().to_string();
+
+    write_skills_to_worktree(&wt, dir.path(), &None, &["grok"]);
+
+    let skill = dir.path().join(".grok/skills/agtx-plan/SKILL.md");
+    assert!(skill.exists(), "grok skills go to .grok/skills/<name>/SKILL.md");
+    let content = std::fs::read_to_string(&skill).unwrap();
+    assert!(content.starts_with("---"), "frontmatter must be kept for grok");
+    // Canonical copy is always written too
+    assert!(dir.path().join(".agtx/skills/agtx-plan/SKILL.md").exists());
+}
+
+#[test]
 fn test_write_skills_to_worktree_mcp_codex() {
     let dir = tempfile::tempdir().unwrap();
     let wt = dir.path().to_string_lossy().to_string();

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -60,7 +60,7 @@ fn test_known_agents_includes_cursor() {
 fn test_known_agents_includes_all_expected() {
     let agents = known_agents();
     let names: Vec<&str> = agents.iter().map(|a| a.name.as_str()).collect();
-    for expected in &["claude", "codex", "copilot", "gemini", "opencode", "cursor"] {
+    for expected in &["claude", "codex", "copilot", "gemini", "opencode", "cursor", "grok"] {
         assert!(names.contains(expected), "missing agent: {}", expected);
     }
 }
@@ -145,6 +145,10 @@ fn test_build_resume_command_all_agents() {
     assert_eq!(
         by_name("cursor").build_resume_command(),
         "agent --yolo --continue"
+    );
+    assert_eq!(
+        by_name("grok").build_resume_command(),
+        "grok --yolo --trust --continue"
     );
 }
 
@@ -233,4 +237,64 @@ fn test_codex_transform_plugin_command_unchanged() {
 fn test_copilot_has_no_transform() {
     // Copilot: no interactive command transform
     assert_eq!(transform_plugin_command("/agtx:plan", "copilot"), None);
+}
+
+// =============================================================================
+// Tests for grok (xAI Grok Build) integration
+// =============================================================================
+
+#[test]
+fn test_known_agents_includes_grok() {
+    let agents = known_agents();
+    let grok = agents.iter().find(|a| a.name == "grok");
+    assert!(grok.is_some(), "grok should be in known_agents");
+    let grok = grok.unwrap();
+    assert_eq!(grok.command, "grok");
+    assert_eq!(grok.co_author, "Grok <noreply@x.ai>");
+}
+
+#[test]
+fn test_build_interactive_command_grok_no_prompt() {
+    let agents = known_agents();
+    let grok = agents.iter().find(|a| a.name == "grok").unwrap();
+    assert_eq!(grok.build_interactive_command(""), "grok --yolo --trust");
+}
+
+#[test]
+fn test_build_interactive_command_grok_with_prompt() {
+    let agents = known_agents();
+    let grok = agents.iter().find(|a| a.name == "grok").unwrap();
+    assert_eq!(
+        grok.build_interactive_command("do something"),
+        "grok --yolo --trust 'do something'"
+    );
+}
+
+#[test]
+fn test_build_interactive_command_grok_escapes_single_quotes() {
+    let agents = known_agents();
+    let grok = agents.iter().find(|a| a.name == "grok").unwrap();
+    let cmd = grok.build_interactive_command("it's a test");
+    assert!(cmd.starts_with("grok --yolo --trust "), "should use grok --yolo --trust: {cmd}");
+    // The quote must be escaped for the outer sh -c wrapper, not left bare.
+    assert!(cmd.contains("'\"'\"'"), "single quote must be escaped: {cmd}");
+}
+
+#[test]
+fn test_grok_has_native_skill_dir() {
+    let dir = agent_native_skill_dir("grok");
+    assert_eq!(dir, Some((".grok/skills", "")));
+}
+
+#[test]
+fn test_grok_transform_plugin_command() {
+    // Grok: colon → hyphen, slash kept (same as Cursor)
+    assert_eq!(
+        transform_plugin_command("/agtx:plan", "grok"),
+        Some("/agtx-plan".to_string())
+    );
+    assert_eq!(
+        transform_plugin_command("/gsd:plan-phase 1", "grok"),
+        Some("/gsd-plan-phase 1".to_string())
+    );
 }


### PR DESCRIPTION
Adds [Grok Build](https://docs.x.ai/build/overview) (`grok`, xAI's coding-agent CLI) as the seventh
supported agent, wired through the same seams as Cursor/Codex, plus benchmark configs and tools-image
support so it can be used in SWE-bench runs.

## Integration points

| Area | Change |
|---|---|
| `src/agent/mod.rs` | `grok` in `known_agents()`; launch `grok --yolo --trust`, resume `grok --yolo --trust --continue` |
| `src/agent/operations.rs` | Headless `grok -p <prompt>` for PR-description generation |
| `src/skills.rs` | Skills deploy to `.grok/skills/<name>/SKILL.md`; `/agtx:plan` → `/agtx-plan`; skill discovery scans `.grok/skills` |
| `src/tui/app.rs` | Skill deployment, `.grok/config.toml` MCP config, `/quit` on agent switch, activity detection, footer colour |
| `plugins/gsd/plugin.toml` | `grok` added to `supported_agents` |
| `benchmark/` | `grok-agtx`, `grok-agtx-terse`, `grok-void` configs; Grok baked into the prebaked tools image |

Grok is skill-shaped like Cursor (`SKILL.md` per directory, invoked as `/skill-name`), so most arms
are shared rather than duplicated.

## Two bugs found by running it for real

Both were invisible to unit tests and only surfaced when driving the actual TUI:

**1. The directory-trust dialog killed sessions.** On first launch in a new worktree Grok asks
*"Do you trust the contents of this directory? [y/n]"*. The task prompt agtx sends next was consumed
by that dialog — and its first `n` selected **No, quit**, so Grok exited before doing any work.
Fixed with `--trust`, which is also the gate on repo-local MCP servers: without it, the
`.grok/config.toml` agtx writes would never load either.

**2. `pane_current_command` reports `bash`, not `grok`.** The npm package launches the real binary
through a Node trampoline, so the pane never shows the agent's own process name and a live session
would eventually read as *Exited*. Fixed by adding `"Grok Build"` and `"Shift+Tab:mode"` to
`AGENT_ACTIVE_INDICATORS` — the same treatment Gemini and Cursor already get.

## MCP config

Grok reads project-scoped MCP servers from `.grok/config.toml` (TOML, not JSON). Unlike the other
writers, this one **appends** `[mcp_servers.agtx]` to any existing file and no-ops if the table is
already present, so a repo that ships its own `.grok/config.toml` is not clobbered.

## Benchmark support

Grok is installed into `agtx/swebench-tools:latest` and symlinked in from the read-only `/tools`
volume, exactly like Claude Code — no per-config install step. The symlink is tolerant, so a tools
volume that predates this PR degrades to "grok not found" for Grok runs and leaves Claude runs
untouched (`docker volume rm agtx-swebench-tools && python prebake_images.py --force` to refresh).

Container auth uses a snapshot of `~/.grok/auth.json` + `config.toml`, or `XAI_API_KEY` passed
through to the container's tmux env.

## Verification

Tested against **grok 1.0.5** (npm install, macOS host + linux/amd64 container):

- **Host, end-to-end:** real TUI in tmux, `default_agent = "grok"`, agtx plugin. Grok read the
  deployed skill, called the agtx MCP server, wrote `.agtx/plan.md` and `.agtx/execute.md`, and fixed
  a seeded bug. `/agtx-plan` and `/agtx-execute` both submitted on a single Enter — no autocomplete
  popup swallows it, so Grok stays out of the combined-send branch.
- **Sandbox:** `grok-agtx.toml` on `astropy__astropy-12907` inside its SWE-bench image. Grok runs as
  root without complaint, the tools-volume symlink resolves, credentials authenticate, and it
  produced the canonical upstream fix (`cright[...] = 1` → `= right`) plus a regression test.
- `--yolo` and `--dangerously-skip-permissions` are accepted as hidden aliases of `--always-approve`;
  `grok -p` prints plain text to stdout; `/quit` exits cleanly the way `switch_agent_in_tmux` sends it.
- `cargo test --features test-mocks` → **747 passed, 0 failed** (9 new tests: 6 in `tests/agent_tests.rs`,
  3 in `src/tui/app_tests.rs`).

## Docs

`README.md`, `CLAUDE.md` and `benchmark/README.md` updated for the new agent. Two corrections that
came out of the runs and are **not** Grok-specific:

- `void` configs are interactive-only — with no phase command or prompt, agtx prefills the task and
  waits for a human Enter, so an automated benchmark run stalls. Now warned in the benchmark README
  next to the plugin list.
- The tokscale caveat is now stated as which agents it can filter (Cursor and Grok can't be), rather
  than buried per-agent.

`docs/planning/grok-agent-support.md` carries the design notes and the full verification record.

## Known limitations

- No clear-context command wired for Grok, so `clear_context_on_advance` remains Claude-only.
- `tokscale` has no Grok filter → `cost_usd` / `cost_tokens` are `null` for sandbox Grok runs and
  unfiltered in host-mode runs (same as Cursor today).
- `--trust` appends each trusted project root to `~/.grok/trusted_folders.toml`, which grows over time.
- The sandbox run was validated up to the execute phase and then stopped; no completed
  `predictions.jsonl` from a full Grok benchmark run yet.