### PR TITLE
test: cover the checksum rejection branch

### DIFF
--- a/src/update/install.rs
+++ b/src/update/install.rs
@@ -72,6 +72,22 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+/// Compare a downloaded archive against its published `.sha256`.
+///
+/// Extracted from `install_release` so the **rejecting** branch is testable.
+/// A passing verification against a real release proves only that the happy
+/// path works; that a corrupted download actually aborts cannot be shown by
+/// any real release, because a real release matches. It has to be a test.
+pub fn verify_checksum(bytes: &[u8], sums_body: &str, archive: &str) -> Result<()> {
+    let expected = parse_sha256_file(sums_body)
+        .with_context(|| format!("malformed checksum file for {archive}"))?;
+    let actual = sha256_hex(bytes);
+    if actual != expected {
+        bail!("checksum mismatch for {archive}: expected {expected}, got {actual}");
+    }
+    Ok(())
+}
+
 /// What `agtx update` reports back, so the CLI and the TUI can render the same
 /// outcome differently.
 pub struct Installed {
@@ -152,14 +168,7 @@ pub fn install_release(tag: &str, progress: &mut dyn FnMut(&str)) -> Result<Inst
     progress("verifying checksum");
     let bytes = std::fs::read(&archive_path)?;
     match curl_to_string(&format!("{url}.sha256")) {
-        Ok(sums) => {
-            let expected = parse_sha256_file(&sums)
-                .with_context(|| format!("malformed checksum file for {archive}"))?;
-            let actual = sha256_hex(&bytes);
-            if actual != expected {
-                bail!("checksum mismatch for {archive}: expected {expected}, got {actual}");
-            }
-        }
+        Ok(sums) => verify_checksum(&bytes, &sums, &archive)?,
         // Releases before the workflow published checksums have none. Warn
         // rather than refuse, matching install.sh — but say so, so it is
         // visible rather than silent.

--- a/tests/update_tests.rs
+++ b/tests/update_tests.rs
@@ -423,3 +423,40 @@ fn target_path_resolves_to_a_real_file() {
         path.display()
     );
 }
+
+/// A verification that passes against a real release proves only the happy
+/// path — a real release always matches. That a *corrupted* download aborts
+/// can only be shown here.
+#[test]
+fn a_corrupted_archive_is_rejected() {
+    // The real v1.0.0 x86_64-darwin checksum file, verbatim.
+    let published = "b169b83adb8e837f8d5d8f6eb77d15101848109ec6f45217b5d32d6a77445dd3  agtx-v1.0.0-x86_64-darwin.tar.gz\n";
+    let archive = "agtx-v1.0.0-x86_64-darwin.tar.gz";
+
+    let err = install::verify_checksum(b"not the release tarball", published, archive)
+        .expect_err("a body that does not hash to the published digest must abort");
+    let msg = err.to_string();
+    assert!(msg.contains("checksum mismatch"), "{msg}");
+    assert!(
+        msg.contains("b169b83adb8e837f8d5d8f6eb77d15101848109ec6f45217b5d32d6a77445dd3"),
+        "the message must name the expected digest: {msg}"
+    );
+}
+
+#[test]
+fn a_matching_archive_passes() {
+    let body = b"pretend tarball";
+    let sums = format!(
+        "{}  agtx-v1.0.0-x86_64-linux.tar.gz\n",
+        install::sha256_hex(body)
+    );
+    install::verify_checksum(body, &sums, "agtx-v1.0.0-x86_64-linux.tar.gz").unwrap();
+}
+
+#[test]
+fn a_checksum_file_that_is_not_one_aborts_rather_than_skipping() {
+    // A 404 body reaching this point means the file existed but is garbage.
+    // Skipping verification on unreadable input would defeat the check.
+    assert!(install::verify_checksum(b"x", "Not Found", "a.tar.gz").is_err());
+    assert!(install::verify_checksum(b"x", "", "a.tar.gz").is_err());
+}


### PR DESCRIPTION
Verified against the real v1.0.0 release: install.sh printed "Checksum verified" for the first time in its life, and `agtx update` from a 0.9.0-stamped build verified, swapped and left nothing behind.

But a verification that passes against a real release only exercises the happy path — a real release always matches, so no real release can show that a corrupted download aborts. The comparison was inline in install_release and therefore untestable; extract it as verify_checksum and cover the rejecting branch: a body that does not hash to the published digest, a checksum file that is not one, and an empty one.