### PR TITLE
feat: add kimi Code

### DIFF
--- a/.claude/commands/agtx/execute.md
+++ b/.claude/commands/agtx/execute.md
@@ -1,0 +1,43 @@
+---
+name: agtx:execute
+description: Execute an approved implementation plan. Implement the changes, then write a summary to .agtx/execute.md and stop.
+---
+
+# Execution Phase
+
+You are in the **execution phase** of an agtx-managed task.
+
+## Input
+
+The argument to this command is a task ID.
+
+If `.agtx/plan.md` exists in the current working directory, read it — it already contains the approved plan and all needed context. Do NOT call `get_task`.
+
+If `.agtx/plan.md` does not exist, fetch the task description:
+```
+mcp__agtx__get_task(task_id: "<the id passed to this command>")
+```
+
+## Instructions
+
+1. Read `.agtx/plan.md` if it exists (skip `get_task`), otherwise fetch via `get_task`
+2. Implement the changes
+3. Run relevant tests to verify your changes
+4. Fix any issues found during testing
+
+## Output
+
+When implementation is complete, write a summary to `.agtx/execute.md` in the **current working directory** with these sections:
+
+## Changes
+What files were modified/created and what was changed in each.
+
+## Testing
+How you verified the changes — tests run, results, manual checks.
+
+## CRITICAL: Stop After Writing
+
+After writing `.agtx/execute.md` (in the current working directory):
+- Do NOT start new work beyond the plan
+- Say: "Implementation complete. Summary written to `.agtx/execute.md`."
+- Wait for further instructions

--- a/.claude/commands/agtx/merge-conflicts.md
+++ b/.claude/commands/agtx/merge-conflicts.md
@@ -1,0 +1,52 @@
+---
+name: agtx:merge-conflicts
+description: Resolve merge conflicts by merging the default branch into the current feature branch.
+---
+
+# Merge Conflict Resolution
+
+Your feature branch has **merge conflicts** with the default branch (main/master).
+
+## Instructions
+
+1. First, commit all current work so nothing is lost:
+   - Review the staged/unstaged changes with `git diff` and `git diff --cached`
+   - Write a descriptive commit message that summarizes the actual changes
+   - `git add -A && git commit -m "<your message>"`
+   - If there is nothing to commit, skip this step.
+
+2. Merge the default branch into your current branch:
+   ```bash
+   git fetch origin
+   git merge origin/main
+   ```
+   If the project uses `master` instead of `main`, use `origin/master`.
+
+3. Resolve ALL merge conflicts:
+   - **Before resolving**, note which files have conflicts: `git diff --name-only --diff-filter=U`
+   - Open each conflicted file
+   - Remove conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
+   - Choose the correct resolution for each conflict, preserving both sides' intent when possible
+
+4. After resolving all conflicts:
+   - `git add -A && git commit --no-edit`
+
+5. **Review only the conflicted files** to catch resolution mistakes:
+   - For each file that had conflicts (from step 3), compare your resolution against both parents:
+     - `git diff HEAD^2..HEAD -- <file>` (what changed vs the default branch — shows only your feature's additions). **Start here** — this is usually the smaller, more focused diff.
+     - `git diff HEAD^1..HEAD -- <file>` (what changed vs your branch before merge — shows what main brought in). This can be very large; if so, focus on the areas around the conflict markers you resolved rather than reading the entire diff.
+   - Verify:
+     - No code was accidentally dropped from either side
+     - The combined logic is coherent (e.g., imports, function signatures, variable names all consistent)
+     - No duplicate code blocks were introduced
+   - If you find a problem, fix it immediately and commit the fix separately
+
+6. Run tests to verify nothing is broken. Fix any issues introduced by the merge.
+
+## Rules
+
+- **Always merge, never rebase.** The branch may have been shared or pushed.
+- Do NOT squash commits.
+- Do NOT force push.
+- After committing the merge, say: "Merge conflicts resolved and committed."
+- Then **stop and wait** for further instructions.

--- a/.claude/commands/agtx/orchestrate.md
+++ b/.claude/commands/agtx/orchestrate.md
@@ -1,0 +1,199 @@
+---
+name: agtx:orchestrate
+description: Orchestrate the agtx kanban board — advance tasks through planning and running phases, monitor completions, and coordinate multiple agents working in parallel.
+---
+
+# Orchestrator Agent
+
+You are the **orchestrator** for an agtx kanban board. Your job is to advance tasks
+through the **Planning** and **Running** phases until they reach **Review**.
+
+The user manages the Backlog and Research columns. Once a task lands in Planning,
+you take over and drive it to Review — that's where your responsibility ends.
+
+## Available MCP Tools
+
+You have access to these agtx MCP tools:
+
+- **list_tasks** — List all tasks, optionally filtered by status
+- **get_task** — Get full details of a specific task. Includes `allowed_actions`
+  showing which transitions are valid given the task's status and plugin rules.
+- **move_task** — Queue a task state transition (the TUI executes it with full side effects)
+  - Actions: `move_forward`, `escalate_to_user` (flag task for user attention with a reason)
+- **get_transition_status** — Check if a queued transition completed
+- **get_notifications** — Manually fetch pending notifications (usually not needed —
+  notifications are pushed to you automatically when you are idle).
+- **read_pane_content(task_id, lines?)** — Read the last N lines of a task's agent pane
+  (default 50). Use this to see what an agent is showing when a task is stuck.
+- **send_to_task(task_id, message)** — Send a message + Enter to a task's agent pane.
+  Only works for Planning or Running tasks. Use to answer CLI prompts or nudge stuck agents.
+## How You Receive Updates
+
+Notifications are **pushed to you automatically** when you are idle (waiting for input).
+You will receive messages like:
+
+```
+[agtx] Task "fix-auth-bug" (abc12345) completed phase: planning
+```
+
+This is the **only** type of notification you receive — a phase has completed and the
+task is ready to advance. Simply react by moving the task forward.
+If multiple events happened at once, they are combined with `|` separators in a single message.
+
+## Task Lifecycle
+
+```
+Backlog → Research → Planning → Running → Review
+                     ^^^^^^^^    ^^^^^^^
+                     you manage these two phases
+```
+
+- The user moves tasks from Backlog/Research into Planning (or directly into Running).
+- Once a task is in Planning or Running, you are responsible for advancing it.
+- Use `move_task` with action `move_forward` to advance a task to its next phase.
+- **Review is the final state you manage.** Do not move tasks to Done — the user
+  handles merging and cleanup manually.
+
+## Strategy
+
+1. **On startup:** Call `list_tasks` to understand the current board state.
+   Check for tasks in Planning or Running that may need advancing.
+2. **When notified a task entered Planning:** Note it. Wait for its planning phase
+   to complete before advancing.
+3. **When notified of phase completion:**
+   - Read the task details with `get_task`
+   - Check `allowed_actions` — only use actions listed there
+   - If the task is in Planning and planning is complete → `move_forward` to Running
+   - If the task is in Running and running is complete → `move_forward` to Review
+   - If the task is already in Review, your job is done for that task
+4. **Concurrency:** Don't worry about how many tasks are active — the user controls
+   what enters Planning/Running. Just advance what's there.
+5. **Error handling:** If `get_transition_status` shows an error, investigate
+   and try a different approach.
+6. **When idle:** After processing all current work, output exactly
+   `[agtx:idle]` on its own line, then wait for the next notification.
+   Do not poll in a loop. You **must** output `[agtx:idle]` every time you
+   finish processing and have no more pending work — this is how the board
+   knows you are ready to receive the next notification.
+
+## Rules
+
+- **You are a coordinator, not a reviewer.** Your job is to move tasks between phases.
+  Do not read, evaluate, or critique the code or plans produced by coding agents.
+  A separate agent handles review in the Review phase.
+- When a phase completes, advance the task immediately — do not inspect the output.
+- Only act on tasks in Planning or Running — never touch Backlog or Research tasks.
+- Always check `allowed_actions` before choosing a transition.
+- Do not move tasks beyond Review — merging is the user's responsibility.
+- When idle with no pending work, output `[agtx:idle]` and wait — notifications
+  will be pushed to you. Never skip the idle signal.
+
+## Handling Stuck Tasks
+
+When you receive a notification like:
+```
+Task "fix-auth" (abc12345) has been idle for 1m in phase: running
+```
+
+1. Call `read_pane_content(task_id)` to see what the agent is showing.
+2. Classify what you see using the decision rules below, then act accordingly.
+3. After acting, output `[agtx:idle]` on its own line and wait for the next notification.
+
+**Important:** `escalate_to_user` shows a visible warning banner to the user in the TUI
+with your reason text. Keep the reason concise (one sentence). The user will see it when
+they open the task popup.
+
+---
+
+### Decision Rules
+
+#### Yes/No confirmation prompt
+
+Pattern: `[y/N]`, `[Y/n]`, `[y/n]`, `(yes/no)`, `Continue?`, `Press Enter to continue`
+
+- The **uppercase letter** is the default — send it.
+- `[Y/n]` → send `y`
+- `[y/N]` → send `n`
+- `[y/n]` (equal case) → send `y`
+- "Press Enter to continue" → send `""`
+
+After sending, call `read_pane_content` to confirm the prompt was dismissed.
+
+**Examples:**
+```
+Remove 14 packages? [y/N]
+→ send_to_task: "n"
+
+Proceed with installation? [Y/n]
+→ send_to_task: "y"
+
+Press Enter to continue
+→ send_to_task: ""
+```
+
+---
+
+#### Numbered option menu
+
+Pattern: A list of numbered options (`1)`, `2)`, etc.) with a question above.
+
+- If **one option is marked as recommended** (e.g. `(recommended)`, `[default]`, `*`,
+  `(default)`, highlighted with `>`): send that option's number.
+- If **no option is marked as recommended**: escalate to the user — do not guess.
+
+After sending a selection, call `read_pane_content` to confirm the prompt was dismissed.
+
+**Examples:**
+```
+? Select package manager
+  1) npm (recommended)
+  2) yarn
+  3) pnpm
+→ send_to_task: "1"
+
+? Choose database adapter
+  1) PostgreSQL
+  2) MySQL
+  3) SQLite
+→ escalate_to_user: "Agent is asking which database adapter to use — no default recommended"
+
+? Initialize git repository?
+> Yes (default)
+  No
+→ send_to_task: "1"
+```
+
+---
+
+#### Domain question from the agent
+
+Pattern: The agent (not a CLI tool) is asking a question that requires project knowledge,
+architectural judgment, or user preference. Indicators: the question is in prose, refers
+to the task's codebase, mentions trade-offs, or asks "Should I...", "Which approach...",
+"Do you want me to...".
+
+**Always escalate. Never answer domain questions on the user's behalf.**
+
+Call `move_task` with `action: "escalate_to_user"` and set `reason` to a one-sentence
+summary of what the agent is asking.
+
+**Examples:**
+```
+Should I split this into two separate modules or keep it in one file?
+→ escalate_to_user: "Agent is asking whether to split the module — needs user decision"
+
+I can implement this with either a REST API or GraphQL. Which do you prefer?
+→ escalate_to_user: "Agent is asking whether to use REST or GraphQL — needs user decision"
+```
+
+---
+
+#### Agent stuck on an error or in a loop
+
+Pattern: The same error message repeats, the agent is spinning, or the pane shows no
+progress despite prior nudges.
+
+- Compose a short nudge based on what you see (e.g. "The last approach failed with X.
+  Try Y instead.") and call `send_to_task`.
+- If a **second** idle notification arrives for the same task after your nudge,
+  escalate to the user with `escalate_to_user` — do not keep nudging indefinitely.

--- a/.claude/commands/agtx/plan.md
+++ b/.claude/commands/agtx/plan.md
@@ -1,0 +1,45 @@
+---
+name: agtx:plan
+description: Plan a task implementation. Analyze the codebase, create a detailed plan, write it to .agtx/plan.md, then stop and wait for user approval before making any changes.
+---
+
+# Planning Phase
+
+You are in the **planning phase** of an agtx-managed task.
+
+## Input
+
+The argument to this command is a task ID. Fetch the task description using the agtx MCP tool:
+```
+mcp__agtx__get_task(task_id: "<the id passed to this command>")
+```
+Use the `description` field as the task to work on. Also check for `.agtx/research.md` if a research phase was completed first.
+
+## Instructions
+
+1. Fetch the task description via `get_task`
+2. If `.agtx/research.md` exists, read it for prior analysis
+3. Explore the codebase to understand relevant files, patterns, and architecture
+4. Identify all files that need to be created or modified
+5. Create a detailed implementation plan
+
+## Output
+
+Write your plan to `.agtx/plan.md` in the **current working directory** (do NOT navigate up — write directly to `.agtx/plan.md` relative to where you are now) with these sections:
+
+## Analysis
+What you found in the codebase — relevant files, patterns, dependencies.
+
+## Plan
+Step-by-step implementation plan — files to modify, approach, order of changes.
+
+## Risks
+What could go wrong — edge cases, breaking changes, areas needing extra care.
+
+## CRITICAL: Stop After Writing
+
+After writing `.agtx/plan.md` (in the current working directory):
+- Do NOT start implementing
+- Do NOT modify any source files
+- Say: "Plan written to `.agtx/plan.md`. Waiting for approval."
+- Wait for explicit instructions to proceed

--- a/.claude/commands/agtx/research.md
+++ b/.claude/commands/agtx/research.md
@@ -1,0 +1,48 @@
+---
+name: agtx:research
+description: Explore the codebase to understand a task before planning. Write findings to .agtx/research.md and stop. This is a read-only exploration — do not modify any files.
+---
+
+# Research Phase
+
+You are in the **research phase** of an agtx-managed task. This is a read-only exploration.
+
+## Input
+
+The argument to this command is a task ID. Fetch the task description using the agtx MCP tool:
+```
+mcp__agtx__get_task(task_id: "<the id passed to this command>")
+```
+Use the `description` field as the task to work on.
+
+## Instructions
+
+1. Fetch the task description via `get_task`
+2. Explore the codebase to find relevant files, patterns, and architecture
+3. Identify dependencies, related code, and potential complexity
+4. Assess feasibility and estimate scope
+
+## Output
+
+Write your findings to `.agtx/research.md`. Include:
+
+## Relevant Files
+Key files and their roles — what exists, what needs changing.
+
+## Architecture
+How the relevant parts of the codebase fit together.
+
+## Complexity
+Assessment of scope — simple change, moderate refactor, or major undertaking.
+
+## Open Questions
+Things that need clarification before planning can begin.
+
+## CRITICAL: Do Not Modify Code
+
+This is a **read-only** exploration:
+- Do NOT modify any source files
+- Do NOT create branches or worktrees
+- Do NOT start planning or implementing
+- Say: "Research complete. Findings written to .agtx/research.md."
+- Wait for further instructions

--- a/.claude/commands/agtx/review.md
+++ b/.claude/commands/agtx/review.md
@@ -1,0 +1,35 @@
+---
+name: agtx:review
+description: Self-review completed work. Check for correctness, edge cases, and code quality. Write review to .agtx/review.md and stop.
+---
+
+# Review Phase
+
+You are in the **review phase** of an agtx-managed task.
+
+## Instructions
+
+1. Review all changes made during execution: run `git diff HEAD` (staged+unstaged) and `git log --oneline $(git merge-base HEAD origin/HEAD)..HEAD` to see only your commits. Do NOT diff against `main` or `origin/main` — those may include unrelated upstream history.
+2. Check for:
+   - Correctness and edge cases
+   - Error handling
+   - Code style consistency with the existing codebase
+   - Test coverage
+   - Security issues (injection, XSS, etc.)
+3. Fix any issues you find
+
+## Output
+
+Write your review to `.agtx/review.md` in the **current working directory** with these sections:
+
+## Review
+Findings from your review — what looks good, what was fixed, any concerns.
+
+## Status
+Either `READY` (good to merge) or `NEEDS_WORK` (with explanation of remaining issues).
+
+## CRITICAL: Stop After Writing
+
+After writing `.agtx/review.md` (in the current working directory):
+- Say: "Review written to `.agtx/review.md`."
+- Wait for further instructions

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,11 @@
 {
   "mcpServers": {
     "agtx": {
-      "type": "stdio",
-      "command": "agtx",
-      "args": ["mcp-serve"]
+      "args": [
+        "mcp-serve",
+        "/Users/fynn/workspace/agtx"
+      ],
+      "command": "/Users/fynn/workspace/agtx/target/debug/agtx"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # AGTX - Terminal Kanban for Coding Agents
 
-A terminal-native kanban board for managing multiple coding agent sessions (Claude Code, Codex, Gemini, Copilot, OpenCode, Cursor, Grok, Antigravity) with isolated git worktrees.
+A terminal-native kanban board for managing multiple coding agent sessions (Claude Code, Codex, Gemini, Copilot, OpenCode, Cursor, Grok, Antigravity, pi, Kimi Code) with isolated git worktrees.
 
 ## Quick Start
 
@@ -192,6 +192,8 @@ Skills are markdown files with YAML frontmatter deployed to agent-native discove
 - Cursor: `.cursor/skills/agtx-plan/SKILL.md`
 - Grok: `.grok/skills/agtx-plan/SKILL.md`
 - Antigravity: `.agents/skills/agtx-plan/SKILL.md` (vendor-neutral tree, not an agent dotdir)
+- pi: `.pi/skills/agtx-plan/SKILL.md`
+- Kimi: `.kimi-code/skills/agtx-plan/SKILL.md` (**not** `.agents/`, which kimi also scans — that tree is antigravity's, and both may be configured for different phases of one worktree)
 - OpenCode: `.opencode/command/agtx-plan.md` (frontmatter stripped)
 - Copilot: `.github/agents/agtx/plan.md`
 
@@ -209,8 +211,9 @@ Canonical copy always at `.agtx/skills/agtx-plan/SKILL.md`.
 | antigravity | `.agents/mcp_config.json` | JSON, `mcpServers` |
 | opencode | opencode config | JSON, `mcp` |
 | pi | `.pi/mcp.json` | JSON, `mcpServers` |
+| kimi | `.kimi-code/mcp.json` | JSON, `mcpServers` |
 
-Four writers **merge** instead of overwriting, because their file may already exist in the worktree — either tracked in the repo, or (for `.gemini`, `.grok` and `.agents`) copied in from the project root by `AGENT_CONFIG_DIRS`; `.pi` is not in that list, so only the tracked-in-the-repo half applies to it. Grok appends `[mcp_servers.agtx]` to any existing `.grok/config.toml`; antigravity parses `.agents/mcp_config.json` and inserts `mcpServers.agtx`, preserving other servers and top-level sibling keys (`.agents/` is vendor-neutral, so a project is more likely to ship one); gemini inserts into `.gemini/settings.json`, which otherwise loses the user's theme, model and any other `mcpServers`; pi's `.pi/mcp.json` is where the `pi-mcp-adapter` package persists its own per-server `disabled` flags, so clobbering it re-enables servers the user switched off. pi has no MCP client of its own — without that package the file is inert, not harmful. Claude's `settings.local.json` side-effect below merges for the same reason.
+Five writers **merge** instead of overwriting, because their file may already exist in the worktree — either tracked in the repo, or (for `.gemini`) copied in from the project root by `AGENT_CONFIG_DIRS`; `.grok`, `.agents`, `.pi` and `.kimi-code` are not in that list, so only the tracked-in-the-repo half applies to them. Grok appends `[mcp_servers.agtx]` to any existing `.grok/config.toml`; antigravity parses `.agents/mcp_config.json` and inserts `mcpServers.agtx`, preserving other servers and top-level sibling keys (`.agents/` is vendor-neutral, so a project is more likely to ship one); gemini inserts into `.gemini/settings.json`, which otherwise loses the user's theme, model and any other `mcpServers`; pi's `.pi/mcp.json` is where the `pi-mcp-adapter` package persists its own per-server `disabled` flags, so clobbering it re-enables servers the user switched off. pi has no MCP client of its own — without that package the file is inert, not harmful. Kimi's `.kimi-code/mcp.json` is the standard `mcpServers` shape and is also what its in-TUI `/mcp-config` writes, so a task must not drop what the user or the repo put there. Claude's `settings.local.json` side-effect below merges for the same reason.
 
 Claude needs an extra side-effect to avoid an interactive dialog on first open: `.claude/settings.local.json` gets `enableAllProjectMcpServers: true` plus `skipDangerousModePermissionPrompt: true`, which is what actually preflights the bypass-permissions warning (see the dialog table).
 
@@ -224,6 +227,7 @@ agtx used to append a `[projects."<worktree>"] trust_level = "trusted"` entry to
 Commands are written once in canonical format (`/ns:command`) and auto-translated:
 - Claude/Gemini: `/ns:command` (unchanged)
 - OpenCode/Cursor/Grok/Antigravity: `/ns-command` (colon → hyphen, slash kept)
+- pi/Kimi: `/skill:ns-command` — both keep every skill in one `skill:` namespace, so the plugin's namespace folds into the skill *name* rather than staying a prefix
 - Codex: `$ns-command` (slash → dollar, colon → hyphen)
 - Copilot: no interactive skill invocation (prompt only, no commands sent)
 
@@ -243,7 +247,7 @@ Two consequences worth knowing: `resolve_skill_command(collapse: false)` is used
 **Mid-session lane — phase advances into an already-running agent.** `send_skill_and_prompt()`, three paths, because agent TUIs disagree about how a slash command plus arguments must arrive:
 
 1. **opencode** — its picker strips arguments if the whole string is typed at once. So: send the bare command name → wait for the picker → Enter (inserts it) → send the args → Enter. Still on the typed path: it is the one flow where the text has to arrive in two pieces by design
-2. **gemini / codex / cursor / antigravity / pi** — skill + prompt combined into a *single* message delivered by **bracketed paste** (`paste_text`), then one Enter. The paste is atomic, so the old poll-until-it-renders step is gone, and the `\n\n` joining command to prompt stays literal text instead of arriving as a real Enter that submits the message half-written. Gemini executes-and-loses a separately sent prompt; Codex's `$skill` mentions are inline references that do nothing when sent standalone; pi's composer takes a paste as literal text but leaves a combined text+Enter `send_keys` sitting unsent. **How many Enters this takes is not fixed** — see *Submitting is its own delivery problem* below
+2. **gemini / codex / cursor / antigravity / pi / kimi** — skill + prompt combined into a *single* message delivered by **bracketed paste** (`paste_text`), then one Enter. The paste is atomic, so the old poll-until-it-renders step is gone, and the `\n\n` joining command to prompt stays literal text instead of arriving as a real Enter that submits the message half-written. Gemini executes-and-loses a separately sent prompt; Codex's `$skill` mentions are inline references that do nothing when sent standalone; pi's composer takes a paste as literal text but leaves a combined text+Enter `send_keys` sitting unsent, and kimi's is the same pi-tui composer. **How many Enters this takes is not fixed** — see *Submitting is its own delivery problem* below
 3. **everything else** (claude, copilot, grok) — the generic `match (skill_cmd, prompt_trigger)` path using `send_keys`, waiting on `prompt_triggers` between the command and the prompt when configured
 
 **Submitting is its own delivery problem.** A message with a prompt after the command submits on the first Enter. A **bare skill command** — what a phase whose command carries no `{task}`/`{task_id}` sends, which is `review` — exactly matches a skill name, so the composer's command picker opens *on the paste*. That Enter is then consumed by the picker ("Press enter to insert"), which inserts the command and repaints, leaving it parked. Measured against codex-cli 0.144.5 and cursor-agent 2026.08.25: both open the picker on a pasted bare command, and both submit on the second Enter.
@@ -305,6 +309,7 @@ Dialogs are declared per agent on `AgentSpec::dialogs` and **matched against the
 | gemini | folder trust | `Do you trust the files in this folder?` | `1` `Enter` | Launch — answering it restarts the process |
 | cursor | workspace trust | `Workspace Trust Required` | `a` alone | Launch — its question line is *identical* to codex's, so it is matched on the heading. Answered with the access key the dialog advertises, which survives an option being added above the highlighted row |
 | antigravity | project trust | `Do you trust the contents of this project?` | `Enter` alone | Launch — arrow-navigated with "Yes, I trust this folder" preselected, so a digit would land in the composer. Its own wording, not Claude's; codex's differs by one word (`directory`) |
+| kimi | workspace trust | `Trust this folder?` | `Up` `Enter` | Launch — per directory, and **the default answer exits the process**: it is arrow-navigated with `Don't trust` preselected (`selectedIndex = 1`), and choosing it calls `stop()` before a session exists. So never a bare Enter, and never a digit (which would be typed as text). The exact inverse of antigravity's identically-shaped prompt above; do not generalise between them. Mostly moot in practice — `agent::trust` seeds the worktree first |
 
 `require_all` distinguishes alternatives (several wordings of one prompt) from conjunctions (a prompt identified only by a combination of phrases). `security` marks the rows agtx will not answer unless `auto_trust` is on.
 
@@ -689,6 +694,7 @@ pane-hash heuristic — is a supported state, not a degraded one.
 | antigravity | `.agents/hooks.json` | keyed by hook *name*, then event | **none** — passed as `--event` | no |
 | codex | `.codex/hooks.json` | `{description, hooks:{…}}` | `hook_event_name`, PascalCase | mapped, **not deployed** |
 | opencode, copilot, pi | — | — | — | no hooks; see `HookConfigKind` |
+| kimi | — | — | — | Claude-shaped hooks exist, but `[[hooks]]` is **user-global only** (`~/.kimi-code/config.toml`); the one project-local file, `.kimi-code/local.toml`, takes a `[workspace]` table and nothing else |
 
 The formats are **not interchangeable**, and every mismatch below fails silently — a valid-looking
 config in the worktree and no status file ever written. This is why `tests/smoke/agent_smoke.py` is
@@ -808,7 +814,7 @@ writes one.
 - Every per-agent value below is one field of that agent's `AgentSpec` in `src/agent/spec.rs`; the
   functions here read the table rather than matching on the agent's name
 - Agents spawned via `build_interactive_command()` in `src/agent/mod.rs`
-- Each agent has its own flags: Claude (`--dangerously-skip-permissions`), Codex (`--sandbox workspace-write`), Gemini (`GEMINI_TRUST_WORKSPACE=true` + `--approval-mode yolo`), Copilot (`--allow-all-tools`), Cursor (`agent --yolo`), Grok (`--yolo --trust`, where `--trust` also ungates the repo-local `.grok/config.toml` MCP server and suppresses the directory-trust dialog), Antigravity (`agy --dangerously-skip-permissions --mode accept-edits` — two orthogonal controls: the flag governs shell/MCP/URL approvals, `--mode` governs the file-edit diff review, and both are needed to run unattended)
+- Each agent has its own flags: Claude (`--dangerously-skip-permissions`), Codex (`--sandbox workspace-write`), Gemini (`GEMINI_TRUST_WORKSPACE=true` + `--approval-mode yolo`), Copilot (`--allow-all-tools`), Cursor (`agent --yolo`), Grok (`--yolo --trust`, where `--trust` also ungates the repo-local `.grok/config.toml` MCP server and suppresses the directory-trust dialog), Antigravity (`agy --dangerously-skip-permissions --mode accept-edits` — two orthogonal controls: the flag governs shell/MCP/URL approvals, `--mode` governs the file-edit diff review, and both are needed to run unattended), pi (`--approve`), Kimi (`--auto`, **not** `-y/--yolo`: they are separate flags and yolo's own help says the agent "may still ask questions", which hangs an unattended session, where `--auto` is "fully autonomous")
 - `build_resume_command()` is the recovery variant used after a tmux/server restart — mostly `--continue` appended to the launch flags (`ResumeArgs::Append`), but Gemini uses `--resume` and Codex's `resume --last` *replaces* them (`ResumeArgs::Replace`: `codex resume` rejects `--sandbox`)
 - `tests/agent_parity_tests.rs` pins every one of these strings per agent. It is written against
   behaviour, not derived from the table, so a diff there means something actually changed
@@ -898,10 +904,10 @@ Half of this is now one table entry; the other half is still per-agent match arm
    a `.agtx/status/*.json`: a wrong handler shape or event spelling fails silently (see
    *Hook-Based Phase Status*), and `None` is a supported state, not a failure
 10. Add an agent label color in the task-card footer `match task.agent.as_str()`
-11. If Ink/Node TUI: add to the combined-send branch `matches!(agent_name, "gemini" | "codex" | ...)` in `send_skill_and_prompt()`; add double-Enter handling if the agent has a command picker popup
+11. If Ink/Node TUI: set `send_strategy: SendStrategy::Combined` on the spec, which is what `send_skill_and_prompt()` selects the bracketed-paste path from. `submit_message()` counts nothing and watches the composer, so a command picker needing a second Enter needs no extra handling
 
 **Plugins**
-12. Add the agent to `supported_agents` in any `plugins/*/plugin.toml` that whitelists agents
+12. Add the agent to `supported_agents` in any `plugins/*/plugin.toml` that whitelists agents. Only `gsd`, `superpowers` and `oh-my-claudecode` whitelist; the precedent for a newly added agent is to leave it out until a live run says otherwise, as pi, antigravity and kimi are
 
 ### Adding a keyboard shortcut
 1. Find the appropriate `handle_*_key` function in `src/tui/app.rs`
@@ -937,6 +943,8 @@ Detected automatically via `known_agents()` in order of preference:
 6. **cursor** - Cursor Agent CLI (binary is `agent`)
 7. **grok** - xAI's Grok Build CLI
 8. **antigravity** - Google's Antigravity CLI (binary is `agy`)
+9. **pi** - Earendil's pi coding agent
+10. **kimi** - Moonshot AI's Kimi Code CLI
 
 ## Future Enhancements
 - Reopen Done tasks (recreate worktree from preserved branch)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 <a href="https://github.com/google-gemini/gemini-cli"><kbd><img src="docs/logos/gemini.svg" width="18" valign="middle" /> Gemini CLI</kbd></a>
 <a href="https://github.com/github/copilot-cli"><kbd><img src="docs/logos/copilot-dark.svg" width="18" valign="middle" /> Copilot</kbd></a>
 <a href="https://github.com/earendil-works/pi"><kbd><img src="docs/logos/pi-dark.svg" width="18" valign="middle" /> pi</kbd></a>
+<a href="https://github.com/MoonshotAI/kimi-code"><kbd>Kimi Code</kbd></a>
 - **Multi-agent task lifecycle**: Configure different agents per workflow phase — e.g. Gemini for research, Claude for implementation, Codex for review — with automatic agent switching.
 - **Multi-project dashboard**: Manage agent sessions across all projects via a single TUI.
 - **Parallel execution**: Every task gets its own git worktree and tmux window — run as many agents as needed, simultaneously.
@@ -359,6 +360,19 @@ Register `agtx mcp-serve` with the adapter, then in any pi session:
 </details>
 
 <details>
+<summary><strong>Kimi Code</strong></summary>
+
+```bash
+mkdir -p ~/.kimi-code/skills/agtx-sweep
+cp skills/sweep/SKILL.md ~/.kimi-code/skills/agtx-sweep/SKILL.md
+```
+
+Add `agtx mcp-serve` to `~/.kimi-code/mcp.json` under `mcpServers`, then in any
+kimi session: `/skill:agtx-sweep` / `/skill:agtx-brainstorm`
+
+</details>
+
+<details>
 <summary><strong>Other</strong></summary>
 
 Register `agtx mcp-serve` as an MCP server, then copy `skills/sweep/SKILL.md` into your agent's context.
@@ -469,21 +483,21 @@ Press `P` to switch plugins. Ships with 10 built-in:
 
 Commands are written once in canonical format and automatically translated per agent:
 
-| Canonical (plugin.toml) | Claude / Gemini | Codex | OpenCode | Cursor | Grok | Antigravity | pi |
-|--------------------------|-----------------|-------|----------|--------|------|-------------|----|
-| `/agtx:plan` | `/agtx:plan` | `$agtx-plan` | `/agtx-plan` | `/agtx-plan` | `/agtx-plan` | `/agtx-plan` | `/skill:agtx-plan` |
+| Canonical (plugin.toml) | Claude / Gemini | Codex | OpenCode | Cursor | Grok | Antigravity | pi | Kimi |
+|--------------------------|-----------------|-------|----------|--------|------|-------------|----|------|
+| `/agtx:plan` | `/agtx:plan` | `$agtx-plan` | `/agtx-plan` | `/agtx-plan` | `/agtx-plan` | `/agtx-plan` | `/skill:agtx-plan` | `/skill:agtx-plan` |
 
-|  | Claude | Codex | Gemini | OpenCode | Cursor | Copilot | Grok | Antigravity | pi |
-|--|:------:|:-----:|:------:|:--------:|:------:|:-------:|:----:|:-----------:|:--:|
-| **agtx** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | ✅ | ✅ |
-| **gsd** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ |
-| **spec-kit** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | ✅ | 🟡 |
-| **openspec** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | ✅ | 🟡 |
-| **bmad** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | ✅ | 🟡 |
-| **superpowers** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **oh-my-claudecode** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **agent-skills** | ✅ | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 |
-| **void** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+|  | Claude | Codex | Gemini | OpenCode | Cursor | Copilot | Grok | Antigravity | pi | Kimi |
+|--|:------:|:-----:|:------:|:--------:|:------:|:-------:|:----:|:-----------:|:--:|:----:|
+| **agtx** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | ✅ | ✅ | ✅ |
+| **gsd** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| **spec-kit** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | ✅ | 🟡 | 🟡 |
+| **openspec** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | ✅ | 🟡 | 🟡 |
+| **bmad** | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | ✅ | 🟡 | 🟡 |
+| **superpowers** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **oh-my-claudecode** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **agent-skills** | ✅ | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 |
+| **void** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 
 ✅ Skills, commands, and prompts fully supported · 🟡 Prompt only, no interactive skill support · ❌ Not supported

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -51,6 +51,11 @@ impl Agent {
             Some(s) if s.launch_prompt_verified => match s.prompt_form {
                 spec::PromptForm::Argv => PromptInjection::Argv,
                 spec::PromptForm::Flag(flag) => PromptInjection::FlagInteractive(flag),
+                // Belt and braces with the spec-table invariant that forbids
+                // this combination: an agent whose CLI takes no opening message
+                // can never be put on the launch lane, however its
+                // `launch_prompt_verified` is set.
+                spec::PromptForm::None => PromptInjection::Unknown,
             },
             _ => PromptInjection::Unknown,
         }

--- a/src/agent/spec.rs
+++ b/src/agent/spec.rs
@@ -24,6 +24,20 @@ pub enum PromptForm {
     Argv,
     /// Prompt flag: `gemini -i '<text>'`.
     Flag(&'static str),
+    /// The CLI takes no opening message at all.
+    ///
+    /// Not "unverified" — *absent*. Kimi Code is the case: its argument parser
+    /// is `program.argument('[args...]')` followed by
+    /// `program.error("unknown command '<arg>'")`, so a positional prompt kills
+    /// the process on startup, and its only prompt flag (`-p, --prompt`) is
+    /// print mode. There is no third option, so [`compose_command`] appends
+    /// nothing and the prompt goes down the mid-session lane instead.
+    ///
+    /// Paired invariant, asserted below: a `None`-form agent must never be
+    /// `launch_prompt_verified`. `prompt_injection` maps it to
+    /// `PromptInjection::Unknown` regardless, so both halves have to be wrong
+    /// before a task's text can be dropped.
+    None,
 }
 
 /// How the resume flags combine with [`AgentSpec::base_args`].
@@ -58,10 +72,11 @@ pub enum CommandSyntax {
     Hyphen,
     /// `$ns-command` — Codex's inline skill reference.
     Dollar,
-    /// `/skill:ns-command` — pi's skill commands live in one `skill:` namespace
-    /// of their own, so the plugin's namespace collapses into the skill *name*
-    /// (`/agtx:plan` → `/skill:agtx-plan`) rather than staying a prefix.
-    /// Verified against pi 0.84.3.
+    /// `/skill:ns-command` — pi's and kimi's skill commands live in one `skill:`
+    /// namespace of their own, so the plugin's namespace collapses into the
+    /// skill *name* (`/agtx:plan` → `/skill:agtx-plan`) rather than staying a
+    /// prefix. Verified against pi 0.84.3; kimi documents the same form
+    /// (`/skill:<name> <args>`) and reads the same `SKILL.md` frontmatter.
     PiSkill,
     /// No interactive skill invocation; callers fall back to a file-path
     /// reference. Copilot, and any agent agtx has not been taught.
@@ -145,7 +160,7 @@ pub enum SendStrategy {
 
 /// Where and how an agent's project-scoped MCP server config is written.
 ///
-/// Seven variants for seven agents, which looks untidy and is: the formats
+/// Eight variants for eight agents, which looks untidy and is: the formats
 /// genuinely differ (JSON vs TOML, `mcpServers` vs `mcp_servers` vs `mcp`). What
 /// the enum buys is that the mess lives in one function instead of a 170-line
 /// match inside `write_skills_to_worktree`, and that the names now say *why* the
@@ -178,6 +193,11 @@ pub enum McpConfigKind {
     /// reads this path as its highest-precedence project layer, and without the
     /// adapter installed the file is inert rather than harmful.
     PiJsonMerge,
+    /// `.kimi-code/mcp.json` — parsed, agtx inserted, written back. Standard
+    /// `mcpServers` shape. Merged rather than overwritten because a repo may
+    /// track its own project-level servers there and kimi's in-TUI
+    /// `/mcp-config` writes the same file.
+    KimiJsonMerge,
 }
 
 /// Where and how an agent's lifecycle-hook config is written, and which event
@@ -904,6 +924,95 @@ pub const AGENT_SPECS: &[AgentSpec] = &[
         // unloaded — so a pane that reaches the dialog is already misconfigured.
         dialogs: &[],
     },
+    AgentSpec {
+        name: "kimi",
+        binary: "kimi",
+        description: "Moonshot AI's Kimi Code CLI",
+        co_author: "Kimi <noreply@moonshot.cn>",
+        // Empty means *none*, not "unmeasured". Kimi reads provider credentials
+        // only from the `[providers]` table in `~/.kimi-code/config.toml` and
+        // documents that it does not fall back to shell environment variables,
+        // so there is no headless credential a CI runner could supply. The
+        // smoke harness's "is this agent runnable here?" check skips it, which
+        // is correct.
+        api_key_env: &[],
+        env: &[],
+        // `--auto`, not `-y/--yolo`. They are separate flags and only one is
+        // usable unattended: `--yolo` auto-approves tool calls but its own help
+        // says "the agent may still ask questions", which hangs a session
+        // nobody is watching. `--auto` is "fully autonomous, the agent will not
+        // ask questions".
+        base_args: &["--auto"],
+        // Kimi has no launch-prompt form at all — see `PromptForm::None`.
+        prompt_form: PromptForm::None,
+        launch_prompt_verified: false,
+        resume: ResumeArgs::Append(&["--continue"]),
+        headless_args: &["-p"],
+        // Deliberately not `.agents/skills`, which kimi also scans:
+        // antigravity owns that tree, and `write_skills_to_worktree` deploys
+        // for every configured phase agent, so sharing it would have two agents
+        // writing the same files. Kimi discovering antigravity's copies in a
+        // multi-agent worktree is inert — the files are byte-identical and kimi
+        // dedupes by normalized name.
+        skill_dir: Some((".kimi-code/skills", "")),
+        skill_layout: SkillLayout::SkillDir,
+        skill_scan_dir: Some(".kimi-code/skills"),
+        command_syntax: CommandSyntax::PiSkill,
+        mcp_config: Some(McpConfigKind::KimiJsonMerge),
+        // Kimi's hooks are Claude-shaped — PascalCase `hook_event_name` in a
+        // snake_case stdin payload, with the whole `SessionStart` …
+        // `SessionEnd` vocabulary — and would map onto `ClaudeSettings`
+        // almost unchanged. But `[[hooks]]` exists *only* in the user-global
+        // `~/.kimi-code/config.toml`; the one project-local file,
+        // `.kimi-code/local.toml`, accepts a `[workspace]` table and nothing
+        // else. Every `HookConfigKind` is project-local by invariant, so this
+        // stays `None` until kimi gains project-scoped hooks. Phase status
+        // falls back to the pane-hash heuristic, as for opencode and pi.
+        hook_config: None,
+        hook_event_source: HookEventSource::Payload,
+        // `node` must NOT be added: it is every Ink-class agent's pane name and
+        // would make any node process read as a live agent. Kimi sets
+        // `process.title = 'kimi-code'`, which Linux picks up and macOS ignores
+        // (`p_comm` is fixed at exec) — hence the indicators below.
+        process_names: &["kimi", "kimi-code"],
+        active_indicators: &["Welcome to Kimi Code!"],
+        // The splash scrolls away once the session has output; the second
+        // footer line (`context: N% (tokens/max)`) is unconditional. Scoped
+        // rather than global because "context: " occurs in ordinary agent
+        // output and would report an exited agent as still running.
+        scoped_indicators: &["context: "],
+        exit_command: Some("/exit"),
+        label_fg: (170, 140, 250), // violet — unused by the other nine
+        label_bg: None,
+        send_strategy: SendStrategy::Combined,
+        // `/new` — "start a fresh session, discarding the current context".
+        // Documented rather than measured; `/clear` is its alias.
+        clear_context_command: Some("/new"),
+        dialogs: &[
+            // Fires on every untrusted directory — i.e. every fresh worktree —
+            // before any session is created, and gates project MCP servers
+            // *and* project skills. Mostly moot in practice: `agent::trust`
+            // seeds the worktree from the project's existing consent, so the
+            // dialog does not appear.
+            //
+            // `Up` then `Enter`, and never a bare Enter. This menu is
+            // arrow-navigated with `Don't trust` **preselected**
+            // (`selectedIndex = 1`), and choosing it calls `stop()`, which
+            // exits the process before a session exists — a bare Enter would
+            // kill the task's agent outright. It takes no digit either; a `1`
+            // would be typed as literal text. This is the exact inverse of
+            // antigravity's identically-shaped prompt, where the safe option is
+            // preselected and a bare Enter is right. Do not generalise between
+            // them.
+            AgentDialog {
+                patterns: &["Trust this folder?"],
+                security: true,
+                require_all: false,
+                answer: &["Up", "Enter"],
+                scope: DialogScope::Launch,
+            },
+        ],
+    },
     // TODO: investigate CLI usage before enabling
     // aider  — "AI pair programming in your terminal", Aider <noreply@aider.chat>
     // cline  — "AI coding assistant for VS Code",      Cline <noreply@cline.bot>
@@ -976,16 +1085,28 @@ pub fn compose_command(spec: &AgentSpec, args: &[&str], prompt: Option<&str>) ->
         out.push_str(arg);
     }
     if let Some(prompt) = prompt.filter(|p| !p.is_empty()) {
-        if let PromptForm::Flag(flag) = spec.prompt_form {
-            out.push(' ');
-            out.push_str(flag);
-        }
         // POSIX single-quote escaping: close, emit a literal quote, reopen. The
         // whole command is itself wrapped in `sh -c '…'` by create_window, so a
         // bare quote here would end that outer word and let the shell interpret
         // the rest of the task as code.
-        let prompt = normalize_prompt(prompt);
-        out.push_str(&format!(" '{}'", prompt.replace('\'', "'\"'\"'")));
+        let quoted = |out: &mut String| {
+            let prompt = normalize_prompt(prompt);
+            out.push_str(&format!(" '{}'", prompt.replace('\'', "'\"'\"'")));
+        };
+        match spec.prompt_form {
+            // Nothing to append. Appending anyway would produce
+            // `kimi --auto '<task>'`, which kimi rejects with
+            // `unknown command` before it ever draws its TUI. The caller sees
+            // `PromptInjection::Unknown`, so the text is typed after readiness
+            // by `send_skill_and_prompt` instead.
+            PromptForm::None => {}
+            PromptForm::Flag(flag) => {
+                out.push(' ');
+                out.push_str(flag);
+                quoted(&mut out);
+            }
+            PromptForm::Argv => quoted(&mut out),
+        }
     }
     out
 }
@@ -1054,6 +1175,40 @@ mod tests {
                 entry.prompt_form,
                 PromptForm::Flag("-p"),
                 "{} cannot deliver its prompt at launch through print mode",
+                entry.name
+            );
+        }
+    }
+
+    #[test]
+    fn a_verified_launch_prompt_needs_a_launch_form_to_exist() {
+        // The sibling of the guard above, and the one that keeps kimi safe:
+        // `PromptForm::None` means the CLI has *no* way to take an opening
+        // message, so marking such an agent verified would silently drop every
+        // task's text — `compose_command` appends nothing, and the caller would
+        // believe it had been delivered.
+        for entry in AGENT_SPECS.iter().filter(|s| s.launch_prompt_verified) {
+            assert_ne!(
+                entry.prompt_form,
+                PromptForm::None,
+                "{} has no launch-prompt form to verify",
+                entry.name
+            );
+        }
+    }
+
+    #[test]
+    fn a_promptless_agent_composes_the_same_command_with_or_without_a_prompt() {
+        // The regression this exists for: a future match site treating `None`
+        // as "nothing special" and falling through to `Argv`.
+        for entry in AGENT_SPECS
+            .iter()
+            .filter(|s| s.prompt_form == PromptForm::None)
+        {
+            assert_eq!(
+                compose_command(entry, entry.base_args, Some("some task text")),
+                compose_command(entry, entry.base_args, None),
+                "{} must append nothing for a prompt it cannot take",
                 entry.name
             );
         }

--- a/src/agent/trust.rs
+++ b/src/agent/trust.rs
@@ -18,6 +18,7 @@
 //! | codex | `~/.codex/config.toml` → `[projects."<dir>"] trust_level` | ancestor (git repo root) |
 //! | gemini | `~/.gemini/trustedFolders.json` → `{"<dir>": "TRUST_FOLDER"}`, **lowercased** | ancestor |
 //! | antigravity | `~/.gemini/antigravity-cli/settings.json` → `trustedWorkspaces: [...]` | **exact** |
+//! | kimi | `~/.kimi-code/workspace-trust/wd_<slug>_<hash>` → `{"root": "<dir>"}` | **exact** |
 //! | cursor, grok | launch flag `--trust` | n/a |
 //! | pi | launch flag `--approve` (store is `~/.pi/agent/trust.json`) | n/a |
 //! | opencode | no trust concept | n/a |
@@ -25,6 +26,11 @@
 //!
 //! Versions the table was measured against: claude 2.1.246, codex 0.144.5,
 //! gemini 0.46.0, agy 1.1.21, cursor-agent 2026.08.11, opencode 1.18.20, pi 0.84.3.
+//!
+//! kimi is the one store that is a **directory of one-record files** rather than
+//! a single document, so its `trusted_paths` scans instead of parsing, and its
+//! `forget` unlinks instead of editing. Each record carries the directory
+//! verbatim under `root`, which is what lets it be read generically.
 //!
 //! **copilot is deliberately `NotApplicable`, not "assumed inherited".** It is not
 //! installed on any machine this was measured on, so nothing is known about its
@@ -67,6 +73,13 @@ enum Store {
     GeminiTrustedFolders,
     /// `~/.gemini/antigravity-cli/settings.json`, `trustedWorkspaces: ["<dir>", …]`.
     AntigravityWorkspaces,
+    /// `<kimi_home>/workspace-trust/`, one extensionless JSON file per trusted
+    /// directory, named `wd_<slug>_<sha256(root)[..12]>` and holding
+    /// `{"root": "<dir>", "trustedAt": <unix millis>}`.
+    ///
+    /// Unlike the other four this is a *directory*, so [`Store::path`] returns
+    /// the directory and everything that reads it scans rather than parses.
+    KimiWorkspaceTrust,
 }
 
 impl Store {
@@ -86,6 +99,11 @@ impl Store {
             // brand-new directory created *directly under it* still prompted. No
             // inheritance at any depth.
             Store::AntigravityWorkspaces => Match::Exact,
+            // `WorkspaceTrustService` sets `this.root = workspace.cwd` and looks
+            // up `encodeWorkDirKey(canonicalWorkspaceRoot(root))` — a hash of
+            // that one directory. There is no ancestor walk, so a trusted
+            // project root cannot cover a worktree beneath it.
+            Store::KimiWorkspaceTrust => Match::Exact,
         }
     }
 
@@ -98,11 +116,28 @@ impl Store {
                 .join(".gemini")
                 .join("antigravity-cli")
                 .join("settings.json"),
+            // A directory, not a file — the only such store here.
+            Store::KimiWorkspaceTrust => kimi_home(home).join("workspace-trust"),
         }
     }
 
     /// Every path this store currently trusts, in the form the agent stores them.
     fn trusted_paths(self, home: &Path) -> Vec<String> {
+        // Handled before the read below, because this store is a directory of
+        // one-record files rather than one document. Each record carries the
+        // trusted directory verbatim under `root`, so the generic `is_covered`
+        // comparison works on the result unchanged — and consent the user gave
+        // outside agtx is discovered the same way it is for every other agent.
+        if self == Store::KimiWorkspaceTrust {
+            return std::fs::read_dir(self.path(home))
+                .into_iter()
+                .flatten()
+                .flatten()
+                .filter_map(|entry| std::fs::read_to_string(entry.path()).ok())
+                .filter_map(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+                .filter_map(|v| v.get("root")?.as_str().map(str::to_string))
+                .collect();
+        }
         let raw = match std::fs::read_to_string(self.path(home)) {
             Ok(r) => r,
             Err(_) => return Vec::new(),
@@ -167,6 +202,8 @@ impl Store {
                         .collect()
                 })
                 .unwrap_or_default(),
+            // Returned above, before the file read this arm follows.
+            Store::KimiWorkspaceTrust => Vec::new(),
         }
     }
 
@@ -185,6 +222,7 @@ fn store_for(agent: &str) -> Option<Store> {
         "codex" => Some(Store::CodexToml),
         "gemini" => Some(Store::GeminiTrustedFolders),
         "antigravity" => Some(Store::AntigravityWorkspaces),
+        "kimi" => Some(Store::KimiWorkspaceTrust),
         // cursor and grok pass `--trust` at launch and pi passes `--approve`;
         // opencode has no trust gate; copilot is unmeasured. None of them are a
         // blocker agtx can reason about. pi does keep a store
@@ -192,6 +230,80 @@ fn store_for(agent: &str) -> Option<Store> {
         // the flag decides the run, and unlike codex it writes nothing global.
         _ => None,
     }
+}
+
+/// Kimi's data root: `$KIMI_CODE_HOME` if set, else `<home>/.kimi-code`.
+///
+/// The environment variable is honoured **only when `AGTX_AGENT_HOME` is unset**.
+/// Same reasoning as `agent_trust_home()` itself: a developer who exports
+/// `KIMI_CODE_HOME` for their own use would otherwise have the test suite — which
+/// redirects the home directory precisely so it cannot touch real agent config —
+/// write into their live kimi store anyway.
+fn kimi_home(home: &Path) -> PathBuf {
+    if std::env::var_os("AGTX_AGENT_HOME").is_none() {
+        if let Some(dir) = std::env::var_os("KIMI_CODE_HOME") {
+            if !dir.is_empty() {
+                return PathBuf::from(dir);
+            }
+        }
+    }
+    home.join(".kimi-code")
+}
+
+/// The filename kimi stores a directory's trust record under.
+///
+/// A pure port of `encodeWorkDirKey ∘ canonicalWorkspaceRoot`:
+///
+/// ```text
+/// normalized: backslashes → "/", trailing "/" stripped
+/// slug:       basename(normalized) → lowercase → s/[^a-z0-9._-]+/-/g
+///             → trim "-" → take 40 → trim "-"
+///             → "" | "." | ".." becomes "workspace"
+/// key:        wd_<slug>_<sha256(normalized)[..12 hex chars]>
+/// ```
+///
+/// **Not `realpath`.** `canonicalWorkspaceRoot` uses pathe's lexical `resolve()`,
+/// so `/tmp/x` stays `/tmp/x` rather than becoming `/private/tmp/x` on macOS.
+/// Canonicalising here would compute a key kimi never looks up — the same
+/// mismatch that invalidated the first codex measurement. [`seed_kimi`] writes
+/// one record per [`path_forms`] spelling instead, each keyed from *that*
+/// spelling.
+fn kimi_trust_key(root: &str) -> String {
+    use sha2::{Digest, Sha256};
+
+    let normalized = root.replace('\\', "/");
+    let normalized = normalized.trim_end_matches('/');
+    let base = normalized.rsplit('/').next().unwrap_or(normalized);
+
+    // The JS regex `[^a-z0-9._-]+` replaces each *run* with a single dash, so
+    // collapse runs rather than mapping character-for-character. Done after
+    // lowercasing, and the result is pure ASCII — which is what makes the
+    // 40-byte truncation below equal JS's 40-UTF-16-unit `slice`.
+    let mut slug = String::new();
+    let mut in_run = false;
+    for c in base.to_lowercase().chars() {
+        if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+            slug.push(c);
+            in_run = false;
+        } else if !in_run {
+            slug.push('-');
+            in_run = true;
+        }
+    }
+    // Trimmed twice, and that is deliberate: the first trim is the JS `replace`
+    // chain's own, and the second catches a dash left exposed by a truncation
+    // that cut through a run.
+    let slug = slug.trim_matches('-');
+    let slug = &slug[..slug.len().min(40)];
+    let slug = slug.trim_matches('-');
+    let slug = match slug {
+        "" | "." | ".." => "workspace",
+        other => other,
+    };
+
+    let digest = Sha256::digest(normalized.as_bytes());
+    let hash: String = digest.iter().take(6).map(|b| format!("{b:02x}")).collect();
+    format!("wd_{slug}_{hash}")
 }
 
 /// The forms of `path` an agent might have recorded.
@@ -253,8 +365,8 @@ pub fn status(agent: &str, path: &Path, home: &Path) -> Trust {
 
 /// Whether this agent needs a per-directory entry that agtx can write for it.
 ///
-/// True only for antigravity: it matches exactly, so a project-level consent the
-/// user has already given cannot cover a new worktree on its own. Every other
+/// True for antigravity and kimi: both match exactly, so a project-level consent
+/// the user has already given cannot cover a new worktree on its own. Every other
 /// agent either inherits from an ancestor (nothing to write) or has no store.
 pub fn needs_seeding(agent: &str) -> bool {
     store_for(agent).map(Store::matching) == Some(Match::Exact)
@@ -290,6 +402,7 @@ pub fn seed_from_project(
     }
     match store {
         Store::AntigravityWorkspaces => seed_antigravity(worktree, home).map(|()| true),
+        Store::KimiWorkspaceTrust => seed_kimi(worktree, home).map(|()| true),
         _ => Ok(false),
     }
 }
@@ -331,6 +444,40 @@ fn seed_antigravity(worktree: &Path, home: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Write kimi's trust record for the worktree, one file per path spelling.
+///
+/// Kimi's `readWorkspaceTrust` returns true if the file merely **exists and
+/// parses as JSON** — the contents are not validated — but the record carries
+/// `root` verbatim anyway, because that is what lets [`Store::trusted_paths`]
+/// read the store back generically.
+///
+/// One record per [`path_forms`] spelling, as [`seed_antigravity`] does: on macOS
+/// `/tmp` and `/private/tmp` are both live spellings of one directory and kimi
+/// hashes whichever it is handed. Each key is computed from *its own* spelling —
+/// canonicalising first would produce a key kimi never looks up.
+fn seed_kimi(worktree: &Path, home: &Path) -> Result<()> {
+    let dir = Store::KimiWorkspaceTrust.path(home);
+    std::fs::create_dir_all(&dir)?;
+    let trusted_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    for form in path_forms(worktree) {
+        let record = serde_json::json!({ "root": form, "trustedAt": trusted_at });
+        let file = dir.join(kimi_trust_key(&form));
+        // Written-then-renamed like the others: kimi reads these files while it
+        // starts, and a half-written one would parse as untrusted.
+        let tmp = dir.join(format!(
+            ".agtx-tmp{}-{}",
+            std::process::id(),
+            kimi_trust_key(&form)
+        ));
+        std::fs::write(&tmp, serde_json::to_string(&record)?)?;
+        std::fs::rename(&tmp, &file)?;
+    }
+    Ok(())
+}
+
 /// Drop `worktree` from an agent's trust store.
 ///
 /// Called when a worktree is removed. Without it these lists grow one entry per
@@ -340,10 +487,24 @@ pub fn forget(agent: &str, worktree: &Path, home: &Path) -> Result<()> {
     let Some(store) = store_for(agent) else {
         return Ok(());
     };
-    if store.matching() != Match::Exact {
-        return Ok(());
+    // Dispatched on the store, not merely gated on `Match::Exact`: there are two
+    // exact-matching stores now and their shapes have nothing in common — one is
+    // a JSON array to edit, the other a directory of files to unlink. Falling
+    // through to antigravity's JSON surgery would try to parse kimi's directory
+    // and silently prune nothing, leaving one dead record per task forever,
+    // which is the exact leak the `forget` call sites were added to stop.
+    match store {
+        Store::AntigravityWorkspaces => forget_antigravity(worktree, home),
+        Store::KimiWorkspaceTrust => forget_kimi(worktree, home),
+        // An inheriting store holds records agtx never wrote, so it is not
+        // agtx's to prune.
+        _ => Ok(()),
     }
-    let file = store.path(home);
+}
+
+/// Remove the worktree's entries from antigravity's `trustedWorkspaces` array.
+fn forget_antigravity(worktree: &Path, home: &Path) -> Result<()> {
+    let file = Store::AntigravityWorkspaces.path(home);
     let Ok(raw) = std::fs::read_to_string(&file) else {
         return Ok(());
     };
@@ -366,6 +527,19 @@ pub fn forget(agent: &str, worktree: &Path, home: &Path) -> Result<()> {
     let tmp = file.with_extension(format!("agtx-tmp{}", std::process::id()));
     std::fs::write(&tmp, serde_json::to_string_pretty(&root)?)?;
     std::fs::rename(&tmp, &file)?;
+    Ok(())
+}
+
+/// Unlink the worktree's trust records from kimi's `workspace-trust` directory.
+///
+/// One key per path spelling, matching what [`seed_kimi`] wrote. A missing file
+/// is not an error — the user may have removed it, or the seed may never have
+/// run because the project root was untrusted.
+fn forget_kimi(worktree: &Path, home: &Path) -> Result<()> {
+    let dir = Store::KimiWorkspaceTrust.path(home);
+    for form in path_forms(worktree) {
+        let _ = std::fs::remove_file(dir.join(kimi_trust_key(&form)));
+    }
     Ok(())
 }
 

--- a/src/agent/trust_tests.rs
+++ b/src/agent/trust_tests.rs
@@ -200,10 +200,11 @@ fn antigravity_trust_is_exact_and_never_inherited() {
 }
 
 #[test]
-fn only_antigravity_needs_seeding() {
+fn only_exact_matching_agents_need_seeding() {
     assert!(needs_seeding("antigravity"));
+    assert!(needs_seeding("kimi"));
     for other in [
-        "claude", "codex", "gemini", "cursor", "grok", "opencode", "copilot",
+        "claude", "codex", "gemini", "cursor", "grok", "opencode", "copilot", "pi",
     ] {
         assert!(!needs_seeding(other), "{other}");
     }
@@ -318,13 +319,270 @@ fn forget_never_touches_a_store_agtx_does_not_seed() {
     );
 }
 
+// ------------------------------------------------------------------ kimi ----
+
+/// Guard on the *shape* of the key rather than a frozen hash: a hand-computed
+/// digest could only restate this implementation. What it does pin is every
+/// lexical rule — `wd_` + slug + `_` + exactly 12 lowercase hex characters.
+#[test]
+fn kimi_trust_key_has_the_documented_shape() {
+    let key = kimi_trust_key("/Users/fynn/workspace/agtx");
+    let rest = key
+        .strip_prefix("wd_")
+        .unwrap_or_else(|| panic!("wd_ prefix: {key}"));
+    let (slug, hash) = rest
+        .rsplit_once('_')
+        .unwrap_or_else(|| panic!("slug_hash: {key}"));
+    assert_eq!(slug, "agtx", "the slug is the basename, lowercased");
+    assert_eq!(hash.len(), 12, "sha256 truncated to 12 hex chars: {key}");
+    assert!(
+        hash.chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "lowercase hex only: {key}"
+    );
+}
+
+/// The hash covers the *normalized whole path*, so spellings that normalize
+/// alike collide deliberately and different directories do not.
+#[test]
+fn kimi_trust_key_is_derived_from_the_whole_path() {
+    // Same basename, different parents: the slug matches, the hash must not.
+    let a = kimi_trust_key("/one/proj");
+    let b = kimi_trust_key("/two/proj");
+    assert_ne!(a, b, "the hash must cover the full path, not just the slug");
+    assert!(a.starts_with("wd_proj_") && b.starts_with("wd_proj_"));
+    // A trailing slash is stripped before hashing — the same directory.
+    assert_eq!(kimi_trust_key("/one/proj/"), a);
+    // Backslashes are rewritten to forward slashes first.
+    assert_eq!(kimi_trust_key(r"\one\proj"), a);
+}
+
+/// `[^a-z0-9._-]+` replaces each *run* with one dash, not one per character.
+fn slug_of(root: &str) -> String {
+    kimi_trust_key(root)
+        .strip_prefix("wd_")
+        .unwrap()
+        .rsplit_once('_')
+        .unwrap()
+        .0
+        .to_string()
+}
+
+#[test]
+fn kimi_trust_key_slugifies_and_collapses_runs() {
+    assert_eq!(slug_of("/tmp/My Project (v2)!!"), "my-project-v2");
+}
+
+/// The trim runs twice: once as part of the replacement chain, and again after
+/// the 40-character truncation, so a cut through a run leaves no trailing dash.
+#[test]
+fn kimi_trust_key_trims_after_truncating() {
+    // 39 kept characters, then a separator run — the cut lands inside the run.
+    let name = format!("{}   tail", "a".repeat(39));
+    let slug = slug_of(&format!("/tmp/{name}"));
+    assert_eq!(slug, "a".repeat(39), "no dash left exposed by the cut");
+    assert!(slug.len() <= 40);
+}
+
+#[test]
+fn kimi_trust_key_falls_back_to_workspace_for_an_empty_basename() {
+    for root in ["/", ".", "..", "///"] {
+        assert_eq!(slug_of(root), "workspace", "{root}");
+    }
+}
+
+/// `AGTX_AGENT_HOME` is the suite's guarantee that it never touches real agent
+/// config. A developer's own `KIMI_CODE_HOME` must not defeat it.
+#[test]
+fn kimi_home_yields_to_the_test_redirect() {
+    let h = home();
+    let prev_kimi = std::env::var_os("KIMI_CODE_HOME");
+    let prev_agtx = std::env::var_os("AGTX_AGENT_HOME");
+
+    std::env::remove_var("AGTX_AGENT_HOME");
+    std::env::set_var("KIMI_CODE_HOME", "/elsewhere/kimi");
+    assert_eq!(kimi_home(h.path()), Path::new("/elsewhere/kimi"));
+
+    std::env::set_var("AGTX_AGENT_HOME", h.path());
+    assert_eq!(
+        kimi_home(h.path()),
+        h.path().join(".kimi-code"),
+        "AGTX_AGENT_HOME must win over a developer's own KIMI_CODE_HOME"
+    );
+
+    std::env::remove_var("KIMI_CODE_HOME");
+    assert_eq!(kimi_home(h.path()), h.path().join(".kimi-code"));
+
+    match prev_kimi {
+        Some(v) => std::env::set_var("KIMI_CODE_HOME", v),
+        None => std::env::remove_var("KIMI_CODE_HOME"),
+    }
+    match prev_agtx {
+        Some(v) => std::env::set_var("AGTX_AGENT_HOME", v),
+        None => std::env::remove_var("AGTX_AGENT_HOME"),
+    }
+}
+
+/// Consent given outside agtx is discovered by reading kimi's own records: the
+/// directory is scanned and each record's `root` is what is compared.
+#[test]
+fn kimi_reads_a_record_written_by_the_agent_itself() {
+    let h = home();
+    write(
+        h.path(),
+        &format!(".kimi-code/workspace-trust/{}", kimi_trust_key("/proj")),
+        r#"{"root":"/proj","trustedAt":1756512000000}"#,
+    );
+    assert_eq!(status("kimi", Path::new("/proj"), h.path()), Trust::Trusted);
+}
+
+/// What makes kimi the second seeding agent: the key is the working directory
+/// verbatim, with no ancestor walk.
+#[test]
+fn kimi_trust_is_exact_and_never_inherited() {
+    let h = home();
+    write(
+        h.path(),
+        &format!(".kimi-code/workspace-trust/{}", kimi_trust_key("/proj")),
+        r#"{"root":"/proj"}"#,
+    );
+    assert_eq!(status("kimi", Path::new("/proj"), h.path()), Trust::Trusted);
+    assert_eq!(
+        status("kimi", Path::new("/proj/wt"), h.path()),
+        Trust::Untrusted
+    );
+}
+
+/// Trust the project root for kimi, the way the user's own first `kimi` run does.
+fn trust_kimi_root(h: &Path, root: &Path) {
+    write(
+        h,
+        &format!(
+            ".kimi-code/workspace-trust/{}",
+            kimi_trust_key(&root.to_string_lossy())
+        ),
+        &format!(r#"{{"root":"{}"}}"#, root.to_string_lossy()),
+    );
+}
+
+#[test]
+fn kimi_seeding_replays_project_consent_onto_a_worktree() {
+    let h = home();
+    let root = h.path().join("proj");
+    let wt = root.join(".agtx/worktrees/w1");
+    fs::create_dir_all(&wt).unwrap();
+    trust_kimi_root(h.path(), &root);
+
+    assert_eq!(status("kimi", &wt, h.path()), Trust::Untrusted);
+    assert!(seed_from_project("kimi", &root, &wt, h.path()).unwrap());
+    assert_eq!(status("kimi", &wt, h.path()), Trust::Trusted);
+}
+
+/// The seeded record has to be readable *by kimi*, not merely by agtx: found at
+/// the key kimi computes, and parsing as JSON — which is the whole of kimi's own
+/// `readWorkspaceTrust` check.
+#[test]
+fn kimi_seeding_writes_the_record_at_the_computed_key() {
+    let h = home();
+    let root = h.path().join("proj");
+    let wt = root.join("wt");
+    fs::create_dir_all(&wt).unwrap();
+    trust_kimi_root(h.path(), &root);
+    seed_from_project("kimi", &root, &wt, h.path()).unwrap();
+
+    let store = h.path().join(".kimi-code/workspace-trust");
+    let file = store.join(kimi_trust_key(&wt.to_string_lossy()));
+    let v: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&file).expect("record at the computed key"))
+            .expect("valid JSON");
+    assert_eq!(v["root"], wt.to_string_lossy().to_string());
+    assert!(v["trustedAt"].is_number(), "unix millis, as kimi writes");
+
+    // The write-then-rename must leave nothing behind for kimi to trip over —
+    // every file in this directory is a trust record to it.
+    for entry in fs::read_dir(&store).unwrap() {
+        let name = entry.unwrap().file_name();
+        assert!(
+            !name.to_string_lossy().starts_with(".agtx-tmp"),
+            "temp file left behind: {name:?}"
+        );
+    }
+}
+
+/// The policy assertion: agtx replays a decision, it never makes one.
+#[test]
+fn kimi_seeding_does_nothing_when_the_project_was_never_trusted() {
+    let h = home();
+    let root = h.path().join("proj");
+    let wt = root.join("wt");
+    fs::create_dir_all(&wt).unwrap();
+    assert!(!seed_from_project("kimi", &root, &wt, h.path()).unwrap());
+    assert_eq!(status("kimi", &wt, h.path()), Trust::Untrusted);
+    assert!(
+        !h.path().join(".kimi-code/workspace-trust").exists(),
+        "an untrusted project must not even create the store directory"
+    );
+}
+
+/// Redeploying a worktree must not accumulate records.
+#[test]
+fn kimi_seeding_is_idempotent() {
+    let h = home();
+    let root = h.path().join("proj");
+    let wt = root.join("wt");
+    fs::create_dir_all(&wt).unwrap();
+    trust_kimi_root(h.path(), &root);
+    seed_from_project("kimi", &root, &wt, h.path()).unwrap();
+    let after_first = Store::KimiWorkspaceTrust.trusted_paths(h.path()).len();
+    // Already trusted, so the second call is a no-op before it writes anything.
+    assert!(!seed_from_project("kimi", &root, &wt, h.path()).unwrap());
+    assert_eq!(
+        Store::KimiWorkspaceTrust.trusted_paths(h.path()).len(),
+        after_first
+    );
+}
+
+/// The leak regression test. Before `forget` dispatched on the store it gated on
+/// `Match::Exact` and then ran antigravity's JSON surgery, which would try to
+/// parse kimi's *directory* and prune nothing — one dead record per task forever,
+/// the exact leak the `forget` call sites were added to stop.
+#[test]
+fn kimi_forget_removes_the_seeded_record() {
+    let h = home();
+    let root = h.path().join("proj");
+    let wt = root.join("wt");
+    fs::create_dir_all(&wt).unwrap();
+    trust_kimi_root(h.path(), &root);
+    seed_from_project("kimi", &root, &wt, h.path()).unwrap();
+    assert_eq!(status("kimi", &wt, h.path()), Trust::Trusted);
+
+    forget("kimi", &wt, h.path()).unwrap();
+    assert_eq!(status("kimi", &wt, h.path()), Trust::Untrusted);
+    // The project's own consent is not agtx's to drop.
+    assert_eq!(status("kimi", &root, h.path()), Trust::Trusted);
+}
+
+/// A missing record is the ordinary case when seeding never ran, not an error.
+#[test]
+fn kimi_forget_is_a_no_op_with_no_store() {
+    let h = home();
+    forget("kimi", Path::new("/proj/wt"), h.path()).unwrap();
+}
+
 // ------------------------------------------------------------ no-op agents --
 
 /// Flag-based, conceptless and unmeasured agents must never read as a blocker.
 #[test]
 fn agents_without_a_readable_store_are_not_applicable() {
     let h = home();
-    for a in ["cursor", "grok", "opencode", "copilot", "somethingelse"] {
+    for a in [
+        "cursor",
+        "grok",
+        "pi",
+        "opencode",
+        "copilot",
+        "somethingelse",
+    ] {
         assert_eq!(
             status(a, Path::new("/anywhere"), h.path()),
             Trust::NotApplicable,
@@ -350,6 +608,7 @@ fn a_missing_store_reads_as_untrusted_not_as_an_error() {
         status("antigravity", Path::new("/p"), h.path()),
         Trust::Untrusted
     );
+    assert_eq!(status("kimi", Path::new("/p"), h.path()), Trust::Untrusted);
 }
 
 /// A half-written or hand-edited file must not panic the refresh thread.
@@ -359,6 +618,13 @@ fn malformed_stores_degrade_to_untrusted() {
     write(h.path(), ".claude.json", "{not json");
     write(h.path(), ".gemini/trustedFolders.json", "[]");
     write(h.path(), ".gemini/antigravity-cli/settings.json", "null");
+    // kimi's store is a directory, so its malformed case is a record in it that
+    // does not parse — which kimi itself also reads as no consent.
+    write(
+        h.path(),
+        &format!(".kimi-code/workspace-trust/{}", kimi_trust_key("/p")),
+        "{not json",
+    );
     assert_eq!(
         status("claude", Path::new("/p"), h.path()),
         Trust::Untrusted
@@ -371,4 +637,5 @@ fn malformed_stores_degrade_to_untrusted() {
         status("antigravity", Path::new("/p"), h.path()),
         Trust::Untrusted
     );
+    assert_eq!(status("kimi", Path::new("/p"), h.path()), Trust::Untrusted);
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -11613,9 +11613,9 @@ fn merge_hooks_into_json_settings(path: &Path, ours: serde_json::Value) {
 
 /// Insert agtx's entry into a `mcpServers` JSON file without disturbing the rest.
 ///
-/// Shared by the two `…Merge` JSON kinds (antigravity, pi), which differ only in
-/// directory and filename: their file is vendor-neutral or written back by the
-/// agent's own tooling, so the project's other servers — and any sibling
+/// Shared by the three `…Merge` JSON kinds (antigravity, pi, kimi), which differ
+/// only in directory and filename: their file is vendor-neutral or written back by
+/// the agent's own tooling, so the project's other servers — and any sibling
 /// top-level keys — have to survive. A missing or unparseable file starts from an
 /// empty object rather than failing, on the same best-effort footing as the rest
 /// of worktree setup.
@@ -11643,8 +11643,8 @@ fn merge_mcp_servers_json(dir: &Path, filename: &str, agtx_bin: &str, project_pa
 /// Write the project-scoped MCP server config for one agent into its worktree.
 ///
 /// Selected by [`McpConfigKind`](agent::McpConfigKind) rather than agent name.
-/// The variants are genuinely seven, not one parameterised writer: the formats
-/// differ (JSON vs TOML, `mcpServers` vs `mcp_servers` vs `mcp`), two must
+/// The variants are genuinely eight, not one parameterised writer: the formats
+/// differ (JSON vs TOML, `mcpServers` vs `mcp_servers` vs `mcp`), four must
 /// **merge** rather than overwrite because their file may already be tracked in
 /// the repo, and two carry a side-effect beyond the config file itself — so the
 /// `…Merge` names mark where clobbering a user's file is the failure mode.
@@ -11824,6 +11824,20 @@ fn write_mcp_config(
                 "mcp.json",
                 &agtx_bin,
                 &project_path_str,
+            );
+        }
+        agent::McpConfigKind::KimiJsonMerge => {
+            // `.kimi-code/mcp.json`, standard `mcpServers`. Merged rather than
+            // overwritten: a repo may track its own project-level servers here,
+            // and kimi's in-TUI `/mcp-config` writes this same file, so a task
+            // must not silently drop what either put there. `.kimi-code` is not
+            // in AGENT_CONFIG_DIRS, so only the tracked-in-the-repo half
+            // applies — as for pi.
+            merge_mcp_servers_json(
+                &Path::new(worktree_path).join(".kimi-code"),
+                "mcp.json",
+                agtx_bin,
+                project_path_str,
             );
         }
         agent::McpConfigKind::OpenCode => {

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -3233,6 +3233,29 @@ fn test_is_pane_at_shell_returns_false_for_codex() {
     assert!(!is_pane_at_shell(&mock, "sess:win"));
 }
 
+/// Both of kimi's process names read as a live agent, and a shell does not.
+///
+/// `kimi-code` is what `process.title` sets, which Linux picks up and macOS
+/// ignores (`p_comm` is fixed at exec) — so both spellings have to match, and
+/// on macOS neither may, which is what `scoped_indicators` covers.
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_is_pane_at_shell_detects_kimi() {
+    for cmd in ["kimi", "kimi-code"] {
+        let mut mock = MockTmuxOperations::new();
+        mock.expect_pane_current_command()
+            .returning(move |_| Some(cmd.to_string()));
+        assert!(
+            !is_pane_at_shell(&mock, "sess:win"),
+            "{cmd} must read as a live agent"
+        );
+    }
+    let mut mock = MockTmuxOperations::new();
+    mock.expect_pane_current_command()
+        .returning(|_| Some("zsh".to_string()));
+    assert!(is_pane_at_shell(&mock, "sess:win"));
+}
+
 #[test]
 #[cfg(feature = "test-mocks")]
 fn test_is_pane_at_shell_returns_false_when_none() {
@@ -4750,6 +4773,200 @@ fn test_write_skills_to_worktree_mcp_pi_preserves_existing_config() {
         "top-level sibling keys must survive: {content}"
     );
     assert!(v["mcpServers"]["agtx"]["command"].is_string());
+}
+
+#[test]
+fn test_write_skills_to_worktree_mcp_kimi() {
+    let dir = tempfile::tempdir().unwrap();
+    let wt = dir.path().to_string_lossy().to_string();
+
+    write_skills_to_worktree(&wt, dir.path(), &None, &["kimi"], false);
+
+    let cfg = dir.path().join(".kimi-code/mcp.json");
+    assert!(
+        cfg.exists(),
+        ".kimi-code/mcp.json should be written for kimi"
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&cfg).unwrap()).unwrap();
+    assert!(v["mcpServers"]["agtx"]["command"].is_string());
+    assert_eq!(v["mcpServers"]["agtx"]["args"][0], "mcp-serve");
+    // Plain `{command, args}` — none of the extra keys other agents' formats
+    // carry. kimi rejects a config it cannot parse, taking its MCP with it.
+    let entry = v["mcpServers"]["agtx"].as_object().unwrap();
+    assert!(
+        entry.get("lifecycle").is_none() && entry.get("transport").is_none(),
+        "kimi's entry shape is {{command, args}} only: {entry:?}"
+    );
+}
+
+/// A repo may track its own `.kimi-code/mcp.json`, and kimi's in-TUI
+/// `/mcp-config` writes the same file, so a task must not clobber either.
+#[test]
+fn test_write_skills_to_worktree_mcp_kimi_preserves_existing_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let wt = dir.path().to_string_lossy().to_string();
+    let kimi_dir = dir.path().join(".kimi-code");
+    std::fs::create_dir_all(&kimi_dir).unwrap();
+    std::fs::write(
+        kimi_dir.join("mcp.json"),
+        r#"{"mcpServers":{"other":{"command":"other"}},"somethingElse":true}"#,
+    )
+    .unwrap();
+
+    write_skills_to_worktree(&wt, dir.path(), &None, &["kimi"], false);
+
+    let content = std::fs::read_to_string(kimi_dir.join("mcp.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(
+        v["mcpServers"]["other"]["command"], "other",
+        "a project's own .kimi-code/mcp.json must not be clobbered: {content}"
+    );
+    assert_eq!(
+        v["somethingElse"], true,
+        "top-level sibling keys must survive: {content}"
+    );
+    assert!(v["mcpServers"]["agtx"]["command"].is_string());
+}
+
+#[test]
+fn test_write_skills_to_worktree_kimi_skills() {
+    let dir = tempfile::tempdir().unwrap();
+    let wt = dir.path().to_string_lossy().to_string();
+
+    write_skills_to_worktree(&wt, dir.path(), &None, &["kimi"], false);
+
+    let skill = dir.path().join(".kimi-code/skills/agtx-plan/SKILL.md");
+    assert!(
+        skill.exists(),
+        "kimi skills go to .kimi-code/skills/<name>/SKILL.md, not the .agents/ \
+         tree it also scans — that one is antigravity's"
+    );
+    let content = std::fs::read_to_string(&skill).unwrap();
+    assert!(
+        content.starts_with("---"),
+        "frontmatter must be kept for kimi: its directory-form skills require \
+         `name` and `description`"
+    );
+    // Canonical copy is always written too
+    assert!(dir.path().join(".agtx/skills/agtx-plan/SKILL.md").exists());
+    // And nothing lands in antigravity's tree when only kimi is configured.
+    assert!(
+        !dir.path().join(".agents/skills").exists(),
+        "kimi must not deploy into .agents/, which antigravity owns"
+    );
+}
+
+/// Kimi names MCP tools the Claude way (`mcp__<server>__<tool>`), so the skill
+/// bodies need no rewriting — the references in them resolve as written.
+#[test]
+fn test_write_skills_to_worktree_kimi_preserves_mcp_tool_names() {
+    let dir = tempfile::tempdir().unwrap();
+    let wt = dir.path().to_string_lossy().to_string();
+
+    write_skills_to_worktree(&wt, dir.path(), &None, &["kimi"], false);
+
+    let content =
+        std::fs::read_to_string(dir.path().join(".kimi-code/skills/agtx-plan/SKILL.md")).unwrap();
+    assert!(
+        content.contains("mcp__agtx__"),
+        "kimi resolves mcp__<server>__<tool> verbatim; rewriting would break it"
+    );
+}
+
+/// Kimi matches trusted paths **exactly**, so every worktree needs its own
+/// record — and `write_skills_to_worktree` is where it is written, because that
+/// is the one call site reached by both worktree creation and an agent switch.
+#[test]
+fn test_write_skills_to_worktree_kimi_seeds_workspace_trust() {
+    let (home, _guard) = redirect_agent_home();
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().join("proj");
+    let wt = project.join(".agtx/worktrees/w1");
+    std::fs::create_dir_all(&wt).unwrap();
+
+    // Trust the project root the way the user's own first `kimi` run does.
+    let store = home.join(".kimi-code").join("workspace-trust");
+    std::fs::create_dir_all(&store).unwrap();
+    let project_key = kimi_trust_key_for_test(&project.to_string_lossy());
+    std::fs::write(
+        store.join(&project_key),
+        serde_json::json!({ "root": project.to_string_lossy() }).to_string(),
+    )
+    .unwrap();
+
+    write_skills_to_worktree(&wt.to_string_lossy(), &project, &None, &["kimi"], false);
+
+    let record = store.join(kimi_trust_key_for_test(&wt.to_string_lossy()));
+    let v: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&record)
+            .expect("the worktree must be seeded at the key kimi computes"),
+    )
+    .unwrap();
+    assert_eq!(v["root"], wt.to_string_lossy().to_string());
+
+    // This HOME is shared across the tests that redirect it — leave it clean.
+    let _ = agent::trust::forget("kimi", &wt, &home);
+    let _ = std::fs::remove_file(store.join(&project_key));
+}
+
+/// The negative twin, and the policy the whole design rests on: with the project
+/// root untrusted, agtx writes nothing. Granting a consent the user never gave
+/// would be a different feature from replaying one they did.
+#[test]
+fn test_write_skills_to_worktree_kimi_does_not_seed_an_untrusted_project() {
+    let (home, _guard) = redirect_agent_home();
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().join("untrusted-proj");
+    let wt = project.join(".agtx/worktrees/w1");
+    std::fs::create_dir_all(&wt).unwrap();
+
+    write_skills_to_worktree(&wt.to_string_lossy(), &project, &None, &["kimi"], false);
+
+    let record = home
+        .join(".kimi-code")
+        .join("workspace-trust")
+        .join(kimi_trust_key_for_test(&wt.to_string_lossy()));
+    assert!(
+        !record.exists(),
+        "no record may be written for a worktree whose project was never trusted"
+    );
+}
+
+/// The key derivation, restated here rather than exported from `agent::trust`.
+///
+/// Deliberate duplication: `kimi_trust_key` is private to the trust module and
+/// pinned by its own tests. Restating it means this test asserts kimi would find
+/// the record, not merely that agtx and agtx agree with each other.
+fn kimi_trust_key_for_test(root: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let normalized = root.replace('\\', "/");
+    let normalized = normalized.trim_end_matches('/');
+    let base = normalized.rsplit('/').next().unwrap_or(normalized);
+    let mut slug = String::new();
+    let mut in_run = false;
+    for c in base.to_lowercase().chars() {
+        if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+            slug.push(c);
+            in_run = false;
+        } else if !in_run {
+            slug.push('-');
+            in_run = true;
+        }
+    }
+    let slug = slug.trim_matches('-');
+    let slug = &slug[..slug.len().min(40)];
+    let slug = slug.trim_matches('-');
+    let slug = match slug {
+        "" | "." | ".." => "workspace",
+        other => other,
+    };
+    let hash: String = Sha256::digest(normalized.as_bytes())
+        .iter()
+        .take(6)
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    format!("wd_{slug}_{hash}")
 }
 
 #[test]
@@ -12492,8 +12709,14 @@ fn test_agent_commands_derivation_matches_the_previous_literals() {
         // `node` itself must never join this list: it is every Ink agent's pane
         // name, and would make any node process read as a live agent.
         "pi",
+        // kimi. Same Linux/macOS split as pi: `process.title = 'kimi-code'` is
+        // picked up on Linux and ignored on macOS, where the scoped
+        // `context: ` indicator does the detecting instead.
+        "kimi",
+        "kimi-code",
         // Not agent binaries, but a Python entry point must not read as "shell".
-        "python3", "python",
+        "python3",
+        "python",
     ];
     want.sort_unstable();
     assert_eq!(got, want);
@@ -12517,6 +12740,9 @@ fn test_active_indicator_derivation_matches_the_previous_literals() {
         // fallback needs three. Its trust dialog's footer reads
         // "↑/↓ Navigate · enter Confirm", so this cannot fire while blocked.
         "? for shortcuts",
+        // kimi's splash, shown until output scrolls it away. Its footer
+        // `context: ` needle is scoped, not here — see below.
+        "Welcome to Kimi Code!",
     ];
     want.sort_unstable();
     // pi's "%/" is deliberately absent: it lives in `scoped_indicators`, which
@@ -12524,6 +12750,9 @@ fn test_active_indicator_derivation_matches_the_previous_literals() {
     // used for panes whose agent is unknown — it would report an exited claude
     // or codex as still running the moment output contained "85%/90%".
     assert!(!got.contains(&"%/"));
+    // kimi's "context: " is absent for the same reason: it is the unconditional
+    // half of its footer, but the phrase occurs in ordinary agent output too.
+    assert!(!got.contains(&"context: "));
     assert_eq!(got, want);
 }
 
@@ -12539,6 +12768,7 @@ fn test_exit_command_per_agent() {
         ("gemini", Some("/quit")),
         ("grok", Some("/quit")),
         ("pi", Some("/quit")),
+        ("kimi", Some("/exit")),
         ("codex", None),
         ("cursor", None),
     ];
@@ -12569,6 +12799,8 @@ fn test_send_strategy_per_agent() {
         ("cursor", SendStrategy::Combined),
         ("antigravity", SendStrategy::Combined),
         ("pi", SendStrategy::Combined),
+        // pi-tui composer, same class as pi's.
+        ("kimi", SendStrategy::Combined),
         ("opencode", SendStrategy::OpenCodePicker),
     ];
     for (agent, want) in table {
@@ -12589,6 +12821,9 @@ fn test_clear_context_command_per_agent() {
     let table = [
         ("claude", Some("/clear")),
         ("pi", Some("/new")),
+        // Documented (`/new`, alias `/clear`), not yet measured against the
+        // binary — the one kimi spec field taken from docs alone.
+        ("kimi", Some("/new")),
         ("codex", None),
         ("gemini", None),
         ("cursor", None),
@@ -12689,6 +12924,10 @@ fn test_launch_dialog_derivation_matches_the_previous_literals() {
         ),
         // Cursor advertises its own access key, so that is what it is sent.
         (vec!["Workspace Trust Required"], vec!["a"]),
+        // Kimi's is arrow-navigated with the *unsafe* option preselected and
+        // takes no digit, so `Up` then `Enter` — the inverse of antigravity's
+        // identically-shaped prompt above.
+        (vec!["Trust this folder?"], vec!["Up", "Enter"]),
     ];
     want.sort();
     assert_eq!(got, want);
@@ -13105,6 +13344,7 @@ fn test_dialog_security_classification() {
         ("gemini", "Do you trust the files in this folder?"),
         ("cursor", "Workspace Trust Required"),
         ("antigravity", "Do you trust the contents of this project?"),
+        ("kimi", "Trust this folder?"),
     ];
     for (agent, pattern) in secure {
         let d = agent::spec(agent)

--- a/tests/agent_parity_tests.rs
+++ b/tests/agent_parity_tests.rs
@@ -25,6 +25,7 @@ const AGENTS: &[&str] = &[
     "grok",
     "antigravity",
     "pi",
+    "kimi",
 ];
 
 fn agent(name: &str) -> Agent {
@@ -76,6 +77,9 @@ fn interactive_command_parity_without_prompt() {
         // pi has no permission system to bypass; `--approve` is project trust,
         // without which the worktree's own skills are never loaded.
         ("pi", "pi --approve"),
+        // `--auto` is "fully autonomous"; `--yolo` auto-approves tools but the
+        // agent "may still ask questions", which hangs an unattended session.
+        ("kimi", "kimi --auto"),
     ];
     for (name, want) in expected {
         assert_eq!(&agent(name).build_interactive_command(""), want, "{name}");
@@ -104,6 +108,12 @@ fn interactive_command_parity_with_prompt() {
             "agy --dangerously-skip-permissions --mode accept-edits -i 'hi'",
         ),
         ("pi", "pi --approve 'hi'"),
+        // **The prompt is dropped, on purpose.** kimi's CLI has no launch form
+        // for one: positional args are rejected with `unknown command`, and its
+        // only prompt flag is print mode. Appending anything here would produce
+        // a command that dies before drawing its TUI. `prompt_injection` returns
+        // `Unknown`, so the text goes down the typed mid-session lane instead.
+        ("kimi", "kimi --auto"),
     ];
     for (name, want) in expected {
         assert_eq!(&agent(name).build_interactive_command("hi"), want, "{name}");
@@ -118,11 +128,28 @@ fn interactive_command_parity_with_prompt() {
 fn interactive_command_escapes_single_quotes_for_every_agent() {
     // The command is wrapped in `sh -c '...'` downstream, so a prompt quote must
     // survive as the POSIX '"'"' idiom for every agent, including the fallback.
-    for name in AGENTS.iter().copied() {
+    //
+    // kimi is exempt because it emits no quoted prompt at all to escape — and
+    // the exemption is written as a positive assertion below rather than a hole,
+    // so an agent that starts emitting one cannot slip through unescaped.
+    const NO_LAUNCH_PROMPT: &[&str] = &["kimi"];
+    for name in AGENTS
+        .iter()
+        .copied()
+        .filter(|n| !NO_LAUNCH_PROMPT.contains(n))
+    {
         let cmd = agent(name).build_interactive_command("it's");
         assert!(
             cmd.ends_with(r#"'it'"'"'s'"#),
             "{name} lost single-quote escaping: {cmd}"
+        );
+    }
+    for name in NO_LAUNCH_PROMPT {
+        let a = agent(name);
+        assert_eq!(
+            a.build_interactive_command("it's"),
+            a.build_interactive_command(""),
+            "{name} must append no prompt at all, quoted or otherwise"
         );
     }
     assert!(unknown()
@@ -154,6 +181,7 @@ fn resume_command_parity() {
             "agy --dangerously-skip-permissions --mode accept-edits --continue",
         ),
         ("pi", "pi --approve --continue"),
+        ("kimi", "kimi --auto --continue"),
     ];
     for (name, want) in expected {
         assert_eq!(&agent(name).build_resume_command(), want, "{name}");
@@ -180,6 +208,9 @@ fn headless_invocation_parity() {
         // `--no-approve`: a one-shot PR description has no use for the repo's
         // own skills or extensions, so it declines them.
         ("pi", "pi", &["--no-approve", "-p"]),
+        // `-p, --prompt` — "run one prompt non-interactively and print the
+        // response". Exactly why it cannot double as a launch prompt.
+        ("kimi", "kimi", &["-p"]),
     ];
     for (name, bin, flags) in expected {
         let a = agent(name);
@@ -243,7 +274,15 @@ fn prompt_injection_parity() {
     // dialogs, no located trust store, `-i` unchecked. It must stay unverified
     // rather than inherit a neighbour's behaviour — assuming that is what produced
     // the antigravity and cursor dialog bugs in the first place.
-    let unverified = ["copilot"];
+    // Two agents, two different reasons — worth stating, because
+    // `verified.len() + unverified.len() == AGENTS.len()` is asserted below and
+    // would otherwise read as one category.
+    //
+    // - copilot: a launch form *exists* (`-i`) and has never been measured.
+    // - kimi: **no launch form exists**. Positional args are rejected and `-p`
+    //   is print mode, so `PromptForm::None` is the shape of the CLI, not a
+    //   statement about agtx's confidence in it. No measurement can promote it.
+    let unverified = ["copilot", "kimi"];
     for name in unverified {
         assert_eq!(
             agent(name).prompt_injection(),
@@ -277,6 +316,9 @@ fn native_skill_dir_parity() {
         // Vendor-neutral tree, not an agent dotdir.
         ("antigravity", Some((".agents/skills", ""))),
         ("pi", Some((".pi/skills", ""))),
+        // Not `.agents/skills`, which kimi also scans — that tree is
+        // antigravity's, and both agents deploy into a shared worktree.
+        ("kimi", Some((".kimi-code/skills", ""))),
     ];
     for (name, want) in expected {
         assert_eq!(agent_native_skill_dir(name), *want, "{name}");
@@ -310,6 +352,7 @@ fn skill_filename_parity() {
         ("grok", "plan.md"),
         ("antigravity", "plan.md"),
         ("pi", "plan.md"),
+        ("kimi", "plan.md"),
     ];
     for (name, want) in expected {
         assert_eq!(&skill_dir_to_filename("agtx-plan", name), want, "{name}");
@@ -342,6 +385,8 @@ fn plugin_command_parity() {
         // pi has one `skill:` namespace for every skill, so the plugin's own
         // namespace is folded into the skill name rather than kept as a prefix.
         ("pi", Some("/skill:gsd-plan-phase 1")),
+        // Same one-namespace `skill:` form as pi.
+        ("kimi", Some("/skill:gsd-plan-phase 1")),
     ];
     for (name, want) in expected {
         assert_eq!(
@@ -430,6 +475,12 @@ fn identity_parity() {
             "Earendil's pi coding agent",
             "Pi <noreply@earendil.works>",
         ),
+        (
+            "kimi",
+            "kimi",
+            "Moonshot AI's Kimi Code CLI",
+            "Kimi <noreply@moonshot.cn>",
+        ),
     ];
     for (name, binary, description, co_author) in expected {
         let a = agent(name);
@@ -469,6 +520,7 @@ fn scan_agent_skills_parity() {
     write(root, ".grok/skills/agtx-plan/SKILL.md", MD_SKILL);
     write(root, ".agents/skills/agtx-plan/SKILL.md", MD_SKILL);
     write(root, ".pi/skills/agtx-plan/SKILL.md", MD_SKILL);
+    write(root, ".kimi-code/skills/agtx-plan/SKILL.md", MD_SKILL);
     // OpenCode's project commands live under .config/, not in the tree agtx
     // deploys into (.opencode/command). Both are written here to lock which one
     // the scan reads.
@@ -489,6 +541,9 @@ fn scan_agent_skills_parity() {
         ("antigravity", &[("/agtx-plan", "Plan the work")]),
         // Same SkillDir layout, but pi types it under its own namespace.
         ("pi", &[("/skill:agtx-plan", "Plan the work")]),
+        // Same again for kimi — and since pi's tree is in this same fixture,
+        // one entry each also proves neither reads the other's directory.
+        ("kimi", &[("/skill:agtx-plan", "Plan the work")]),
     ];
     for (name, want) in expected {
         let got = agtx::skills::scan_agent_skills(name, root);

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -69,6 +69,7 @@ fn test_known_agents_includes_all_expected() {
         "cursor",
         "grok",
         "antigravity",
+        "kimi",
     ] {
         assert!(names.contains(expected), "missing agent: {}", expected);
     }
@@ -162,6 +163,10 @@ fn test_build_resume_command_all_agents() {
     assert_eq!(
         by_name("antigravity").build_resume_command(),
         "agy --dangerously-skip-permissions --mode accept-edits --continue"
+    );
+    assert_eq!(
+        by_name("kimi").build_resume_command(),
+        "kimi --auto --continue"
     );
 }
 
@@ -409,5 +414,77 @@ fn test_antigravity_transform_plugin_command() {
     assert_eq!(
         transform_plugin_command("/gsd:plan-phase 1", "antigravity"),
         Some("/gsd-plan-phase 1".to_string())
+    );
+}
+
+// =============================================================================
+// Tests for kimi (Moonshot AI Kimi Code CLI) integration
+// =============================================================================
+
+#[test]
+fn test_known_agents_includes_kimi() {
+    let agents = known_agents();
+    let kimi = agents.iter().find(|a| a.name == "kimi");
+    assert!(kimi.is_some(), "kimi should be in known_agents");
+    let kimi = kimi.unwrap();
+    assert_eq!(kimi.command, "kimi");
+    assert_eq!(kimi.co_author, "Kimi <noreply@moonshot.cn>");
+}
+
+#[test]
+fn test_build_interactive_command_kimi_no_prompt() {
+    let agents = known_agents();
+    let kimi = agents.iter().find(|a| a.name == "kimi").unwrap();
+    // `--auto` is "fully autonomous, the agent will not ask questions".
+    // `--yolo` is a *different* flag that auto-approves tools while still
+    // allowing questions, which would hang a session nobody is watching.
+    assert_eq!(kimi.build_interactive_command(""), "kimi --auto");
+}
+
+/// The single highest-value assertion in the kimi integration.
+///
+/// Kimi's CLI takes no opening message: `program.argument('[args...]')` is
+/// followed by `program.error("unknown command '<arg>'")`, so a positional
+/// prompt kills the process before it draws its TUI, and its only prompt flag
+/// (`-p`) is print mode. agtx must therefore compose a *bare* launch command and
+/// deliver the task on the typed mid-session lane.
+#[test]
+fn test_build_interactive_command_kimi_never_carries_a_prompt() {
+    let agents = known_agents();
+    let kimi = agents.iter().find(|a| a.name == "kimi").unwrap();
+    assert_eq!(
+        kimi.build_interactive_command("do something"),
+        "kimi --auto"
+    );
+    assert_eq!(kimi.build_interactive_command("it's a test"), "kimi --auto");
+}
+
+#[test]
+fn test_kimi_does_not_take_the_launch_lane() {
+    use agtx::agent::PromptInjection;
+    let agents = known_agents();
+    let kimi = agents.iter().find(|a| a.name == "kimi").unwrap();
+    assert_eq!(kimi.prompt_injection(), PromptInjection::Unknown);
+}
+
+#[test]
+fn test_kimi_has_native_skill_dir() {
+    // Its own dotdir, not the vendor-neutral `.agents/` tree kimi also scans —
+    // that one is antigravity's, and both may deploy into the same worktree.
+    let dir = agent_native_skill_dir("kimi");
+    assert_eq!(dir, Some((".kimi-code/skills", "")));
+}
+
+#[test]
+fn test_kimi_transform_plugin_command() {
+    // One `skill:` namespace for every skill, like pi: the plugin namespace is
+    // folded into the skill name rather than kept as a prefix.
+    assert_eq!(
+        transform_plugin_command("/agtx:plan", "kimi"),
+        Some("/skill:agtx-plan".to_string())
+    );
+    assert_eq!(
+        transform_plugin_command("/gsd:plan-phase 1", "kimi"),
+        Some("/skill:gsd-plan-phase 1".to_string())
     );
 }

--- a/tests/smoke/agent_matrix.rs
+++ b/tests/smoke/agent_matrix.rs
@@ -117,6 +117,10 @@ fn main() {
             "prompt_form": match s.prompt_form {
                 spec::PromptForm::Argv => Value::String("argv".into()),
                 spec::PromptForm::Flag(f) => Value::String(format!("flag:{f}")),
+                // The CLI takes no opening message at all, so the runner must
+                // expect the prompt on the typed lane however
+                // `launch_prompt_verified` reads.
+                spec::PromptForm::None => Value::String("none".into()),
             },
             "send_strategy": match s.send_strategy {
                 spec::SendStrategy::Generic => "generic",

--- a/tests/smoke/agent_smoke.py
+++ b/tests/smoke/agent_smoke.py
@@ -29,9 +29,11 @@ trusted, a dialog during a *task* is a real defect.
 
 It also makes the run a test of the inheritance property itself. claude, codex and
 gemini inherit the root's trust into their worktrees, so a dialog there means that
-stopped being true. antigravity matches paths exactly and never inherits, so agtx
-must seed each worktree from that consent — if the seeding breaks, its cases park
-and the run says so.
+stopped being true. antigravity and kimi match paths exactly and never inherit, so
+agtx must seed each worktree from that consent — if the seeding breaks, their cases
+park and the run says so. kimi's park is the worst of the set: its dialog
+preselects "Don't trust" and choosing that exits the process, so a broken seed
+leaves a dead shell rather than a waiting prompt.
 
 Usage:
     tests/smoke/agent_smoke.py                      # installed agents x agtx plugin
@@ -46,6 +48,7 @@ real agent auth. Spends real tokens — opt-in, never CI.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import queue
@@ -497,7 +500,13 @@ AGENT_TRUST_STORES = {
     "codex": "codex",
     "gemini": "gemini",
     "antigravity": "antigravity",
+    "kimi": "kimi",
 }
+
+# The stores agtx *seeds and prunes* — the exact-matching ones, where a trusted
+# project root cannot cover a worktree. Only these are meaningful to
+# `trust_store_lists`: the rest record an ancestor agtx neither wrote nor removes.
+SEEDED_TRUST_STORES = ("antigravity", "kimi")
 
 
 def setup_agent_trust(agent: str, repo: Path) -> bool:
@@ -511,9 +520,13 @@ def setup_agent_trust(agent: str, repo: Path) -> bool:
 
     It also turns the run into a test of the inheritance property itself: claude,
     codex and gemini trust the root and their worktrees inherit it, so a dialog in
-    a worktree means that stopped being true. antigravity matches exactly and never
-    inherits, so agtx must seed each worktree from this consent — if that seeding
-    breaks, its cases park and the run says so.
+    a worktree means that stopped being true. antigravity and kimi match exactly and
+    never inherit, so agtx must seed each worktree from this consent — if that
+    seeding breaks, their cases park and the run says so.
+
+    kimi's park is the worst of the set: its dialog preselects "Don't trust" and
+    choosing that exits the process, so a broken seed leaves a dead shell rather
+    than a waiting prompt.
 
     Returns whether anything was written. cursor and grok pass `--trust` at launch
     and pi passes `--approve`, opencode has no trust gate, and copilot is
@@ -551,26 +564,77 @@ def setup_agent_trust(agent: str, repo: Path) -> bool:
         if root not in entries:
             entries.append(root)
         atomic_write_json(path, data)
+    elif kind == "kimi":
+        # One extensionless JSON file per trusted directory, in a directory of
+        # its own. kimi's own check is only that the file exists and parses.
+        path = kimi_home() / "workspace-trust" / kimi_trust_key(root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(path, {"root": root, "trustedAt": int(time.time() * 1000)})
     return True
+
+
+def kimi_home() -> Path:
+    """Kimi's data root: `$KIMI_CODE_HOME`, else `~/.kimi-code`.
+
+    Mirrors `kimi_home` in `src/agent/trust.rs`, minus its `AGTX_AGENT_HOME`
+    guard — the runner drives the real binary against the real home on purpose.
+    """
+    env = os.environ.get("KIMI_CODE_HOME")
+    return Path(env) if env else Path.home() / ".kimi-code"
+
+
+def kimi_trust_key(root: str) -> str:
+    """The filename kimi stores a directory's trust record under.
+
+    Mirrors `kimi_trust_key` in `src/agent/trust.rs`, which is itself a port of
+    kimi's `encodeWorkDirKey ∘ canonicalWorkspaceRoot`. Restated rather than
+    shelled out to, so that a drift between agtx's derivation and kimi's shows up
+    here as a parked dialog instead of being hidden by agtx agreeing with itself.
+
+    Deliberately **not** `realpath`: kimi's normalization is lexical, so
+    `/tmp/x` stays `/tmp/x` rather than becoming `/private/tmp/x` on macOS.
+    """
+    normalized = root.replace("\\", "/").rstrip("/")
+    base = normalized.rsplit("/", 1)[-1]
+    # `[^a-z0-9._-]+` — one dash per *run*, not per character.
+    slug = re.sub(r"[^a-z0-9._-]+", "-", base.lower())
+    slug = slug.strip("-")[:40].strip("-")
+    if slug in ("", ".", ".."):
+        slug = "workspace"
+    digest = hashlib.sha256(normalized.encode()).hexdigest()[:12]
+    return f"wd_{slug}_{digest}"
 
 
 def trust_store_lists(agent: str, path: Path) -> bool | None:
     """Whether `agent`'s trust store still lists `path` exactly.
 
-    `None` for agents with no store agtx seeds. Only the exact-match store
-    (antigravity) is meaningful here: the others record an ancestor, which agtx
-    neither wrote nor prunes.
+    `None` for agents with no store agtx seeds. Only the exact-match stores
+    (antigravity, kimi) are meaningful here: the others record an ancestor, which
+    agtx neither wrote nor prunes.
+
+    Dispatched on the store kind rather than hard-coded to antigravity, because
+    the two shapes have nothing in common — one is a JSON array to search, the
+    other a directory of files to stat. This is the assertion that catches the
+    prune leaking one dead record per task.
     """
-    if AGENT_TRUST_STORES.get(agent) != "antigravity":
+    kind = AGENT_TRUST_STORES.get(agent)
+    if kind not in SEEDED_TRUST_STORES:
         return None
-    store = Path.home() / ".gemini" / "antigravity-cli" / "settings.json"
-    if not store.exists():
-        return False
-    try:
-        entries = json.loads(store.read_text()).get("trustedWorkspaces", [])
-    except (json.JSONDecodeError, OSError):
-        return False
-    return str(path.resolve()) in entries or str(path) in entries
+    if kind == "antigravity":
+        store = Path.home() / ".gemini" / "antigravity-cli" / "settings.json"
+        if not store.exists():
+            return False
+        try:
+            entries = json.loads(store.read_text()).get("trustedWorkspaces", [])
+        except (json.JSONDecodeError, OSError):
+            return False
+        return str(path.resolve()) in entries or str(path) in entries
+    # kimi: one file per path spelling, named by the key kimi computes.
+    store = kimi_home() / "workspace-trust"
+    return any(
+        (store / kimi_trust_key(form)).exists()
+        for form in (str(path), str(path.resolve()))
+    )
 
 
 def atomic_write_json(path: Path, data) -> None:

--- a/tests/smoke/test_agent_smoke.py
+++ b/tests/smoke/test_agent_smoke.py
@@ -713,7 +713,7 @@ class AgentTrustSetup(unittest.TestCase):
         self.assertIn("/somewhere/else", entries)
 
     def test_flag_based_and_unmeasured_agents_write_nothing(self):
-        for agent in ("cursor", "grok", "opencode", "copilot"):
+        for agent in ("cursor", "grok", "pi", "opencode", "copilot"):
             with self.subTest(agent=agent):
                 self.assertFalse(smoke.setup_agent_trust(agent, self.repo))
         self.assertEqual(os.listdir(self.home), [])
@@ -722,8 +722,54 @@ class AgentTrustSetup(unittest.TestCase):
         """Kept in step with `src/agent/trust.rs` — a new store there needs one here."""
         self.assertEqual(
             set(smoke.AGENT_TRUST_STORES),
-            {"claude", "codex", "gemini", "antigravity"},
+            {"claude", "codex", "gemini", "antigravity", "kimi"},
         )
+
+    def test_only_the_exact_matching_stores_are_seeded(self):
+        """`trust_store_lists` is meaningful only where agtx writes the record.
+
+        The inheriting stores hold entries agtx never wrote and does not prune,
+        so asserting on them after Done would fail for the wrong reason.
+        """
+        self.assertEqual(set(smoke.SEEDED_TRUST_STORES), {"antigravity", "kimi"})
+        for agent in ("claude", "codex", "gemini", "cursor", "copilot"):
+            with self.subTest(agent=agent):
+                self.assertIsNone(smoke.trust_store_lists(agent, self.repo))
+
+    def test_kimi_writes_a_record_kimi_would_read(self):
+        smoke.setup_agent_trust("kimi", self.repo)
+        root = str(self.repo.resolve())
+        path = (
+            Path(self.home)
+            / ".kimi-code"
+            / "workspace-trust"
+            / smoke.kimi_trust_key(root)
+        )
+        # kimi's own check is that the file exists and parses as JSON.
+        self.assertEqual(json.loads(path.read_text())["root"], root)
+        self.assertTrue(smoke.trust_store_lists("kimi", self.repo))
+
+    def test_kimi_trust_key_matches_the_rust_derivation(self):
+        """The shape kimi computes: `wd_<slug>_<sha256[:12]>`.
+
+        Restated in both languages on purpose — if only one carried it, a drift
+        would show up as every kimi task parked on a dialog whose default answer
+        kills the agent.
+        """
+        key = smoke.kimi_trust_key("/one/proj")
+        slug, digest = key[len("wd_"):].rsplit("_", 1)
+        self.assertEqual(slug, "proj")
+        self.assertEqual(len(digest), 12)
+        self.assertTrue(all(c in "0123456789abcdef" for c in digest))
+        # Lexical normalization, not realpath: a trailing slash is the same dir.
+        self.assertEqual(smoke.kimi_trust_key("/one/proj/"), key)
+        # The hash covers the whole path, not just the basename.
+        self.assertNotEqual(smoke.kimi_trust_key("/two/proj"), key)
+        # One dash per run of separators; truncate to 40 and trim again.
+        self.assertTrue(
+            smoke.kimi_trust_key("/tmp/My Project (v2)!!").startswith("wd_my-project-v2_")
+        )
+        self.assertTrue(smoke.kimi_trust_key("/").startswith("wd_workspace_"))
 
 
 


### PR DESCRIPTION
Adds Kimi Code (Moonshot AI) as the tenth supported agent: a full `AgentSpec` entry with `--auto` launch flags, `.kimi-code/skills/` skill deployment, `/skill:agtx-*` command syntax, merged `.kimi-code/mcp.json` MCP config, and its inverted `Trust this folder?` dialog (answered `Up`+`Enter`, since the preselected option exits the process).

Introduces `PromptForm::None` for agents whose CLI accepts no opening message — kimi rejects a positional prompt with `unknown command`, so its task text goes down the mid-session typed lane instead, guarded by spec-table invariants that a `None`-form agent can never be marked launch-verified. Also teaches `agent::trust` kimi's workspace-trust store, which is a directory of hash-keyed one-record files rather than a single document, so seeding, scanning and forgetting each get a dedicated path.

## Changes
```
 .mcp.json                       |  10 +-
 CLAUDE.md                       |  20 ++-
 README.md                       |  44 ++++---
 src/agent/mod.rs                |   5 +
 src/agent/spec.rs               | 177 ++++++++++++++++++++++++--
 src/agent/trust.rs              | 184 ++++++++++++++++++++++++++-
 src/agent/trust_tests.rs        | 273 +++++++++++++++++++++++++++++++++++++++-
 src/tui/app.rs                  |  24 +++-
 src/tui/app_tests.rs            | 242 ++++++++++++++++++++++++++++++++++-
 tests/agent_parity_tests.rs     |  59 ++++++++-
 tests/agent_tests.rs            |  77 ++++++++++++
 tests/smoke/agent_matrix.rs     |   4 +
 tests/smoke/agent_smoke.py      | 100 ++++++++++++---
 tests/smoke/test_agent_smoke.py |  50 +++++++-
 14 files changed, 1197 insertions(+), 72 deletions(-)
```
