### PR TITLE
Carry decisions between worktrees, not just isolation

### DIFF
--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -2,6 +2,14 @@
 
 <!-- Written by `knos export`. Commit this file. -->
 
+<!--
+Reading this file needs nothing installed: it is plain markdown, and a fresh
+clone picks it up as-is. The live claim/withhold server is a separate, optional
+step - `pip install knos` (Python 3.10+), which the MCP entry launches as
+`python -m knos.mcp`. Without it, everything below still reads normally.
+-->
+
+
 A second clone reads this on its first question — it is one of the decision
 records knos looks for. Nothing here is private: secrets and private paths
 never reach it.

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -1,0 +1,22 @@
+# Decisions and current work
+
+<!-- Written by `knos export`. Commit this file. -->
+
+A second clone reads this on its first question — it is one of the decision
+records knos looks for. Nothing here is private: secrets and private paths
+never reach it.
+
+
+## Decisions
+
+- **task lifecycle** — Tasks move through `Backlog → Planning → Running → Review → Done`. There is no separate Research status; Backlog's display name is `backlog/research`.  _(AGENTS.md, CLAUDE.md)_
+- **a worktree per task** — Planning creates a git worktree at `{worktree_dir}/{slug}`, default `.agtx/worktrees/{slug}`, copies configured files, runs the init script, deploys skills and starts the agent in planning mode.  _(CLAUDE.md)_
+- **an agent per phase** — Different agents are configured per workflow phase, with automatic switching between them.  _(README.md)_
+- **parallel by default** — Every task gets its own worktree and tmux window, so as many agents run at once as needed.  _(README.md)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>knos export. Claims lapse after 30 minutes.</sub>

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,17 @@
     "agtx": {
       "type": "stdio",
       "command": "agtx",
-      "args": ["mcp-serve"]
+      "args": [
+        "mcp-serve"
+      ]
+    },
+    "knos": {
+      "type": "stdio",
+      "command": "python",
+      "args": [
+        "-m",
+        "knos.mcp"
+      ]
     }
   }
 }


### PR DESCRIPTION
`README.md`: *"Every task gets its own git worktree and tmux window — run as many agents as needed, simultaneously."* Isolation handles the file collisions. What it doesn't carry is the decision — the reason a task was done a particular way in one worktree is not visible in the next one, and the phase handoff from research to implementation to review crosses agents each time.

**What's in the PR**

- `.knos/decisions.md` — a record in the tree, seeded from this repo's own `AGENTS.md`, `CLAUDE.md` and `README.md` with every line citing its source. Every worktree under `.agtx/worktrees/` resolves to the same record, because it keys on `git rev-parse --git-common-dir` rather than `--show-toplevel` — the latter returns the worktree root and would give you one memory per task.
- A `knos` entry in `.mcp.json` alongside `agtx`, same `stdio` shape.

**Disclosure:** I wrote Knos. It is a local MCP server — three tools, no ports, no network, no account, no model download. I seeded the record from your own docs rather than mine so it is checkable rather than promotional. If a third-party entry isn't wanted, close it; the `.knos/decisions.md` half needs no install and works as plain markdown either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)