### PR TITLE
fix: hold the pane-capture rate limit against paints

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -9916,18 +9916,35 @@ impl PaneWatch {
     /// Same reasoning as [`wait_for_change`](Self::wait_for_change): the guard
     /// stays inside the call. A plain sleep would be simpler and wrong — it would
     /// hold the ceiling meant for the agent's paints against the user's own echo.
+    ///
+    /// **It has to resume the wait**, which a single `wait_timeout` does not: the
+    /// condvar is shared with [`mark_output`](Self::mark_output), so a paint
+    /// notifies it, and returning there releases the ceiling to the very thing
+    /// it is a ceiling *on*. A pane painting flat out then drives one capture per
+    /// notification — exactly what [`PANE_OUTPUT_MIN_INTERVAL`] exists to stop —
+    /// and no wait longer than the gap between two paints is ever served.
     fn wait_out_rate_limit(&self, wait: std::time::Duration) -> Option<bool> {
-        let Ok(state) = self.inner.lock() else {
+        let deadline = Instant::now() + wait;
+        let Ok(mut state) = self.inner.lock() else {
             return None;
         };
         let before = state.poke;
-        let Ok((state, _)) = self.cv.wait_timeout(state, wait) else {
-            return None;
-        };
-        if state.stopped {
-            return None;
+        loop {
+            if state.stopped {
+                return None;
+            }
+            if state.poke != before {
+                return Some(true);
+            }
+            // `None` once the deadline is behind us: the ceiling has been served.
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return Some(false);
+            };
+            let Ok((next, _)) = self.cv.wait_timeout(state, remaining) else {
+                return None;
+            };
+            state = next;
         }
-        Some(state.poke != before)
     }
 
     fn set_pane_id(&self, pane_id: Option<String>) {

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -1015,6 +1015,50 @@ fn the_interval_becomes_a_rate_limit_under_push() {
 }
 
 #[test]
+fn the_rate_limit_holds_against_a_paint_and_yields_to_a_keystroke() {
+    use std::time::{Duration, Instant};
+    // A paint is the thing being rate-limited, so it must not end the wait.
+    // `wait_timeout` returns on *any* notification and the condvar is shared
+    // with `mark_output`, so the ceiling only holds if the wait is resumed for
+    // the remainder — otherwise a pane painting flat out drives one capture per
+    // notification, which is what `PANE_OUTPUT_MIN_INTERVAL` exists to stop.
+    let ceiling = Duration::from_millis(150);
+    let watch = Arc::new(PaneWatch::default());
+    watch.set_pane_id(Some("%1".to_string()));
+    let painter = Arc::clone(&watch);
+    std::thread::spawn(move || {
+        for _ in 0..5 {
+            std::thread::sleep(Duration::from_millis(10));
+            painter.mark_output("%1");
+        }
+    });
+    let start = Instant::now();
+    assert_eq!(watch.wait_out_rate_limit(ceiling), Some(false));
+    assert!(
+        start.elapsed() >= ceiling,
+        "a paint released the ceiling after {:?}",
+        start.elapsed()
+    );
+
+    // A keystroke does end it: the user's own echo is what the fast floor is
+    // for, and holding the agent's ceiling against it would delay every first
+    // character typed after a pause.
+    let watch = Arc::new(PaneWatch::default());
+    let typist = Arc::clone(&watch);
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(10));
+        typist.poke();
+    });
+    let start = Instant::now();
+    assert_eq!(watch.wait_out_rate_limit(Duration::from_secs(5)), Some(true));
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "a keystroke waited {:?}",
+        start.elapsed()
+    );
+}
+
+#[test]
 fn output_is_sampled_slower_than_a_keystroke_echo() {
     use std::time::Duration;
     // The two reasons to capture deserve different answers. One shared ceiling


### PR DESCRIPTION
`wait_out_rate_limit` called `wait_timeout` once and discarded its `WaitTimeoutResult`, so any notification ended the wait. The condvar is shared with `mark_output`, which means a *paint* released the ceiling meant to rate-limit paints: a pane painting flat out drove one capture per notification — what `PANE_OUTPUT_MIN_INTERVAL` exists to stop — and no wait longer than the gap between two paints was ever served. Measured before the fix: 22ms served against a 400ms ask.

Resume the wait for the remainder instead. Only a poke ends it early, which is what the return value (`state.poke != before`) always claimed.