### PR TITLE
Add Jujutsu support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,9 +482,10 @@ update_check = true          # Check GitHub daily for a new release (see Updatin
 
 ### Worktree Base Branch
 
-agtx creates a new git worktree for each task. By default it auto-detects the base branch in this
+For Git projects, agtx creates a new worktree for each task and auto-detects the base branch in this
 order: `main`, then `master`, then the current branch. You can override this to force a specific
-base branch (for example `dev` or `develop`).
+base branch (for example `dev` or `develop`). Jujutsu projects use the project setting described
+below.
 
 Global worktree defaults can be set here:
 
@@ -503,8 +504,11 @@ to `.agtx/worktrees` if not set.
 Per-project settings can be placed in `.agtx/config.toml` at the project root:
 
 ```toml
+# Version-control backend: "git" (default) or "jj"
+vcs = "jj"
+
 # Base branch used when creating new task worktrees (optional)
-base_branch = "dev"
+base_branch = "trunk()"
 
 # Directory where worktrees are created (optional, default: ".agtx/worktrees")
 worktree_dir = ".worktrees"
@@ -520,8 +524,18 @@ init_script = "scripts/init_worktree.sh"
 cleanup_script = "scripts/cleanup_worktree.sh"
 ```
 
-`base_branch` controls which branch new task worktrees are created from. If omitted or empty, agtx
-auto-detects `main`, `master`, or falls back to the current branch.
+The VCS is never inferred from repository metadata: an absent `vcs` setting means Git, including in
+a colocated Git/Jujutsu repository. Set `vcs = "jj"` to create Jujutsu workspaces instead. Both
+colocated and non-colocated Jujutsu repositories are supported.
+
+`base_branch` controls the revision used for new task workspaces. If omitted or empty, Git projects
+detect `main`, `master`, or the current branch; Jujutsu projects use `trunk()`.
+
+Agent prompts use `agtx vcs` commands for status, task diffs, checkpoints, logs, and base
+integration. These commands get the task identity, checkout, and project root from the environment
+agtx attaches to the task's tmux window, then validate all three against the project database. The
+same environment exposes `AGTX_BIN`, and deployed skills bake in that running binary's absolute
+path, so they do not depend on `agtx` being on `PATH`.
 
 ### Per-Phase Agent Configuration
 

--- a/plugins/agtx-terse/skills/agtx-review/SKILL.md
+++ b/plugins/agtx-terse/skills/agtx-review/SKILL.md
@@ -9,7 +9,7 @@ You are in the **review phase** of an agtx-managed task.
 
 ## Instructions
 
-1. Review all changes made during execution: run `git diff HEAD` (staged+unstaged) and `git log --oneline $(git merge-base HEAD origin/HEAD)..HEAD` to see only your commits. Do NOT diff against `main` or `origin/main` — those may include unrelated upstream history.
+1. Review all changes made during execution with `{{AGTX_BIN}} vcs diff --task` and `{{AGTX_BIN}} vcs log --task`. These commands use the task's recorded backend and base revision.
 2. Check for:
    - Correctness and edge cases
    - Error handling

--- a/plugins/agtx/skills/merge-conflicts.md
+++ b/plugins/agtx/skills/merge-conflicts.md
@@ -1,52 +1,31 @@
 ---
 name: agtx-merge-conflicts
-description: Resolve merge conflicts by merging the default branch into the current feature branch.
+description: Merge the task's configured base, resolve conflicts, verify the result, and stop.
 ---
 
 # Merge Conflict Resolution
 
-Your feature branch has **merge conflicts** with the default branch (main/master).
+The task conflicts with its configured base revision. Use agtx's VCS-neutral
+commands; they select Git or Jujutsu from the task record.
 
 ## Instructions
 
-1. First, commit all current work so nothing is lost:
-   - Review the staged/unstaged changes with `git diff` and `git diff --cached`
-   - Write a descriptive commit message that summarizes the actual changes
-   - `git add -A && git commit -m "<your message>"`
-   - If there is nothing to commit, skip this step.
-
-2. Merge the default branch into your current branch:
-   ```bash
-   git fetch origin
-   git merge origin/main
-   ```
-   If the project uses `master` instead of `main`, use `origin/master`.
-
-3. Resolve ALL merge conflicts:
-   - **Before resolving**, note which files have conflicts: `git diff --name-only --diff-filter=U`
-   - Open each conflicted file
-   - Remove conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
-   - Choose the correct resolution for each conflict, preserving both sides' intent when possible
-
-4. After resolving all conflicts:
-   - `git add -A && git commit --no-edit`
-
-5. **Review only the conflicted files** to catch resolution mistakes:
-   - For each file that had conflicts (from step 3), compare your resolution against both parents:
-     - `git diff HEAD^2..HEAD -- <file>` (what changed vs the default branch — shows only your feature's additions). **Start here** — this is usually the smaller, more focused diff.
-     - `git diff HEAD^1..HEAD -- <file>` (what changed vs your branch before merge — shows what main brought in). This can be very large; if so, focus on the areas around the conflict markers you resolved rather than reading the entire diff.
-   - Verify:
-     - No code was accidentally dropped from either side
-     - The combined logic is coherent (e.g., imports, function signatures, variable names all consistent)
-     - No duplicate code blocks were introduced
-   - If you find a problem, fix it immediately and commit the fix separately
-
-6. Run tests to verify nothing is broken. Fix any issues introduced by the merge.
+1. Inspect the workspace with `{{AGTX_BIN}} vcs status`.
+2. Preserve current work with
+   `{{AGTX_BIN}} vcs checkpoint -m "Checkpoint before integrating task base"`.
+3. Run `{{AGTX_BIN}} vcs integrate-base --fetch`. The integration may contain
+   conflicts even when this command succeeds.
+4. List unresolved paths with `{{AGTX_BIN}} vcs conflicts`, then resolve every path.
+   Preserve both the task's intent and compatible upstream changes.
+5. Run `{{AGTX_BIN}} vcs finish-integration`. If it reports unresolved paths, continue
+   resolving and retry it.
+6. Inspect the result with `{{AGTX_BIN}} vcs status` and `{{AGTX_BIN}} vcs diff --task`.
+7. Run the relevant test suite. Fix any integration regressions you introduced.
 
 ## Rules
 
-- **Always merge, never rebase.** The branch may have been shared or pushed.
-- Do NOT squash commits.
-- Do NOT force push.
+- Merge the base; do not rebase or squash task history.
+- Do not force-push.
+- Do not discard either side wholesale merely to remove conflict markers.
 - After committing the merge, say: "Merge conflicts resolved and committed."
 - Then **stop and wait** for further instructions.

--- a/plugins/agtx/skills/review.md
+++ b/plugins/agtx/skills/review.md
@@ -9,7 +9,7 @@ You are in the **review phase** of an agtx-managed task.
 
 ## Instructions
 
-1. Review all changes made during execution: run `git diff HEAD` (staged+unstaged) and `git log --oneline $(git merge-base HEAD origin/HEAD)..HEAD` to see only your commits. Do NOT diff against `main` or `origin/main` — those may include unrelated upstream history.
+1. Review all changes made during execution with `{{AGTX_BIN}} vcs diff --task` and `{{AGTX_BIN}} vcs log --task`. These commands use the task's recorded backend and base revision.
 2. Check for:
    - Correctness and edge cases
    - Error handling

--- a/plugins/superpowers/plugin.toml
+++ b/plugins/superpowers/plugin.toml
@@ -7,7 +7,7 @@ init_script = "claude plugin install superpowers@claude-plugins-official --scope
 planning = "docs/superpowers/plans/*.md"
 
 [prompts]
-planning = "You are already in an isolated git worktree managed by agtx. Do NOT create additional worktrees or branches. Work directly in this directory.\n\nUse the brainstorming skill to explore and design this task. When the design is approved, use the writing-plans skill to produce an implementation plan.\n\nTask: {task}"
+planning = "You are already in an isolated VCS workspace managed by agtx. Do NOT create additional workspaces or branches. Work directly in this directory.\n\nUse the brainstorming skill to explore and design this task. When the design is approved, use the writing-plans skill to produce an implementation plan.\n\nTask: {task}"
 running = "Use the executing-plans skill (or subagent-driven-development if subagents are available) to implement the plan in docs/superpowers/plans/."
 review = "Use the requesting-code-review skill to review the completed work."
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -249,6 +249,9 @@ fn default_true() -> bool {
 /// Project-specific configuration (stored in .agtx/config.toml)
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProjectConfig {
+    /// Version-control backend for this project. Omitted means Git.
+    pub vcs: Option<crate::git::VcsKind>,
+
     /// Override default agent for this project
     pub default_agent: Option<String>,
 
@@ -486,6 +489,7 @@ const PROJECT_MANAGED: ManagedKeys = ManagedKeys {
         // `agents` is itself optional here, so clearing it must drop the whole
         // `[agents]` section rather than leaving an empty header behind.
         "agents",
+        "vcs",
         "default_agent",
         "base_branch",
         "github_url",
@@ -617,6 +621,7 @@ pub fn determine_first_run_action(
 /// Merged configuration (global + project)
 #[derive(Debug, Clone)]
 pub struct MergedConfig {
+    pub vcs: crate::git::VcsKind,
     pub default_agent: String,
     pub phase_agents: PhaseAgentsConfig,
     pub worktree_enabled: bool,
@@ -643,7 +648,9 @@ impl MergedConfig {
     /// Create merged config from global and project configs
     pub fn merge(global: &GlobalConfig, project: &ProjectConfig) -> Self {
         let project_agents = project.agents.clone().unwrap_or_default();
+        let vcs = project.vcs.unwrap_or_default();
         Self {
+            vcs,
             default_agent: project
                 .default_agent
                 .clone()
@@ -660,7 +667,10 @@ impl MergedConfig {
             base_branch: project
                 .base_branch
                 .clone()
-                .unwrap_or_else(|| global.worktree.base_branch.clone()),
+                .unwrap_or_else(|| match vcs {
+                    crate::git::VcsKind::Git => global.worktree.base_branch.clone(),
+                    crate::git::VcsKind::Jj => String::new(),
+                }),
             worktree_dir: project
                 .worktree_dir
                 .clone()
@@ -1041,6 +1051,7 @@ mod managed_keys_tests {
     #[test]
     fn project_managed_keys_covers_every_optional_field() {
         let config = ProjectConfig {
+            vcs: Some(crate::git::VcsKind::Git),
             default_agent: Some("claude".into()),
             agents: Some(PhaseAgentsConfig {
                 research: Some("claude".into()),

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -74,6 +74,11 @@ pub struct Task {
     pub referenced_tasks: Option<String>,
     pub escalation_note: Option<String>,
     pub base_branch: Option<String>,
+    /// Backend captured when the task checkout was created. `None` is a
+    /// pre-migration task and therefore means Git.
+    pub vcs: Option<crate::git::VcsKind>,
+    /// Jujutsu workspace name. Git worktrees do not need a separate identity.
+    pub workspace_name: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -103,6 +108,8 @@ impl Task {
             referenced_tasks: None,
             escalation_note: None,
             base_branch: None,
+            vcs: None,
+            workspace_name: None,
             created_at: now,
             updated_at: now,
         }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -206,6 +206,12 @@ impl Database {
         let _ = self
             .conn
             .execute("ALTER TABLE tasks ADD COLUMN base_branch TEXT", []);
+        let _ = self
+            .conn
+            .execute("ALTER TABLE tasks ADD COLUMN vcs TEXT", []);
+        let _ = self
+            .conn
+            .execute("ALTER TABLE tasks ADD COLUMN workspace_name TEXT", []);
 
         // MCP transition request queue
         self.conn.execute_batch(
@@ -345,8 +351,8 @@ impl Database {
     pub fn create_task(&self, task: &Task) -> Result<()> {
         self.conn.execute(
             r#"
-            INSERT INTO tasks (id, title, description, status, agent, project_id, session_name, worktree_path, branch_name, pr_number, pr_url, plugin, cycle, referenced_tasks, escalation_note, base_branch, created_at, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+            INSERT INTO tasks (id, title, description, status, agent, project_id, session_name, worktree_path, branch_name, pr_number, pr_url, plugin, cycle, referenced_tasks, escalation_note, base_branch, vcs, workspace_name, created_at, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
             "#,
             params![
                 task.id,
@@ -365,6 +371,8 @@ impl Database {
                 task.referenced_tasks,
                 task.escalation_note,
                 task.base_branch,
+                task.vcs.map(|v| v.as_str()),
+                task.workspace_name,
                 task.created_at.to_rfc3339(),
                 task.updated_at.to_rfc3339(),
             ],
@@ -377,8 +385,8 @@ impl Database {
         for task in tasks {
             tx.execute(
                 r#"
-                INSERT INTO tasks (id, title, description, status, agent, project_id, session_name, worktree_path, branch_name, pr_number, pr_url, plugin, cycle, referenced_tasks, escalation_note, base_branch, created_at, updated_at)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+                INSERT INTO tasks (id, title, description, status, agent, project_id, session_name, worktree_path, branch_name, pr_number, pr_url, plugin, cycle, referenced_tasks, escalation_note, base_branch, vcs, workspace_name, created_at, updated_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
                 "#,
                 params![
                     task.id,
@@ -397,6 +405,8 @@ impl Database {
                     task.referenced_tasks,
                     task.escalation_note,
                     task.base_branch,
+                    task.vcs.map(|v| v.as_str()),
+                    task.workspace_name,
                     task.created_at.to_rfc3339(),
                     task.updated_at.to_rfc3339(),
                 ],
@@ -424,7 +434,9 @@ impl Database {
                 referenced_tasks = ?13,
                 escalation_note = ?14,
                 base_branch = ?15,
-                updated_at = ?16
+                vcs = ?16,
+                workspace_name = ?17,
+                updated_at = ?18
             WHERE id = ?1
             "#,
             params![
@@ -443,6 +455,8 @@ impl Database {
                 task.referenced_tasks,
                 task.escalation_note,
                 task.base_branch,
+                task.vcs.map(|v| v.as_str()),
+                task.workspace_name,
                 task.updated_at.to_rfc3339(),
             ],
         )?;
@@ -474,6 +488,12 @@ impl Database {
             referenced_tasks: row.get("referenced_tasks").ok().flatten(),
             escalation_note: row.get("escalation_note").ok().flatten(),
             base_branch: row.get("base_branch").ok().flatten(),
+            vcs: row
+                .get::<_, Option<String>>("vcs")
+                .ok()
+                .flatten()
+                .and_then(|v| v.parse().ok()),
+            workspace_name: row.get("workspace_name").ok().flatten(),
             created_at: chrono::DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at")?)
                 .map(|dt| dt.with_timezone(&chrono::Utc))
                 .unwrap_or_else(|_| chrono::Utc::now()),

--- a/src/git/jj_operations.rs
+++ b/src/git/jj_operations.rs
@@ -1,0 +1,556 @@
+//! Jujutsu implementation of the checkout operations agtx needs.
+
+use anyhow::{bail, Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use super::operations::GitOperations;
+
+pub struct RealJjOps;
+
+impl RealJjOps {
+    pub fn remove_workspace(
+        &self,
+        project_path: &Path,
+        workspace_path: &Path,
+        workspace_name: Option<&str>,
+    ) -> Result<()> {
+        let project_root = project_path
+            .canonicalize()
+            .context("Jujutsu project root does not resolve")?;
+        let workspace_root = workspace_path.canonicalize().ok();
+        if workspace_root.as_ref() == Some(&project_root) {
+            return Ok(());
+        }
+        let name = workspace_name
+            .or_else(|| workspace_path.file_name().and_then(|part| part.to_str()))
+            .context("Jujutsu workspace has no recorded name")?;
+
+        // `workspace forget` succeeds even for an unknown name. Resolve the
+        // recorded registration first and prove that it names this directory;
+        // otherwise a stale task record could delete an unrelated checkout.
+        let registered = successful(project_path, &["workspace", "root", "--name", name])?;
+        let registered = PathBuf::from(String::from_utf8_lossy(&registered.stdout).trim());
+        let registered = if registered.is_absolute() {
+            registered
+        } else {
+            project_root.join(registered)
+        };
+        let expected = if workspace_path.is_absolute() {
+            workspace_path.to_path_buf()
+        } else {
+            project_root.join(workspace_path)
+        };
+        let registered_matches = match (registered.canonicalize(), workspace_root.as_ref()) {
+            (Ok(registered), Some(workspace)) => registered == *workspace,
+            _ => registered == expected,
+        };
+        if !registered_matches {
+            bail!(
+                "Jujutsu workspace '{name}' is registered at '{}', not '{}'",
+                registered.display(),
+                workspace_path.display()
+            );
+        }
+
+        successful(project_path, &["workspace", "forget", name])?;
+        if workspace_path.exists() {
+            std::fs::remove_dir_all(workspace_path).with_context(|| {
+                format!("failed to remove workspace '{}'", workspace_path.display())
+            })?;
+        }
+        Ok(())
+    }
+}
+
+fn run(path: &Path, args: &[&str]) -> Result<Output> {
+    Command::new("jj")
+        .current_dir(path)
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run jj {}", args.join(" ")))
+}
+
+fn successful(path: &Path, args: &[&str]) -> Result<Output> {
+    let output = run(path, args)?;
+    if !output.status.success() {
+        bail!(
+            "jj {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(output)
+}
+
+/// Resolve a configured revision to exactly one commit.
+pub fn resolve_revision(repo: &Path, revision: &str) -> Result<String> {
+    let output = successful(
+        repo,
+        &[
+            "log",
+            "-r",
+            revision,
+            "--no-graph",
+            "-T",
+            "commit_id ++ \"\\n\"",
+        ],
+    )?;
+    let commits: Vec<_> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(str::to_owned)
+        .collect();
+    match commits.as_slice() {
+        [commit] => Ok(commit.clone()),
+        [] => bail!("Jujutsu revision '{revision}' did not resolve to a commit"),
+        _ => bail!("Jujutsu revision '{revision}' resolved to multiple commits"),
+    }
+}
+
+fn workspace_path(project: &Path, slug: &str, worktree_dir: &str) -> PathBuf {
+    project.join(worktree_dir).join(slug)
+}
+
+impl GitOperations for RealJjOps {
+    fn create_worktree(
+        &self,
+        project_path: &Path,
+        task_slug: &str,
+        base_branch: &str,
+        worktree_dir: &str,
+        _branch_prefix: &str,
+    ) -> Result<String> {
+        let path = workspace_path(project_path, task_slug, worktree_dir);
+        if path.exists() {
+            if super::is_jj_repo(&path) {
+                return Ok(path.to_string_lossy().into_owned());
+            }
+            bail!(
+                "refusing to replace existing non-Jujutsu directory '{}'",
+                path.display()
+            );
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let requested_base = if base_branch.trim().is_empty() {
+            "trunk()"
+        } else {
+            base_branch.trim()
+        };
+        let base = resolve_revision(project_path, requested_base)?;
+        let output = Command::new("jj")
+            .current_dir(project_path)
+            .args(["workspace", "add", "--name", task_slug, "--revision"])
+            .arg(&base)
+            .arg(&path)
+            .output()
+            .context("failed to create Jujutsu workspace")?;
+        if !output.status.success() {
+            bail!(
+                "failed to create Jujutsu workspace: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Ok(path.to_string_lossy().into_owned())
+    }
+
+    fn remove_worktree(&self, project_path: &Path, worktree_path: &str) -> Result<()> {
+        self.remove_workspace(project_path, Path::new(worktree_path), None)
+    }
+
+    fn worktree_exists(&self, project_path: &Path, task_slug: &str, worktree_dir: &str) -> bool {
+        super::is_jj_repo(&workspace_path(project_path, task_slug, worktree_dir))
+    }
+
+    fn delete_branch(&self, project_path: &Path, branch_name: &str) -> Result<()> {
+        let output = run(project_path, &["bookmark", "forget", branch_name])?;
+        if output.status.success()
+            || String::from_utf8_lossy(&output.stderr).contains("No matching bookmarks")
+        {
+            Ok(())
+        } else {
+            bail!(
+                "failed to forget Jujutsu bookmark '{branch_name}': {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
+        }
+    }
+
+    fn diff(&self, _worktree_path: &Path) -> String {
+        // There is no unstaged/staged split in Jujutsu.
+        String::new()
+    }
+
+    fn diff_cached(&self, worktree_path: &Path) -> String {
+        run(worktree_path, &["diff", "--git"])
+            .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
+            .unwrap_or_default()
+    }
+
+    fn list_untracked_files(&self, _worktree_path: &Path) -> String {
+        String::new()
+    }
+
+    fn diff_untracked_file(&self, worktree_path: &Path, file: &str) -> String {
+        Command::new("jj")
+            .current_dir(worktree_path)
+            .args(["diff", "--git", "--"])
+            .arg(file)
+            .output()
+            .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
+            .unwrap_or_default()
+    }
+
+    fn diff_stat_from_main(&self, worktree_path: &Path) -> String {
+        run(
+            worktree_path,
+            &["diff", "--stat", "--from", "trunk()", "--to", "@"],
+        )
+        .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
+        .unwrap_or_default()
+    }
+
+    fn add_all(&self, worktree_path: &Path) -> Result<()> {
+        successful(worktree_path, &["st"])?;
+        Ok(())
+    }
+
+    fn has_changes(&self, worktree_path: &Path) -> bool {
+        run(worktree_path, &["diff", "--summary"])
+            .map(|output| output.status.success() && !output.stdout.is_empty())
+            .unwrap_or(false)
+    }
+
+    fn commit(&self, worktree_path: &Path, message: &str) -> Result<()> {
+        if !self.has_changes(worktree_path) {
+            return Ok(());
+        }
+        successful(worktree_path, &["describe", "-m", message])?;
+        // Seal the described change so later review edits get their own change.
+        successful(worktree_path, &["new"])?;
+        Ok(())
+    }
+
+    fn push(&self, worktree_path: &Path, branch: &str, _set_upstream: bool) -> Result<()> {
+        // `commit()` leaves an empty working copy at @, so publish its parent.
+        // If the agent already sealed its own work, the same rule selects the
+        // most recent meaningful change.
+        let target = if self.has_changes(worktree_path) {
+            "@"
+        } else {
+            "@-"
+        };
+        successful(
+            worktree_path,
+            &["bookmark", "set", "--allow-backwards", branch, "-r", target],
+        )?;
+        let exact = format!("exact:{branch}");
+        successful(
+            worktree_path,
+            &["git", "push", "--remote", "origin", "--bookmark", &exact],
+        )?;
+        Ok(())
+    }
+
+    fn fetch_and_check_conflicts(&self, worktree_path: &Path) -> Result<bool> {
+        successful(worktree_path, &["git", "fetch", "--remote", "origin"])?;
+        Ok(conflict_probe(worktree_path, "@", "trunk()")?.0)
+    }
+
+    fn list_files(&self, project_path: &Path) -> Vec<String> {
+        run(project_path, &["file", "list"])
+            .map(|output| {
+                String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .map(str::to_owned)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn initialize_worktree(
+        &self,
+        project_path: &Path,
+        worktree_path: &Path,
+        copy_files: Option<String>,
+        init_script: Option<String>,
+        copy_dirs: Vec<String>,
+    ) -> Vec<String> {
+        super::initialize_worktree(
+            project_path,
+            worktree_path,
+            copy_files.as_deref(),
+            init_script.as_deref(),
+            &copy_dirs,
+        )
+    }
+}
+
+/// Probe a hypothetical merge without editing a workspace or integrating the
+/// operation. Returns whether it conflicts and the conflicting file names.
+pub fn conflict_probe(repo: &Path, left: &str, right: &str) -> Result<(bool, Vec<String>)> {
+    let heads = format!("heads(({left}) | ({right}))");
+    let heads = successful(
+        repo,
+        &[
+            "log",
+            "-r",
+            &heads,
+            "--no-graph",
+            "-T",
+            "commit_id ++ \"\\n\"",
+        ],
+    )?;
+    if String::from_utf8_lossy(&heads.stdout)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count()
+        <= 1
+    {
+        return Ok((false, Vec::new()));
+    }
+
+    let marker = format!("agtx-conflict-probe-{}", uuid::Uuid::new_v4());
+    let output = successful(
+        repo,
+        &[
+            "new",
+            "--no-edit",
+            "--no-integrate-operation",
+            "-m",
+            &marker,
+            left,
+            right,
+        ],
+    )?;
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let operation = combined
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix(
+                "Operation left uncommitted because --no-integrate-operation was requested: ",
+            )
+        })
+        .map(str::trim)
+        .context("jj did not report the isolated conflict-probe operation")?;
+
+    let at_op = format!("--at-op={operation}");
+    let listing = successful(
+        repo,
+        &[
+            &at_op,
+            "log",
+            "-r",
+            "all()",
+            "--no-graph",
+            "-T",
+            "change_id ++ \"\\t\" ++ conflict ++ \"\\t\" ++ description.first_line() ++ \"\\n\"",
+        ],
+    )?;
+    let row = String::from_utf8_lossy(&listing.stdout)
+        .lines()
+        .find(|line| line.ends_with(&format!("\t{marker}")))
+        .map(str::to_owned)
+        .context("could not find the isolated conflict-probe change")?;
+    let mut fields = row.splitn(3, '\t');
+    let change_id = fields.next().context("probe row omitted change id")?;
+    let conflicted = fields.next() == Some("true");
+    if !conflicted {
+        return Ok((false, Vec::new()));
+    }
+
+    let conflicts = successful(repo, &[&at_op, "resolve", "--list", "-r", change_id])?;
+    let files = String::from_utf8_lossy(&conflicts.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            line.rsplit_once("    ")
+                .map_or(line, |(path, _kind)| path)
+                .to_owned()
+        })
+        .collect();
+    Ok((true, files))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn jj_available() -> bool {
+        Command::new("jj")
+            .arg("--version")
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+
+    fn jj(repo: &Path, args: &[&str]) -> String {
+        let output = Command::new("jj")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .expect("run jj");
+        assert!(
+            output.status.success(),
+            "jj {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn init_repo() -> Option<tempfile::TempDir> {
+        if !jj_available() {
+            return None;
+        }
+        let temp = tempfile::tempdir().expect("temp repo");
+        let output = Command::new("jj")
+            .args(["git", "init"])
+            .arg(temp.path())
+            .output()
+            .expect("initialize jj repo");
+        assert!(
+            output.status.success(),
+            "jj git init failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        Some(temp)
+    }
+
+    #[test]
+    fn workspace_lifecycle_uses_explicit_revision() {
+        let Some(repo) = init_repo() else { return };
+        fs::write(repo.path().join("base.txt"), "base\n").unwrap();
+        jj(repo.path(), &["describe", "-m", "base"]);
+        jj(repo.path(), &["new"]);
+
+        let ops = RealJjOps;
+        let workspace = ops
+            .create_worktree(repo.path(), "task-one", "@-", "worktrees", "task")
+            .expect("create workspace");
+        let workspace = PathBuf::from(workspace);
+        assert!(workspace.join("base.txt").exists());
+        assert!(jj(repo.path(), &["workspace", "list"]).contains("task-one"));
+
+        ops.remove_worktree(repo.path(), workspace.to_str().unwrap())
+            .expect("remove workspace");
+        assert!(!workspace.exists());
+        assert!(!jj(repo.path(), &["workspace", "list"]).contains("task-one"));
+    }
+
+    #[test]
+    fn nested_directory_is_not_a_workspace_and_is_not_reused() {
+        let Some(repo) = init_repo() else { return };
+        let partial = repo.path().join("worktrees").join("partial");
+        fs::create_dir_all(&partial).unwrap();
+
+        assert!(!crate::git::is_jj_repo(&partial));
+        let error = RealJjOps
+            .create_worktree(repo.path(), "partial", "root()", "worktrees", "task")
+            .unwrap_err();
+        assert!(error.to_string().contains("non-Jujutsu directory"));
+        assert!(partial.exists());
+    }
+
+    #[test]
+    fn removal_requires_the_recorded_workspace_to_match_the_path() {
+        let Some(repo) = init_repo() else { return };
+        let ops = RealJjOps;
+        let workspace = PathBuf::from(
+            ops.create_worktree(repo.path(), "task-one", "root()", "worktrees", "task")
+                .unwrap(),
+        );
+
+        let error = ops
+            .remove_workspace(repo.path(), &workspace, Some("default"))
+            .unwrap_err();
+        assert!(error.to_string().contains("not"));
+        assert!(workspace.exists());
+        assert!(jj(repo.path(), &["workspace", "list"]).contains("task-one"));
+    }
+
+    #[test]
+    fn removal_never_deletes_the_project_workspace() {
+        let Some(repo) = init_repo() else { return };
+        RealJjOps
+            .remove_workspace(repo.path(), repo.path(), None)
+            .unwrap();
+        assert!(repo.path().exists());
+        assert!(crate::git::is_jj_repo(repo.path()));
+    }
+
+    #[test]
+    fn file_listing_works_without_a_colocated_git_repository() {
+        if !jj_available() {
+            return;
+        }
+        let repo = tempfile::tempdir().unwrap();
+        let output = Command::new("jj")
+            .args(["git", "init", "--no-colocate"])
+            .arg(repo.path())
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        fs::write(repo.path().join("listed.txt"), "content\n").unwrap();
+
+        assert!(RealJjOps
+            .list_files(repo.path())
+            .iter()
+            .any(|path| path == "listed.txt"));
+    }
+
+    #[test]
+    fn conflict_probe_isolated_operation_does_not_move_checkout() {
+        let Some(repo) = init_repo() else { return };
+        fs::write(repo.path().join("shared.txt"), "base\n").unwrap();
+        jj(repo.path(), &["describe", "-m", "base"]);
+        let base = jj(
+            repo.path(),
+            &["log", "-r", "@", "--no-graph", "-T", "commit_id"],
+        );
+
+        jj(repo.path(), &["new", &base]);
+        fs::write(repo.path().join("shared.txt"), "left\n").unwrap();
+        jj(repo.path(), &["describe", "-m", "left"]);
+        let left = jj(
+            repo.path(),
+            &["log", "-r", "@", "--no-graph", "-T", "commit_id"],
+        );
+
+        jj(repo.path(), &["new", &base]);
+        fs::write(repo.path().join("shared.txt"), "right\n").unwrap();
+        jj(repo.path(), &["describe", "-m", "right"]);
+        let right = jj(
+            repo.path(),
+            &["log", "-r", "@", "--no-graph", "-T", "commit_id"],
+        );
+        let before = jj(
+            repo.path(),
+            &["log", "-r", "@", "--no-graph", "-T", "change_id"],
+        );
+
+        let (conflicted, files) = conflict_probe(repo.path(), &left, &right).expect("probe merge");
+
+        assert!(conflicted);
+        assert!(
+            files.iter().any(|path| path == "shared.txt"),
+            "unexpected conflict listing: {files:?}"
+        );
+        assert_eq!(
+            jj(
+                repo.path(),
+                &["log", "-r", "@", "--no-graph", "-T", "change_id"]
+            ),
+            before
+        );
+    }
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,9 +1,12 @@
+mod jj_operations;
 mod operations;
 mod provider;
+mod vcs;
 mod worktree;
 
 pub use operations::*;
 pub use provider::{GitProviderOperations, PullRequestState, RealGitHubOps};
+pub use vcs::VcsKind;
 pub use worktree::*;
 
 #[cfg(feature = "test-mocks")]
@@ -23,6 +26,39 @@ pub fn is_git_repo(path: &Path) -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+/// Check whether `path` is the root of a Jujutsu workspace. This validates an
+/// explicit `vcs = "jj"` selection; it is never used to choose a backend.
+///
+/// Comparing the reported root matters because `jj workspace root` walks up
+/// through ordinary subdirectories. A half-created task directory inside the
+/// project must not be mistaken for a registered workspace.
+pub fn is_jj_repo(path: &Path) -> bool {
+    let Ok(requested) = path.canonicalize() else {
+        return false;
+    };
+    let Ok(output) = Command::new("jj")
+        .current_dir(path)
+        .args(["workspace", "root"])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    Path::new(String::from_utf8_lossy(&output.stdout).trim())
+        .canonicalize()
+        .map(|root| root == requested)
+        .unwrap_or(false)
+}
+
+pub fn is_repo_for(path: &Path, kind: VcsKind) -> bool {
+    match kind {
+        VcsKind::Git => is_git_repo(path),
+        VcsKind::Jj => is_jj_repo(path),
+    }
 }
 
 /// Get the root directory of the git repository
@@ -160,3 +196,6 @@ pub fn delete_branch(path: &Path, branch: &str, force: bool) -> Result<()> {
 
     Ok(())
 }
+pub use jj_operations::{
+    conflict_probe as jj_conflict_probe, resolve_revision as resolve_jj_revision, RealJjOps,
+};

--- a/src/git/provider.rs
+++ b/src/git/provider.rs
@@ -40,12 +40,68 @@ pub trait GitProviderOperations: Send + Sync {
 /// GitHub implementation using the `gh` CLI
 pub struct RealGitHubOps;
 
+fn normalize_repo_selector(remote: &str) -> Option<String> {
+    let remote = remote.trim().trim_end_matches('/').trim_end_matches(".git");
+    let selector = if let Some(rest) = remote.strip_prefix("git@") {
+        rest.replacen(':', "/", 1)
+    } else if let Some(rest) = remote.strip_prefix("ssh://git@") {
+        rest.replacen(':', "/", 1)
+    } else if let Some(rest) = remote
+        .strip_prefix("https://")
+        .or_else(|| remote.strip_prefix("http://"))
+    {
+        rest.to_string()
+    } else {
+        remote.to_string()
+    };
+    (selector.split('/').count() >= 3).then_some(selector)
+}
+
+fn repo_selector(project_path: &Path) -> Option<String> {
+    if let Some(remote) = crate::config::ProjectConfig::load(project_path)
+        .ok()
+        .and_then(|config| config.github_url)
+    {
+        if let Some(selector) = normalize_repo_selector(&remote) {
+            return Some(selector);
+        }
+    }
+    if super::is_git_repo(project_path) {
+        return None;
+    }
+    let output = std::process::Command::new("jj")
+        .current_dir(project_path)
+        .args(["git", "remote", "list"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|line| {
+            let mut fields = line.split_whitespace();
+            (fields.next() == Some("origin"))
+                .then(|| fields.next())
+                .flatten()
+                .and_then(normalize_repo_selector)
+        })
+}
+
 impl GitProviderOperations for RealGitHubOps {
     fn get_pr_state(&self, project_path: &Path, pr_number: i32) -> Result<PullRequestState> {
-        let output = std::process::Command::new("gh")
-            .current_dir(project_path)
-            .args(["pr", "view", &pr_number.to_string(), "--json", "state"])
-            .output()?;
+        let mut command = std::process::Command::new("gh");
+        command.current_dir(project_path).args([
+            "pr",
+            "view",
+            &pr_number.to_string(),
+            "--json",
+            "state",
+        ]);
+        if let Some(repo) = repo_selector(project_path) {
+            command.args(["--repo", &repo]);
+        }
+        let output = command.output()?;
 
         if !output.status.success() {
             return Ok(PullRequestState::Unknown);
@@ -85,6 +141,11 @@ impl GitProviderOperations for RealGitHubOps {
             args.push("--base");
             args.push(base);
         }
+        let repo = repo_selector(project_path);
+        if let Some(ref repo) = repo {
+            args.push("--repo");
+            args.push(repo);
+        }
         let output = std::process::Command::new("gh")
             .current_dir(project_path)
             .args(&args)
@@ -105,5 +166,22 @@ impl GitProviderOperations for RealGitHubOps {
             .unwrap_or(0);
 
         Ok((pr_number, pr_url))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_repo_selector;
+
+    #[test]
+    fn normalizes_https_and_ssh_github_remotes() {
+        assert_eq!(
+            normalize_repo_selector("https://github.com/acme/widgets.git").as_deref(),
+            Some("github.com/acme/widgets")
+        );
+        assert_eq!(
+            normalize_repo_selector("git@github.example.com:acme/widgets.git").as_deref(),
+            Some("github.example.com/acme/widgets")
+        );
     }
 }

--- a/src/git/vcs.rs
+++ b/src/git/vcs.rs
@@ -1,0 +1,42 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Version-control backend selected explicitly by project configuration.
+///
+/// There is deliberately no `Auto` variant. An omitted project setting means
+/// Git; repositories that want Jujutsu opt in with `vcs = "jj"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum VcsKind {
+    #[default]
+    Git,
+    Jj,
+}
+
+impl VcsKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Git => "git",
+            Self::Jj => "jj",
+        }
+    }
+}
+
+impl fmt::Display for VcsKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for VcsKind {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "git" => Ok(Self::Git),
+            "jj" => Ok(Self::Jj),
+            other => Err(format!("unsupported VCS '{other}'; expected 'git' or 'jj'")),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod skills;
 pub mod tmux;
 pub mod tui;
 pub mod update;
+pub mod vcs_cli;
 
 /// The HTTP + WebSocket server behind `agtx serve`.
 #[cfg(feature = "serve")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ async fn main() -> Result<()> {
         // match filters out every `--`-prefixed argument, so `--version` would
         // otherwise fall through and open the current directory as a project.
         match raw.get(1).map(String::as_str) {
+            Some("vcs") => return agtx::vcs_cli::run(&raw[2..]),
             Some("--version" | "-V" | "version") => {
                 println!("agtx {}", env!("CARGO_PKG_VERSION"));
                 return Ok(());
@@ -69,8 +70,9 @@ async fn main() -> Result<()> {
             let project_path = match project_path {
                 Some(p) => {
                     let p = p.canonicalize()?;
-                    if !git::is_git_repo(&p) {
-                        anyhow::bail!("mcp-serve requires a git project directory");
+                    let vcs = config::ProjectConfig::load(&p)?.vcs.unwrap_or_default();
+                    if !git::is_repo_for(&p, vcs) {
+                        anyhow::bail!("mcp-serve requires a configured {} project directory", vcs);
                     }
                     Some(p)
                 }
@@ -92,7 +94,10 @@ async fn main() -> Result<()> {
         None => {
             // Default: if in git repo, use project mode; otherwise dashboard
             let current_dir = std::env::current_dir()?;
-            if git::is_git_repo(&current_dir) {
+            let vcs = config::ProjectConfig::load(&current_dir)?
+                .vcs
+                .unwrap_or_default();
+            if git::is_repo_for(&current_dir, vcs) {
                 AppMode::Project(current_dir)
             } else {
                 AppMode::Dashboard

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -466,19 +466,16 @@ impl AgtxMcpServer {
     }
 
     /// Get the default agent and plugin from merged config.
-    fn config_defaults_for(&self, project_id: Option<&str>) -> (String, Option<String>) {
+    fn config_defaults_for(
+        &self,
+        project_id: Option<&str>,
+    ) -> Result<(String, Option<String>, crate::git::VcsKind), String> {
         let global = GlobalConfig::load().unwrap_or_default();
-        match self.resolve_project_path(project_id) {
-            Ok(path) => {
-                let project = ProjectConfig::load(&path).unwrap_or_default();
-                let agent = project
-                    .default_agent
-                    .unwrap_or_else(|| global.default_agent.clone());
-                let plugin = project.workflow_plugin.clone();
-                (agent, plugin)
-            }
-            Err(_) => (global.default_agent.clone(), None),
-        }
+        let path = self.resolve_project_path(project_id)?;
+        let project = ProjectConfig::load(&path)
+            .map_err(|error| format!("Failed to load project config: {error}"))?;
+        let merged = crate::config::MergedConfig::merge(&global, &project);
+        Ok((merged.default_agent, merged.workflow_plugin, merged.vcs))
     }
 
     /// Which `move_task` actions a task permits, as the orchestrator.
@@ -743,7 +740,7 @@ impl AgtxMcpServer {
     }
 
     #[tool(
-        description = "Check if task branches have merge conflicts with the main branch. Pass a task_id to check one task, or omit it to check all Review tasks. Uses a read-only git check — no files are modified."
+        description = "Check whether task changes conflict with their configured base. Pass a task_id to check one task, or omit it to check all Review tasks. The check does not move or modify a working copy."
     )]
     fn check_conflicts(&self, Parameters(params): Parameters<CheckConflictsParams>) -> String {
         tracing::info!(tool = "check_conflicts", task_id = ?params.task_id, "MCP tool called");
@@ -751,10 +748,21 @@ impl AgtxMcpServer {
             Ok(p) => p,
             Err(e) => return e,
         };
-        let main_branch = match crate::git::detect_main_branch(&project_path) {
-            Ok(b) => b,
-            Err(e) => return format!("Failed to detect main branch: {}", e),
+        let project_config = match crate::config::ProjectConfig::load(&project_path) {
+            Ok(config) => config,
+            Err(error) => return format!("Failed to load project config: {error}"),
         };
+        let configured_base = project_config
+            .base_branch
+            .filter(|base| !base.trim().is_empty());
+        let main_branch = configured_base.clone().unwrap_or_else(|| {
+            if project_config.vcs.unwrap_or_default() == crate::git::VcsKind::Jj {
+                "trunk()".to_string()
+            } else {
+                crate::git::detect_main_branch(&project_path)
+                    .unwrap_or_else(|_| "(per-task default)".to_string())
+            }
+        });
 
         let tasks = match self.open_project_db_for(params.project_id.as_deref()) {
             Ok(db) => {
@@ -777,25 +785,51 @@ impl AgtxMcpServer {
         let results: Vec<ConflictCheckResult> = tasks
             .into_iter()
             .map(|t| {
-                let branch = match &t.branch_name {
-                    Some(b) => b.clone(),
-                    None => {
-                        return ConflictCheckResult {
-                            task_id: t.id,
-                            title: t.title,
-                            branch_name: None,
-                            has_conflicts: false,
-                            conflicting_files: vec![],
-                            error: Some("No branch name set for this task".to_string()),
-                        };
-                    }
+                let branch = t.branch_name.clone();
+                let vcs = t.vcs.unwrap_or_default();
+                let base = t
+                    .base_branch
+                    .clone()
+                    .filter(|base| !base.trim().is_empty())
+                    .or_else(|| configured_base.clone())
+                    .or_else(|| match vcs {
+                        crate::git::VcsKind::Git => {
+                            crate::git::detect_main_branch(&project_path).ok()
+                        }
+                        crate::git::VcsKind::Jj => Some("trunk()".to_string()),
+                    });
+                let Some(base) = base else {
+                    return ConflictCheckResult {
+                        task_id: t.id,
+                        title: t.title,
+                        branch_name: branch,
+                        has_conflicts: false,
+                        conflicting_files: vec![],
+                        error: Some("Could not resolve a base revision".to_string()),
+                    };
+                };
+                let check = match vcs {
+                    crate::git::VcsKind::Git => match branch.as_deref() {
+                        Some(branch) => {
+                            crate::git::check_merge_conflicts(&project_path, &base, branch)
+                        }
+                        None => Err(anyhow::anyhow!("No branch name set for this task")),
+                    },
+                    crate::git::VcsKind::Jj => match t.worktree_path.as_deref() {
+                        Some(worktree) => crate::git::jj_conflict_probe(
+                            std::path::Path::new(worktree),
+                            "@",
+                            &base,
+                        ),
+                        None => Err(anyhow::anyhow!("No workspace set for this task")),
+                    },
                 };
 
-                match crate::git::check_merge_conflicts(&project_path, &main_branch, &branch) {
+                match check {
                     Ok((has_conflicts, files)) => ConflictCheckResult {
                         task_id: t.id,
                         title: t.title,
-                        branch_name: Some(branch),
+                        branch_name: branch,
                         has_conflicts,
                         conflicting_files: files,
                         error: None,
@@ -803,7 +837,7 @@ impl AgtxMcpServer {
                     Err(e) => ConflictCheckResult {
                         task_id: t.id,
                         title: t.title,
-                        branch_name: Some(branch),
+                        branch_name: branch,
                         has_conflicts: false,
                         conflicting_files: vec![],
                         error: Some(format!("{}", e)),
@@ -989,8 +1023,11 @@ impl AgtxMcpServer {
             Err(e) => return e,
         };
 
-        let (default_agent, default_plugin) =
-            self.config_defaults_for(params.project_id.as_deref());
+        let (default_agent, default_plugin, vcs) =
+            match self.config_defaults_for(params.project_id.as_deref()) {
+                Ok(defaults) => defaults,
+                Err(error) => return error,
+            };
         let project_name = self.project_name_for(params.project_id.as_deref());
 
         // Validate referenced task IDs exist
@@ -1009,6 +1046,7 @@ impl AgtxMcpServer {
         task.plugin = params.plugin.or(default_plugin);
         task.referenced_tasks = params.referenced_tasks;
         task.base_branch = params.base_branch;
+        task.vcs = Some(vcs);
 
         match db.create_task(&task) {
             Ok(()) => {
@@ -1066,8 +1104,11 @@ impl AgtxMcpServer {
             Err(e) => return e,
         };
 
-        let (default_agent, default_plugin) =
-            self.config_defaults_for(params.project_id.as_deref());
+        let (default_agent, default_plugin, vcs) =
+            match self.config_defaults_for(params.project_id.as_deref()) {
+                Ok(defaults) => defaults,
+                Err(error) => return error,
+            };
         let project_name = self.project_name_for(params.project_id.as_deref());
 
         // Pass 2: Create all tasks, collect IDs
@@ -1077,6 +1118,7 @@ impl AgtxMcpServer {
             task.description = batch_task.description.clone();
             task.plugin = batch_task.plugin.clone().or_else(|| default_plugin.clone());
             task.base_branch = batch_task.base_branch.clone();
+            task.vcs = Some(vcs);
             created_tasks.push(task);
         }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -546,4 +546,25 @@ mod tests {
         assert!(found[0].plugin.supports_agent("claude"));
         assert!(!found[0].plugin.supports_agent("codex"));
     }
+
+    #[test]
+    fn vcs_aware_prompts_do_not_embed_backend_commands() {
+        let terse_review = include_str!("../plugins/agtx-terse/skills/agtx-review/SKILL.md");
+        for (name, content) in [
+            ("review", REVIEW_SKILL),
+            ("merge-conflicts", MERGE_CONFLICTS_SKILL),
+            ("terse review", terse_review),
+        ] {
+            assert!(!content.contains("`git "), "{name} embeds a git command");
+            assert!(!content.contains("`jj "), "{name} embeds a jj command");
+            assert!(
+                content.contains("{{AGTX_BIN}} vcs"),
+                "{name} does not use the VCS-neutral wrapper"
+            );
+            assert!(
+                !content.contains("`agtx "),
+                "{name} assumes agtx is on PATH"
+            );
+        }
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -502,6 +502,9 @@ struct SetupResult {
     new_status: Option<TaskStatus>,
     agent: String,
     plugin: Option<String>,
+    vcs: Option<git::VcsKind>,
+    workspace_name: Option<String>,
+    base_branch: Option<String>,
     error: Option<String>,
 }
 
@@ -511,6 +514,8 @@ struct ReferencedTaskInfo {
     slug: String,
     branch_name: Option<String>,
     worktree_path: Option<String>,
+    vcs: git::VcsKind,
+    base_branch: String,
 }
 
 /// The card / notification text for a task parked on a security prompt.
@@ -804,7 +809,16 @@ impl App {
                         .unwrap_or("unknown")
                         .to_string();
                     let tmux_name = tmux::safe_session_name(&name);
-                    let mut project_config = ProjectConfig::load(&canonical).unwrap_or_default();
+                    let mut project_config = ProjectConfig::load(&canonical)?;
+                    let vcs = project_config.vcs.unwrap_or_default();
+                    if !git::is_repo_for(&canonical, vcs) {
+                        anyhow::bail!(
+                            "project config selects {}, but '{}' is not a {} repository",
+                            vcs,
+                            canonical.display(),
+                            vcs
+                        );
+                    }
                     let db = Database::open_project(&canonical)?;
 
                     // Trust-on-first-use: suppress dangerous config fields from untrusted projects
@@ -1409,6 +1423,9 @@ impl App {
                             task.branch_name = Some(result.branch_name);
                             task.agent = result.agent;
                             task.plugin = result.plugin;
+                            task.vcs = result.vcs;
+                            task.workspace_name = result.workspace_name;
+                            task.base_branch = result.base_branch;
                             if let Some(status) = result.new_status {
                                 task.status = status;
                             }
@@ -4007,6 +4024,8 @@ impl App {
                 let worktree_path = task.worktree_path.clone();
                 let branch_name = task.branch_name.clone();
                 let agent = task.agent.clone();
+                let vcs = task.vcs.unwrap_or_default();
+                let workspace_name = task.workspace_name.clone();
 
                 // Update task status immediately
                 task.session_name = None;
@@ -4034,9 +4053,11 @@ impl App {
                     self.state.config.cleanup_script.clone()
                 };
                 std::thread::spawn(move || {
-                    cleanup_task_resources(
+                    cleanup_task_resources_for_vcs(
                         &task_id,
                         &agent,
+                        vcs,
+                        workspace_name.as_deref(),
                         &branch_name,
                         &session_name,
                         &worktree_path,
@@ -4056,6 +4077,8 @@ impl App {
             if let Some(task) = db.get_task(task_id)? {
                 let task_title = task.title.clone();
                 let worktree_path = task.worktree_path.clone();
+                let base_revision = task.base_branch.clone();
+                let vcs = task.vcs.unwrap_or_default();
 
                 // Show popup immediately with loading state
                 self.state.pr_confirm_popup = Some(PrConfirmPopup {
@@ -4078,10 +4101,11 @@ impl App {
                     .agent_registry
                     .get(&self.state.config.default_agent);
                 std::thread::spawn(move || {
-                    let (pr_title, pr_body) = generate_pr_description(
+                    let (pr_title, pr_body) = generate_pr_description_for_vcs(
                         &title_for_thread,
                         worktree_for_thread.as_deref(),
-                        None,
+                        base_revision.as_deref(),
+                        vcs,
                         git_ops.as_ref(),
                         agent_ops.as_ref(),
                     );
@@ -4578,7 +4602,8 @@ impl App {
                 }
                 KeyCode::Char('n') => {
                     let current_dir = std::env::current_dir()?;
-                    if crate::git::is_git_repo(&current_dir) {
+                    let vcs = ProjectConfig::load(&current_dir)?.vcs.unwrap_or_default();
+                    if crate::git::is_repo_for(&current_dir, vcs) {
                         let canonical = current_dir.canonicalize().unwrap_or(current_dir);
                         let name = canonical
                             .file_name()
@@ -5359,8 +5384,13 @@ impl App {
             (&mut self.state.file_search, &self.state.project_path)
         {
             let pattern = &search.pattern;
-            search.matches =
-                fuzzy_find_files(project_path, pattern, 10, self.state.git_ops.as_ref());
+            search.matches = fuzzy_find_files(
+                project_path,
+                pattern,
+                10,
+                self.state.config.vcs,
+                self.state.git_ops.as_ref(),
+            );
             search.selected = 0;
         }
     }
@@ -5445,6 +5475,7 @@ impl App {
                 task.description = description;
                 task.plugin = plugin;
                 task.referenced_tasks = refs;
+                task.vcs = Some(self.state.config.vcs);
                 // Task starts in Backlog without tmux window.
                 // No orchestrator notification — it only manages Planning/Running.
                 db.create_task(&task)?;
@@ -5737,8 +5768,9 @@ impl App {
                     plugin.map_or_else(Vec::new, |p| p.copy_dirs.clone());
                 let plugin_dir_refs: Vec<&str> = plugin_dirs.iter().map(|s| s.as_str()).collect();
                 exclude_prefixes.extend(plugin_dir_refs);
-                collect_task_diff(
+                collect_task_diff_for_vcs(
                     worktree_path,
+                    task.vcs.unwrap_or_default(),
                     self.state.git_ops.as_ref(),
                     &exclude_prefixes,
                 )
@@ -5993,6 +6025,7 @@ impl App {
             .base_branch
             .clone()
             .unwrap_or_else(|| self.state.config.base_branch.clone());
+        let vcs = task.vcs.unwrap_or_default();
         let worktree_dir = self.state.config.worktree_dir.clone();
         let branch_prefix = self.state.config.branch_prefix.clone();
         let copy_files = self.state.config.copy_files.clone();
@@ -6029,10 +6062,33 @@ impl App {
                             .db
                             .as_ref()
                             .and_then(|db| db.get_task(ref_id).ok().flatten())
-                            .map(|ref_task| ReferencedTaskInfo {
-                                slug: generate_task_slug(&ref_task.id, &ref_task.title),
-                                branch_name: ref_task.branch_name.clone(),
-                                worktree_path: ref_task.worktree_path.clone(),
+                            .map(|ref_task| {
+                                let vcs = ref_task.vcs.unwrap_or_default();
+                                let configured_base = self.state.config.base_branch.trim();
+                                let base_branch = ref_task
+                                    .base_branch
+                                    .as_deref()
+                                    .map(str::trim)
+                                    .filter(|base| !base.is_empty())
+                                    .map(str::to_string)
+                                    .unwrap_or_else(|| match vcs {
+                                        git::VcsKind::Git if configured_base.is_empty() => {
+                                            git::detect_main_branch(&project_path)
+                                                .unwrap_or_else(|_| "main".to_string())
+                                        }
+                                        git::VcsKind::Git => configured_base.to_string(),
+                                        git::VcsKind::Jj if configured_base.is_empty() => {
+                                            "trunk()".to_string()
+                                        }
+                                        git::VcsKind::Jj => configured_base.to_string(),
+                                    });
+                                ReferencedTaskInfo {
+                                    slug: generate_task_slug(&ref_task.id, &ref_task.title),
+                                    branch_name: ref_task.branch_name.clone(),
+                                    worktree_path: ref_task.worktree_path.clone(),
+                                    vcs,
+                                    base_branch,
+                                }
                             })
                     })
                     .collect()
@@ -6048,11 +6104,12 @@ impl App {
             tmp_task.id = task_id.clone();
             tmp_task.plugin = plugin_name.clone();
 
-            let result = setup_task_worktree(
+            let result = setup_task_worktree_for_vcs(
                 &mut tmp_task,
                 &project_path,
                 &tmux_project_name,
                 &prompt,
+                vcs,
                 &base_branch,
                 &worktree_dir,
                 &branch_prefix,
@@ -6081,6 +6138,9 @@ impl App {
                         new_status: Some(TaskStatus::Planning),
                         agent: planning_agent_clone.clone(),
                         plugin: plugin_name,
+                        vcs: tmp_task.vcs,
+                        workspace_name: tmp_task.workspace_name,
+                        base_branch: tmp_task.base_branch,
                         error: None,
                     });
                     // Skip the whole send-after-ready dance when the agent was
@@ -6115,6 +6175,9 @@ impl App {
                         new_status: None,
                         agent: planning_agent_clone,
                         plugin: plugin_name,
+                        vcs: None,
+                        workspace_name: None,
+                        base_branch: None,
                         error: Some(format!("Planning setup failed: {}", e)),
                     });
                 }
@@ -6311,10 +6374,15 @@ impl App {
         }
 
         // No PR — check for uncommitted changes
+        let jj_ops = git::RealJjOps;
+        let task_ops: &dyn GitOperations = match task.vcs.unwrap_or_default() {
+            git::VcsKind::Git => self.state.git_ops.as_ref(),
+            git::VcsKind::Jj => &jj_ops,
+        };
         let has_uncommitted = task
             .worktree_path
             .as_ref()
-            .map_or(false, |wt| self.state.git_ops.has_changes(Path::new(wt)));
+            .map_or(false, |wt| task_ops.has_changes(Path::new(wt)));
         if has_uncommitted {
             self.state.done_confirm_popup = Some(DoneConfirmPopup {
                 task_id: task.id.clone(),
@@ -6329,6 +6397,8 @@ impl App {
         let worktree_path = task.worktree_path.clone();
         let branch_name = task.branch_name.clone();
         let agent = task.agent.clone();
+        let vcs = task.vcs.unwrap_or_default();
+        let workspace_name = task.workspace_name.clone();
         task.session_name = None;
         task.worktree_path = None;
 
@@ -6342,9 +6412,11 @@ impl App {
             self.state.config.cleanup_script.clone()
         };
         std::thread::spawn(move || {
-            cleanup_task_resources(
+            cleanup_task_resources_for_vcs(
                 &task_id_clone,
                 &agent,
+                vcs,
+                workspace_name.as_deref(),
                 &branch_name,
                 &session_name,
                 &worktree_path,
@@ -6415,6 +6487,7 @@ impl App {
             .base_branch
             .clone()
             .unwrap_or_else(|| self.state.config.base_branch.clone());
+        let vcs = task.vcs.unwrap_or_default();
         let worktree_dir = self.state.config.worktree_dir.clone();
         let branch_prefix = self.state.config.branch_prefix.clone();
         let copy_files = self.state.config.copy_files.clone();
@@ -6450,11 +6523,12 @@ impl App {
 
             // setup_task_worktree creates the worktree and copies files (including preresearch artifacts if they exist at root)
             // We pass an empty prompt here — the actual prompt is resolved after worktree creation
-            let result = setup_task_worktree(
+            let result = setup_task_worktree_for_vcs(
                 &mut tmp_task,
                 &project_path,
                 &tmux_project_name,
                 "",
+                vcs,
                 &base_branch,
                 &worktree_dir,
                 &branch_prefix,
@@ -6522,6 +6596,9 @@ impl App {
                         new_status: None, // stays in Backlog
                         agent: agent_name.clone(),
                         plugin: plugin_name,
+                        vcs: tmp_task.vcs,
+                        workspace_name: tmp_task.workspace_name,
+                        base_branch: tmp_task.base_branch,
                         error: None,
                     });
 
@@ -6555,6 +6632,9 @@ impl App {
                         new_status: None,
                         agent: agent_name,
                         plugin: plugin_name,
+                        vcs: None,
+                        workspace_name: None,
+                        base_branch: None,
                         error: Some(format!("Research setup failed: {}", e)),
                     });
                 }
@@ -7171,6 +7251,7 @@ impl App {
             .base_branch
             .clone()
             .unwrap_or_else(|| self.state.config.base_branch.clone());
+        let vcs = task.vcs.unwrap_or_default();
         let worktree_dir = self.state.config.worktree_dir.clone();
         let branch_prefix = self.state.config.branch_prefix.clone();
         let copy_files = self.state.config.copy_files.clone();
@@ -7198,11 +7279,12 @@ impl App {
             tmp_task.id = task_id.clone();
             tmp_task.plugin = plugin_name.clone();
 
-            let result = setup_task_worktree(
+            let result = setup_task_worktree_for_vcs(
                 &mut tmp_task,
                 &project_path,
                 &tmux_project_name,
                 &prompt,
+                vcs,
                 &base_branch,
                 &worktree_dir,
                 &branch_prefix,
@@ -7231,6 +7313,9 @@ impl App {
                         new_status: Some(TaskStatus::Running),
                         agent: running_agent_clone.clone(),
                         plugin: plugin_name,
+                        vcs: tmp_task.vcs,
+                        workspace_name: tmp_task.workspace_name,
+                        base_branch: tmp_task.base_branch,
                         error: None,
                     });
 
@@ -7266,6 +7351,9 @@ impl App {
                         new_status: None,
                         agent: running_agent_clone,
                         plugin: plugin_name,
+                        vcs: None,
+                        workspace_name: None,
+                        base_branch: None,
                         error: Some(format!("Running setup failed: {}", e)),
                     });
                 }
@@ -7278,7 +7366,7 @@ impl App {
     /// Move task from Review back to Running (only allowed transition backwards)
     /// The tmux window should still be open from when it was in Running state
     fn move_review_to_running(&mut self, task_id: &str) -> Result<()> {
-        if let (Some(db), Some(_project_path)) = (&self.state.db, &self.state.project_path) {
+        if let (Some(db), Some(project_path)) = (&self.state.db, &self.state.project_path) {
             if let Some(mut task) = db.get_task(task_id)? {
                 if task.status != TaskStatus::Review {
                     return Ok(());
@@ -7296,6 +7384,7 @@ impl App {
                         let running_agent_clone = running_agent.clone();
                         let current_agent_clone = task.agent.clone();
                         let wt_path = task.worktree_path.clone();
+                        let project_path = project_path.clone();
                         std::thread::spawn(move || {
                             let agent_ops = agent_registry.get(&running_agent_clone);
                             ensure_window_or_recover(
@@ -7304,6 +7393,7 @@ impl App {
                                 agent_ops.as_ref(),
                                 wt_path.as_deref(),
                                 &hook_task_id,
+                                Some(&project_path),
                             );
                             let new_cmd = agent_ops.build_interactive_command("");
                             switch_agent_in_tmux(
@@ -7327,7 +7417,7 @@ impl App {
     }
 
     fn move_review_to_planning(&mut self, task_id: &str) -> Result<()> {
-        if let (Some(db), Some(_project_path)) = (&self.state.db, &self.state.project_path) {
+        if let (Some(db), Some(project_path)) = (&self.state.db, &self.state.project_path) {
             if let Some(mut task) = db.get_task(task_id)? {
                 if task.status != TaskStatus::Review {
                     return Ok(());
@@ -7386,6 +7476,7 @@ impl App {
                         .map_or_else(Vec::new, |p| p.auto_dismiss.clone());
                     let wt_path = task.worktree_path.clone();
                     let auto_trust = self.state.config.auto_trust;
+                    let project_path = project_path.clone();
                     std::thread::spawn(move || {
                         let agent_ops = agent_registry.get(&planning_agent_clone);
                         // Recover window if it was lost
@@ -7395,6 +7486,7 @@ impl App {
                             agent_ops.as_ref(),
                             wt_path.as_deref(),
                             &hook_task_id,
+                            Some(&project_path),
                         );
                         // An agent switch starts a *new process*, so it takes the
                         // opening message in argv exactly like a first launch —
@@ -7457,7 +7549,7 @@ impl App {
     }
 
     fn move_running_to_planning(&mut self, task_id: &str) -> Result<()> {
-        if let (Some(db), Some(_project_path)) = (&self.state.db, &self.state.project_path) {
+        if let (Some(db), Some(project_path)) = (&self.state.db, &self.state.project_path) {
             if let Some(mut task) = db.get_task(task_id)? {
                 if task.status != TaskStatus::Running {
                     return Ok(());
@@ -7475,6 +7567,7 @@ impl App {
                         let planning_agent_clone = planning_agent.clone();
                         let current_agent_clone = task.agent.clone();
                         let wt_path = task.worktree_path.clone();
+                        let project_path = project_path.clone();
                         std::thread::spawn(move || {
                             let agent_ops = agent_registry.get(&planning_agent_clone);
                             ensure_window_or_recover(
@@ -7483,6 +7576,7 @@ impl App {
                                 agent_ops.as_ref(),
                                 wt_path.as_deref(),
                                 &hook_task_id,
+                                Some(&project_path),
                             );
                             let new_cmd = agent_ops.build_interactive_command("");
                             switch_agent_in_tmux(
@@ -8709,9 +8803,55 @@ impl App {
                             let wt = wt.clone();
                             let sn = sn.clone();
                             let agent_name = task_status.agent.clone();
+                            let configured_base = self.state.config.base_branch.clone();
+                            let (vcs, base) = self
+                                .state
+                                .board
+                                .tasks
+                                .iter()
+                                .find(|task| task.id == task_status.task_id)
+                                .map(|task| {
+                                    let vcs = task.vcs.unwrap_or_default();
+                                    let fallback = if configured_base.trim().is_empty()
+                                        && vcs == git::VcsKind::Jj
+                                    {
+                                        "trunk()".to_string()
+                                    } else {
+                                        configured_base.clone()
+                                    };
+                                    let base = task
+                                        .base_branch
+                                        .clone()
+                                        .filter(|base| !base.trim().is_empty())
+                                        .unwrap_or(fallback);
+                                    (vcs, base)
+                                })
+                                .unwrap_or((git::VcsKind::Git, String::new()));
 
                             std::thread::spawn(move || {
-                                match git_ops.fetch_and_check_conflicts(Path::new(&wt)) {
+                                let check = match vcs {
+                                    git::VcsKind::Git => {
+                                        git_ops.fetch_and_check_conflicts(Path::new(&wt))
+                                    }
+                                    git::VcsKind::Jj => {
+                                        let fetch = std::process::Command::new("jj")
+                                            .current_dir(&wt)
+                                            .args(["git", "fetch", "--remote", "origin"])
+                                            .output();
+                                        match fetch {
+                                            Ok(output) if output.status.success() => {
+                                                git::jj_conflict_probe(Path::new(&wt), "@", &base)
+                                                    .map(|result| result.0)
+                                            }
+                                            Ok(output) => Err(anyhow::anyhow!(
+                                                "jj git fetch failed: {}",
+                                                String::from_utf8_lossy(&output.stderr).trim()
+                                            )),
+                                            Err(error) => Err(error.into()),
+                                        }
+                                    }
+                                };
+                                match check {
                                     Ok(true) => {
                                         let skill_cmd = skills::transform_plugin_command(
                                             "/agtx:merge-conflicts",
@@ -8859,6 +8999,27 @@ impl App {
             // Skip non-existent projects silently
             return Ok(());
         }
+        let project_config = match ProjectConfig::load(&project_path) {
+            Ok(config) => config,
+            Err(error) => {
+                self.state.warning_message = Some((
+                    format!("Could not load project config: {error}"),
+                    Instant::now(),
+                ));
+                return Ok(());
+            }
+        };
+        let selected_vcs = project_config.vcs.unwrap_or_default();
+        if !git::is_repo_for(&project_path, selected_vcs) {
+            self.state.warning_message = Some((
+                format!(
+                    "Project selects {}, but the configured path is not a {} repository",
+                    selected_vcs, selected_vcs
+                ),
+                Instant::now(),
+            ));
+            return Ok(());
+        }
 
         // Update current project
         self.state.project_name = project.name.clone();
@@ -8898,7 +9059,6 @@ impl App {
 
         // Reload config for the new project so per-phase agent overrides are respected
         let global_config = GlobalConfig::load().unwrap_or_default();
-        let project_config = ProjectConfig::load(&project_path).unwrap_or_default();
         self.state.config = MergedConfig::merge(&global_config, &project_config);
         self.state.cached_plugin = Some(load_plugin_if_configured(
             &self.state.config,
@@ -9046,7 +9206,7 @@ fn recover_task_session(
         worktree_path,
         Some(resume_cmd),
         true,
-        &agtx_task_env(&task.id, worktree_path),
+        &agtx_task_env(&task.id, worktree_path, project_path),
     )?;
 
     Ok(target.clone())
@@ -9139,9 +9299,11 @@ fn run_cleanup_script_for_worktree(cleanup_script: Option<&str>, worktree_path: 
 
 /// Background-safe cleanup: archive artifacts, kill tmux window, run cleanup script, remove worktree.
 /// Takes owned/cloned values so it can run in a spawned thread.
-fn cleanup_task_resources(
+fn cleanup_task_resources_for_vcs(
     task_id: &str,
     agent: &str,
+    vcs: git::VcsKind,
+    workspace_name: Option<&str>,
     branch_name: &Option<String>,
     session_name: &Option<String>,
     worktree_path: &Option<String>,
@@ -9150,6 +9312,7 @@ fn cleanup_task_resources(
     tmux_ops: &dyn TmuxOperations,
     git_ops: &dyn GitOperations,
 ) {
+    let jj_ops = git::RealJjOps;
     // Drop this worktree from the agent's trust store, before it is removed —
     // `forget` resolves the path, which needs the directory to still exist.
     //
@@ -9189,10 +9352,44 @@ fn cleanup_task_resources(
     }
     if let Some(worktree) = worktree_path {
         run_cleanup_script_for_worktree(cleanup_script, Path::new(worktree));
-        if let Err(e) = git_ops.remove_worktree(project_path, worktree) {
+        let result = match vcs {
+            git::VcsKind::Git => git_ops.remove_worktree(project_path, worktree),
+            git::VcsKind::Jj => {
+                jj_ops.remove_workspace(project_path, Path::new(worktree), workspace_name)
+            }
+        };
+        if let Err(e) = result {
             tracing::warn!(worktree = %worktree, error = %e, "Failed to remove worktree");
         }
     }
+}
+
+#[cfg(feature = "test-mocks")]
+#[allow(dead_code)]
+fn cleanup_task_resources(
+    task_id: &str,
+    agent: &str,
+    branch_name: &Option<String>,
+    session_name: &Option<String>,
+    worktree_path: &Option<String>,
+    cleanup_script: Option<&str>,
+    project_path: &Path,
+    tmux_ops: &dyn TmuxOperations,
+    git_ops: &dyn GitOperations,
+) {
+    cleanup_task_resources_for_vcs(
+        task_id,
+        agent,
+        git::VcsKind::Git,
+        None,
+        branch_name,
+        session_name,
+        worktree_path,
+        cleanup_script,
+        project_path,
+        tmux_ops,
+        git_ops,
+    );
 }
 
 /// Set up a worktree and tmux window for a task.
@@ -9203,11 +9400,12 @@ fn cleanup_task_resources(
 /// `prompt` is used only for agents without native skill invocation (fallback).
 /// For agents with skill support, the agent starts with no prompt and the skill command
 /// is sent later via send_keys (see the acceptance thread in move_task_right).
-fn setup_task_worktree(
+fn setup_task_worktree_for_vcs(
     task: &mut Task,
     project_path: &Path,
     tmux_project_name: &str,
     prompt: &str,
+    vcs: git::VcsKind,
     base_branch: &str,
     worktree_dir: &str,
     branch_prefix: &str,
@@ -9231,14 +9429,27 @@ fn setup_task_worktree(
 
     // When skip_worktree is set, use the project root directly instead of creating a git worktree.
     // Useful for isolated environments (e.g. Docker) where the repo is already the working copy.
+    let jj_ops = git::RealJjOps;
+    let vcs_ops: &dyn GitOperations = match vcs {
+        git::VcsKind::Git => git_ops,
+        git::VcsKind::Jj => &jj_ops,
+    };
+    let effective_base = if base_branch.trim().is_empty() {
+        match vcs {
+            git::VcsKind::Git => git::detect_main_branch(project_path)?,
+            git::VcsKind::Jj => "trunk()".to_string(),
+        }
+    } else {
+        base_branch.trim().to_string()
+    };
     let worktree_path_str = if skip_worktree {
         project_path.to_string_lossy().to_string()
     } else {
         // Create git worktree from the configured base branch
-        match git_ops.create_worktree(
+        match vcs_ops.create_worktree(
             project_path,
             &unique_slug,
-            base_branch,
+            &effective_base,
             worktree_dir,
             branch_prefix,
         ) {
@@ -9278,7 +9489,7 @@ fn setup_task_worktree(
             Some(parts.join(","))
         }
     };
-    let init_warnings = git_ops.initialize_worktree(
+    let init_warnings = vcs_ops.initialize_worktree(
         project_path,
         worktree_path,
         merged_copy_files,
@@ -9303,18 +9514,42 @@ fn setup_task_worktree(
     if !referenced_tasks.is_empty() {
         let refs_dir = worktree_path.join(".agtx").join("references");
         for ref_info in referenced_tasks {
-            // 1. Git diff of referenced task's branch
-            if let Some(ref branch) = ref_info.branch_name {
-                if let Ok(output) = std::process::Command::new("git")
-                    .args(["diff", &format!("main..{}", branch)])
-                    .current_dir(project_path)
-                    .output()
-                {
-                    if output.status.success() && !output.stdout.is_empty() {
-                        let _ = std::fs::create_dir_all(&refs_dir);
-                        let diff_path = refs_dir.join(format!("{}.diff", ref_info.slug));
-                        let _ = std::fs::write(&diff_path, &output.stdout);
-                    }
+            // 1. VCS-neutral diff of the referenced task.
+            let diff = match ref_info.vcs {
+                git::VcsKind::Git => ref_info.branch_name.as_ref().and_then(|branch| {
+                    std::process::Command::new("git")
+                        .args(["diff", &format!("{}...{}", ref_info.base_branch, branch)])
+                        .current_dir(project_path)
+                        .output()
+                        .ok()
+                }),
+                git::VcsKind::Jj => {
+                    let target = ref_info
+                        .worktree_path
+                        .as_deref()
+                        .filter(|path| Path::new(path).exists())
+                        .map(|path| (Path::new(path), "@"))
+                        .or_else(|| {
+                            ref_info
+                                .branch_name
+                                .as_deref()
+                                .map(|branch| (project_path, branch))
+                    });
+                    target.and_then(|(repo, target)| {
+                        let fork = format!("fork_point(({}) | {target})", ref_info.base_branch);
+                        std::process::Command::new("jj")
+                            .args(["diff", "--git", "--from", &fork, "--to", target])
+                            .current_dir(repo)
+                            .output()
+                            .ok()
+                    })
+                }
+            };
+            if let Some(output) = diff {
+                if output.status.success() && !output.stdout.is_empty() {
+                    let _ = std::fs::create_dir_all(&refs_dir);
+                    let diff_path = refs_dir.join(format!("{}.diff", ref_info.slug));
+                    let _ = std::fs::write(&diff_path, &output.stdout);
                 }
             }
             // 2. Copy artifact files from referenced task's worktree (if it still exists)
@@ -9410,14 +9645,66 @@ fn setup_task_worktree(
         &worktree_path_str,
         Some(agent_cmd),
         true,
-        &agtx_task_env(&task.id, &worktree_path_str),
+        &agtx_task_env(&task.id, &worktree_path_str, project_path),
     )?;
 
     task.session_name = Some(target.clone());
     task.worktree_path = Some(worktree_path_str);
     task.branch_name = Some(format!("{}/{}", branch_prefix, unique_slug));
+    task.vcs = Some(vcs);
+    task.workspace_name = (vcs == git::VcsKind::Jj && !skip_worktree).then_some(unique_slug);
+    task.base_branch = Some(effective_base);
 
     Ok((target, launched_with_prompt))
+}
+
+#[cfg(feature = "test-mocks")]
+#[allow(clippy::too_many_arguments, dead_code)]
+fn setup_task_worktree(
+    task: &mut Task,
+    project_path: &Path,
+    tmux_project_name: &str,
+    prompt: &str,
+    base_branch: &str,
+    worktree_dir: &str,
+    branch_prefix: &str,
+    copy_files: Option<String>,
+    init_script: Option<String>,
+    plugin: &Option<WorkflowPlugin>,
+    agent_name: &str,
+    all_phase_agents: &[String],
+    tmux_ops: &dyn TmuxOperations,
+    git_ops: &dyn GitOperations,
+    agent_ops: &dyn AgentOperations,
+    referenced_tasks: &[ReferencedTaskInfo],
+    skip_init_scripts: bool,
+    skip_worktree: bool,
+    agent_hooks: bool,
+    skill_cmd: Option<&str>,
+) -> Result<(String, bool)> {
+    setup_task_worktree_for_vcs(
+        task,
+        project_path,
+        tmux_project_name,
+        prompt,
+        git::VcsKind::Git,
+        base_branch,
+        worktree_dir,
+        branch_prefix,
+        copy_files,
+        init_script,
+        plugin,
+        agent_name,
+        all_phase_agents,
+        tmux_ops,
+        git_ops,
+        agent_ops,
+        referenced_tasks,
+        skip_init_scripts,
+        skip_worktree,
+        agent_hooks,
+        skill_cmd,
+    )
 }
 
 /// Delete task resources: kill tmux window, run cleanup script, remove worktree, delete branch
@@ -9428,6 +9715,8 @@ fn delete_task_resources(
     tmux_ops: &dyn TmuxOperations,
     git_ops: &dyn GitOperations,
 ) {
+    let jj_ops = git::RealJjOps;
+    let vcs = task.vcs.unwrap_or_default();
     // Same prune as the Done path: a deleted task's worktree is just as gone.
     if let (Some(worktree), Some(home)) = (&task.worktree_path, agent_trust_home()) {
         let _ = agent::trust::forget(&task.agent, Path::new(worktree), &home);
@@ -9444,7 +9733,15 @@ fn delete_task_resources(
     // research session that never reached Planning.
     if let Some(ref worktree) = task.worktree_path {
         run_cleanup_script_for_worktree(cleanup_script, Path::new(worktree));
-        if let Err(e) = git_ops.remove_worktree(project_path, worktree) {
+        let result = match vcs {
+            git::VcsKind::Git => git_ops.remove_worktree(project_path, worktree),
+            git::VcsKind::Jj => jj_ops.remove_workspace(
+                project_path,
+                Path::new(worktree),
+                task.workspace_name.as_deref(),
+            ),
+        };
+        if let Err(e) = result {
             tracing::warn!(worktree = %worktree, error = %e, "Failed to remove worktree");
         }
 
@@ -9454,19 +9751,37 @@ fn delete_task_resources(
         // purpose — and `delete_branch` is `git branch -D`, so hoisting it would
         // silently force-delete work the user was told was preserved.
         if let Some(ref branch_name) = task.branch_name {
-            let _ = git_ops.delete_branch(project_path, branch_name);
+            let result = match vcs {
+                git::VcsKind::Git => git_ops.delete_branch(project_path, branch_name),
+                git::VcsKind::Jj => jj_ops.delete_branch(project_path, branch_name),
+            };
+            let _ = result;
         }
     }
 }
 
 /// Collect git diff content from a worktree
 /// Returns formatted diff sections (unstaged, staged, untracked)
-fn collect_task_diff(
+fn collect_task_diff_for_vcs(
     worktree_path: &str,
+    vcs: git::VcsKind,
     git_ops: &dyn GitOperations,
     exclude_prefixes: &[&str],
 ) -> String {
     let worktree = Path::new(worktree_path);
+    let jj_ops = git::RealJjOps;
+    if vcs == git::VcsKind::Jj {
+        let diff = jj_ops.diff_cached(worktree);
+        return if diff.trim().is_empty() {
+            format!("(no changes)\n\nWorkspace: {}", worktree_path)
+        } else {
+            format!("=== Changes ===\n\n{diff}")
+        };
+    }
+    let git_ops: &dyn GitOperations = match vcs {
+        git::VcsKind::Git => git_ops,
+        git::VcsKind::Jj => &jj_ops,
+    };
     let mut sections = Vec::new();
 
     // Unstaged changes (modified tracked files)
@@ -9514,6 +9829,16 @@ fn collect_task_diff(
     } else {
         sections.join("\n\n")
     }
+}
+
+#[cfg(feature = "test-mocks")]
+#[allow(dead_code)]
+fn collect_task_diff(
+    worktree_path: &str,
+    git_ops: &dyn GitOperations,
+    exclude_prefixes: &[&str],
+) -> String {
+    collect_task_diff_for_vcs(worktree_path, git::VcsKind::Git, git_ops, exclude_prefixes)
 }
 
 /// Helper function to create a centered rect
@@ -9710,13 +10035,19 @@ fn capture_pane_text(
 }
 
 /// Generate PR title and description using the configured agent
-pub(crate) fn generate_pr_description(
+pub(crate) fn generate_pr_description_for_vcs(
     task_title: &str,
     worktree_path: Option<&str>,
-    _branch_name: Option<&str>,
+    base_revision: Option<&str>,
+    vcs: git::VcsKind,
     git_ops: &dyn GitOperations,
     agent_ops: &dyn AgentOperations,
 ) -> (String, String) {
+    let jj_ops = git::RealJjOps;
+    let git_ops: &dyn GitOperations = match vcs {
+        git::VcsKind::Git => git_ops,
+        git::VcsKind::Jj => &jj_ops,
+    };
     // Default values
     let default_title = task_title.to_string();
     let mut default_body = String::new();
@@ -9724,8 +10055,21 @@ pub(crate) fn generate_pr_description(
     // Try to get git diff for context
     if let Some(worktree) = worktree_path {
         let worktree_path = Path::new(worktree);
-        // Get diff from main
-        let diff_stat = git_ops.diff_stat_from_main(worktree_path);
+        let diff_stat = if vcs == git::VcsKind::Jj {
+            let base = base_revision
+                .filter(|base| !base.trim().is_empty())
+                .unwrap_or("trunk()");
+            std::process::Command::new("jj")
+                .current_dir(worktree_path)
+                .args(["diff", "--stat", "--from", base, "--to", "@"])
+                .output()
+                .ok()
+                .filter(|output| output.status.success())
+                .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
+                .unwrap_or_default()
+        } else {
+            git_ops.diff_stat_from_main(worktree_path)
+        };
 
         if !diff_stat.is_empty() {
             default_body.push_str("## Changes\n```\n");
@@ -9749,6 +10093,25 @@ pub(crate) fn generate_pr_description(
     (default_title, default_body)
 }
 
+#[cfg(feature = "test-mocks")]
+#[allow(dead_code)]
+pub(crate) fn generate_pr_description(
+    task_title: &str,
+    worktree_path: Option<&str>,
+    branch_name: Option<&str>,
+    git_ops: &dyn GitOperations,
+    agent_ops: &dyn AgentOperations,
+) -> (String, String) {
+    generate_pr_description_for_vcs(
+        task_title,
+        worktree_path,
+        branch_name,
+        git::VcsKind::Git,
+        git_ops,
+        agent_ops,
+    )
+}
+
 /// Create a PR with provided title and body, return (pr_number, pr_url)
 fn create_pr_with_content(
     task: &Task,
@@ -9761,6 +10124,11 @@ fn create_pr_with_content(
 ) -> Result<(i32, String)> {
     let worktree = task.worktree_path.as_deref().unwrap_or(".");
     let worktree_path = Path::new(worktree);
+    let jj_ops = git::RealJjOps;
+    let git_ops: &dyn GitOperations = match task.vcs.unwrap_or_default() {
+        git::VcsKind::Git => git_ops,
+        git::VcsKind::Jj => &jj_ops,
+    };
 
     // Stage all changes
     git_ops.add_all(worktree_path)?;
@@ -9784,12 +10152,30 @@ fn create_pr_with_content(
     }
 
     // Create PR (use base_branch for stacked PRs)
+    let provider_base = match task.vcs.unwrap_or_default() {
+        git::VcsKind::Git => task.base_branch.clone(),
+        git::VcsKind::Jj => task.base_branch.as_deref().and_then(|base| {
+            let base = base.trim();
+            if base.is_empty() || base == "trunk()" {
+                None
+            } else if let Some(bookmark) = base.strip_suffix("@origin") {
+                Some(bookmark.to_string())
+            } else if base
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '/' | '.'))
+            {
+                Some(base.to_string())
+            } else {
+                None
+            }
+        }),
+    };
     git_provider_ops.create_pr(
         project_path,
         pr_title,
         pr_body,
         task.branch_name.as_deref().unwrap_or(""),
-        task.base_branch.clone(),
+        provider_base,
     )
 }
 
@@ -9801,6 +10187,11 @@ fn push_changes_to_existing_pr(
 ) -> Result<String> {
     let worktree = task.worktree_path.as_deref().unwrap_or(".");
     let worktree_path = Path::new(worktree);
+    let jj_ops = git::RealJjOps;
+    let git_ops: &dyn GitOperations = match task.vcs.unwrap_or_default() {
+        git::VcsKind::Git => git_ops,
+        git::VcsKind::Jj => &jj_ops,
+    };
 
     // Stage all changes
     git_ops.add_all(worktree_path)?;
@@ -11044,10 +11435,15 @@ fn fuzzy_find_files(
     project_path: &Path,
     pattern: &str,
     max_results: usize,
+    vcs: git::VcsKind,
     git_ops: &dyn GitOperations,
 ) -> Vec<String> {
-    // Use git ls-files to get tracked files (respects .gitignore)
-    let files = git_ops.list_files(project_path);
+    let jj_ops = git::RealJjOps;
+    let vcs_ops: &dyn GitOperations = match vcs {
+        git::VcsKind::Git => git_ops,
+        git::VcsKind::Jj => &jj_ops,
+    };
+    let files = vcs_ops.list_files(project_path);
 
     if files.is_empty() {
         return vec![];
@@ -11278,6 +11674,7 @@ fn spawn_send_to_agent(
                 agent_ops.as_ref(),
                 worktree_path.as_deref(),
                 &task_id,
+                Some(&project_path),
             );
         }
 
@@ -12149,6 +12546,7 @@ fn ensure_window_or_recover(
     agent_ops: &dyn AgentOperations,
     worktree_path: Option<&str>,
     task_id: &str,
+    project_path: Option<&Path>,
 ) {
     if !tmux_ops.window_exists(target).unwrap_or(true) {
         let Some(wt_path) = worktree_path else { return };
@@ -12168,7 +12566,11 @@ fn ensure_window_or_recover(
             wt_path,
             Some(resume_cmd),
             true,
-            &agtx_task_env(task_id, wt_path),
+            &agtx_task_env(
+                task_id,
+                wt_path,
+                project_path.unwrap_or_else(|| Path::new(wt_path)),
+            ),
         );
     }
 }
@@ -12919,11 +13321,22 @@ fn compose_launch_text(skill_cmd: Option<&str>, prompt: &str) -> String {
 /// inherits it. Agent hooks are registered once with a task-agnostic command and
 /// read these to know what they are reporting about, which is what lets several
 /// tasks share one `.claude/settings.local.json` under `skip_worktree`.
-fn agtx_task_env(task_id: &str, worktree: &str) -> Vec<(String, String)> {
-    vec![
+fn agtx_task_env(task_id: &str, worktree: &str, project_root: &Path) -> Vec<(String, String)> {
+    let mut env = vec![
         ("AGTX_TASK_ID".to_string(), task_id.to_string()),
         ("AGTX_WORKTREE".to_string(), worktree.to_string()),
-    ]
+        (
+            "AGTX_PROJECT_ROOT".to_string(),
+            project_root.to_string_lossy().into_owned(),
+        ),
+    ];
+    if let Ok(agtx_bin) = std::env::current_exe() {
+        env.push((
+            "AGTX_BIN".to_string(),
+            agtx_bin.to_string_lossy().into_owned(),
+        ));
+    }
+    env
 }
 
 /// Merge agtx's hook entries into an existing `hooks` object, preserving the
@@ -13040,36 +13453,16 @@ fn write_skills_to_worktree(
     let agtx_dir = Path::new(worktree_path).join(".agtx");
     let _ = std::fs::create_dir_all(&agtx_dir);
 
-    // Write canonical .agtx/skills/ directory
+    // Write canonical .agtx/skills/ directory. Resolve plugin overrides through
+    // the same path as native skills, then bake in the exact running binary so
+    // agents never depend on `agtx` being on PATH.
     let skills_dir = agtx_dir.join("skills");
-    if let Some(ref p) = plugin {
-        // Copy skills from plugin directory, falling back to built-in defaults
-        if let Some(plugin_dir) = WorkflowPlugin::plugin_dir(&p.name, Some(project_path)) {
-            for (skill_name, default_content) in skills::BUILTIN_SKILLS {
-                let src = plugin_dir.join(skill_name).join("SKILL.md");
-                let dst_dir = skills_dir.join(skill_name);
-                let _ = std::fs::create_dir_all(&dst_dir);
-                if src.exists() {
-                    let _ = std::fs::copy(&src, dst_dir.join("SKILL.md"));
-                } else {
-                    let _ = std::fs::write(dst_dir.join("SKILL.md"), default_content);
-                }
-            }
-        } else {
-            // Plugin dir not found, write defaults
-            for (skill_name, skill_content) in skills::BUILTIN_SKILLS {
-                let skill_dir = skills_dir.join(skill_name);
-                let _ = std::fs::create_dir_all(&skill_dir);
-                let _ = std::fs::write(skill_dir.join("SKILL.md"), skill_content);
-            }
-        }
-    } else {
-        // Write built-in default skills
-        for (skill_name, skill_content) in skills::BUILTIN_SKILLS {
-            let skill_dir = skills_dir.join(skill_name);
-            let _ = std::fs::create_dir_all(&skill_dir);
-            let _ = std::fs::write(skill_dir.join("SKILL.md"), skill_content);
-        }
+    for (skill_name, default_content) in skills::BUILTIN_SKILLS {
+        let content = resolve_skill_content(plugin, skill_name, project_path, default_content);
+        let content = materialize_skill_content(&content);
+        let skill_dir = skills_dir.join(skill_name);
+        let _ = std::fs::create_dir_all(&skill_dir);
+        let _ = std::fs::write(skill_dir.join("SKILL.md"), content);
     }
 
     // Write project-scoped MCP server config for each configured agent.
@@ -13110,6 +13503,7 @@ fn write_skills_to_worktree(
             for (skill_dir_name, default_content) in skills::BUILTIN_SKILLS {
                 let content =
                     resolve_skill_content(plugin, skill_dir_name, project_path, default_content);
+                let content = materialize_skill_content(&content);
                 write_skill_file(spec, skill_dir_name, &content, &native_dir);
             }
         }
@@ -13558,6 +13952,20 @@ fn write_mcp_config(
 /// and had already drifted: the latter treated Claude's format as its `_`
 /// fallback, so a future agent with a skill dir but no arm would silently get
 /// Claude's `.md` layout from one and nothing from the other.
+fn materialize_skill_content(content: &str) -> String {
+    if !content.contains("{{AGTX_BIN}}") {
+        return content.to_string();
+    }
+    let executable = std::env::current_exe()
+        .map(|path| shell_quote(&path.to_string_lossy()))
+        .unwrap_or_else(|_| "\"$AGTX_BIN\"".to_string());
+    content.replace("{{AGTX_BIN}}", &executable)
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
 fn write_skill_file(spec: &agent::AgentSpec, skill_name: &str, content: &str, native_dir: &Path) {
     match spec.skill_layout {
         agent::SkillLayout::CommandFile => {
@@ -13588,10 +13996,11 @@ fn write_skill_file(spec: &agent::AgentSpec, skill_name: &str, content: &str, na
 /// Deploy a single skill to a target directory for the given agent.
 /// Writes both the canonical `.agtx/skills/` copy and the agent-native discovery path.
 fn deploy_skill(target_dir: &Path, skill_name: &str, content: &str, agent_name: &str) {
+    let content = materialize_skill_content(content);
     // Write canonical copy
     let canonical_dir = target_dir.join(".agtx/skills").join(skill_name);
     let _ = std::fs::create_dir_all(&canonical_dir);
-    let _ = std::fs::write(canonical_dir.join("SKILL.md"), content);
+    let _ = std::fs::write(canonical_dir.join("SKILL.md"), &content);
 
     // Write to agent-native discovery path
     let Some(spec) = agent::spec(agent_name) else {
@@ -13604,7 +14013,7 @@ fn deploy_skill(target_dir: &Path, skill_name: &str, content: &str, agent_name: 
             target_dir.join(base_dir).join(namespace)
         };
         let _ = std::fs::create_dir_all(&native_dir);
-        write_skill_file(spec, skill_name, content, &native_dir);
+        write_skill_file(spec, skill_name, &content, &native_dir);
     }
 }
 

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -316,6 +316,8 @@ fn test_create_pr_with_content_success() {
         referenced_tasks: None,
         escalation_note: None,
         base_branch: None,
+        vcs: None,
+        workspace_name: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -415,6 +417,8 @@ fn test_create_pr_with_content_no_changes() {
         referenced_tasks: None,
         escalation_note: None,
         base_branch: None,
+        vcs: None,
+        workspace_name: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -473,6 +477,8 @@ fn test_create_pr_with_content_push_failure() {
         referenced_tasks: None,
         escalation_note: None,
         base_branch: None,
+        vcs: None,
+        workspace_name: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -537,6 +543,8 @@ fn test_push_changes_to_existing_pr_success() {
         referenced_tasks: None,
         escalation_note: None,
         base_branch: None,
+        vcs: None,
+        workspace_name: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -592,6 +600,8 @@ fn test_push_changes_to_existing_pr_no_changes() {
         referenced_tasks: None,
         escalation_note: None,
         base_branch: None,
+        vcs: None,
+        workspace_name: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -630,6 +640,8 @@ fn test_push_changes_to_existing_pr_no_url() {
         referenced_tasks: None,
         escalation_note: None,
         base_branch: None,
+        vcs: None,
+        workspace_name: None,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
@@ -664,7 +676,13 @@ fn test_fuzzy_find_files_basic() {
         ]
     });
 
-    let results = fuzzy_find_files(Path::new("/project"), "app", 10, &mock_git);
+    let results = fuzzy_find_files(
+        Path::new("/project"),
+        "app",
+        10,
+        crate::git::VcsKind::Git,
+        &mock_git,
+    );
 
     assert!(!results.is_empty());
     assert!(results.contains(&"src/tui/app.rs".to_string()));
@@ -686,7 +704,13 @@ fn test_fuzzy_find_files_empty_pattern() {
         ]
     });
 
-    let results = fuzzy_find_files(Path::new("/project"), "", 3, &mock_git);
+    let results = fuzzy_find_files(
+        Path::new("/project"),
+        "",
+        3,
+        crate::git::VcsKind::Git,
+        &mock_git,
+    );
 
     assert_eq!(results.len(), 3);
     assert_eq!(results[0], "a.rs");
@@ -704,7 +728,13 @@ fn test_fuzzy_find_files_no_matches() {
         .expect_list_files()
         .returning(|_| vec!["main.rs".to_string(), "lib.rs".to_string()]);
 
-    let results = fuzzy_find_files(Path::new("/project"), "xyz123", 10, &mock_git);
+    let results = fuzzy_find_files(
+        Path::new("/project"),
+        "xyz123",
+        10,
+        crate::git::VcsKind::Git,
+        &mock_git,
+    );
 
     assert!(results.is_empty());
 }
@@ -717,7 +747,13 @@ fn test_fuzzy_find_files_empty_list() {
 
     mock_git.expect_list_files().returning(|_| vec![]);
 
-    let results = fuzzy_find_files(Path::new("/project"), "app", 10, &mock_git);
+    let results = fuzzy_find_files(
+        Path::new("/project"),
+        "app",
+        10,
+        crate::git::VcsKind::Git,
+        &mock_git,
+    );
 
     assert!(results.is_empty());
 }
@@ -738,7 +774,13 @@ fn test_fuzzy_find_files_max_results() {
         ]
     });
 
-    let results = fuzzy_find_files(Path::new("/project"), "app", 2, &mock_git);
+    let results = fuzzy_find_files(
+        Path::new("/project"),
+        "app",
+        2,
+        crate::git::VcsKind::Git,
+        &mock_git,
+    );
 
     assert_eq!(results.len(), 2);
 }
@@ -1050,7 +1092,10 @@ fn the_rate_limit_holds_against_a_paint_and_yields_to_a_keystroke() {
         typist.poke();
     });
     let start = Instant::now();
-    assert_eq!(watch.wait_out_rate_limit(Duration::from_secs(5)), Some(true));
+    assert_eq!(
+        watch.wait_out_rate_limit(Duration::from_secs(5)),
+        Some(true)
+    );
     assert!(
         start.elapsed() < Duration::from_secs(1),
         "a keystroke waited {:?}",
@@ -5514,6 +5559,7 @@ fn test_create_task_full_flow() {
         Some("Users report 500 error on the login page")
     );
     assert_eq!(task.status, TaskStatus::Backlog);
+    assert_eq!(task.vcs, Some(crate::git::VcsKind::Git));
 }
 
 #[test]
@@ -13089,6 +13135,12 @@ fn test_switch_to_project_reloads_config() {
 
     // Create a temp dir simulating a project with review = "codex"
     let project_dir = TempDir::new().unwrap();
+    let init = std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .arg(project_dir.path())
+        .output()
+        .unwrap();
+    assert!(init.status.success());
     let agtx_dir = project_dir.path().join(".agtx");
     fs::create_dir_all(&agtx_dir).unwrap();
     fs::write(
@@ -14003,6 +14055,34 @@ fn test_skip_worktree_tasks_share_one_task_agnostic_hook() {
 }
 
 // ── binary-path drift ────────────────────────────────────────────────────────
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn task_environment_carries_the_exact_agtx_binary() {
+    let env = agtx_task_env("task-id", "/tmp/worktree", Path::new("/tmp/project"));
+    let expected = std::env::current_exe()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    assert!(env.contains(&("AGTX_BIN".to_string(), expected)));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn deployed_vcs_skills_bake_in_the_exact_agtx_binary() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_string_lossy().into_owned();
+    write_skills_to_worktree(&root, dir.path(), &None, &["claude"], false);
+
+    let review = std::fs::read_to_string(
+        dir.path()
+            .join(".agtx/skills/agtx-review/SKILL.md"),
+    )
+    .unwrap();
+    let executable = std::env::current_exe().unwrap();
+    assert!(review.contains(&shell_quote(&executable.to_string_lossy())));
+    assert!(!review.contains("{{AGTX_BIN}}"));
+}
 
 /// Deploying records which binary did it, so the startup check is O(1) per task
 /// instead of parsing seven config formats.

--- a/src/tui/config_editor.rs
+++ b/src/tui/config_editor.rs
@@ -42,6 +42,7 @@ pub enum FieldId {
     ColorPopupBorder,
     ColorPopupHeader,
     // Project overrides
+    ProjectVcs,
     ProjectDefaultAgent,
     ProjectWorkflowPlugin,
     ProjectBaseBranch,
@@ -306,6 +307,15 @@ impl ConfigEditor {
             sections.push(Section {
                 title: "Project",
                 fields: vec![
+                    Field {
+                        id: FieldId::ProjectVcs,
+                        label: "Version control",
+                        help: "Backend for new task workspaces. Git is the default.",
+                        kind: FieldKind::Choice(vec![
+                            Choice::new("git", "git (default)"),
+                            Choice::new("jj", "jj"),
+                        ]),
+                    },
                     Field {
                         id: FieldId::ProjectDefaultAgent,
                         label: "Default agent",
@@ -643,6 +653,11 @@ fn read(id: FieldId, global: &GlobalConfig, project: Option<&ProjectConfig>) -> 
         ColorPopupHeader => text(&global.theme.color_popup_header),
 
         ProjectDefaultAgent => opt(p.and_then(|c| c.default_agent.as_ref())),
+        ProjectVcs => FieldValue::Text(
+            p.and_then(|c| c.vcs)
+                .map(|v| v.as_str().to_string())
+                .unwrap_or_else(|| "git".to_string()),
+        ),
         ProjectWorkflowPlugin => opt(p.and_then(|c| c.workflow_plugin.as_ref())),
         ProjectBaseBranch => opt(p.and_then(|c| c.base_branch.as_ref())),
         ProjectWorktreeDir => opt(p.and_then(|c| c.worktree_dir.as_ref())),
@@ -698,7 +713,8 @@ fn write(
         ColorPopupBorder => global.theme.color_popup_border = string,
         ColorPopupHeader => global.theme.color_popup_header = string,
 
-        ProjectDefaultAgent
+        ProjectVcs
+        | ProjectDefaultAgent
         | ProjectWorkflowPlugin
         | ProjectBaseBranch
         | ProjectWorktreeDir
@@ -712,6 +728,9 @@ fn write(
             // only added to the form then.
             let Some(config) = project else { return };
             match id {
+                ProjectVcs => {
+                    config.vcs = string.parse().ok();
+                }
                 ProjectDefaultAgent => config.default_agent = some_unless_blank(string),
                 ProjectWorkflowPlugin => config.workflow_plugin = some_unless_blank(string),
                 ProjectBaseBranch => config.base_branch = some_unless_blank(string),

--- a/src/tui/dep_graph.rs
+++ b/src/tui/dep_graph.rs
@@ -230,6 +230,8 @@ mod tests {
             referenced_tasks: refs.map(|s| s.to_string()),
             escalation_note: None,
             base_branch: None,
+            vcs: None,
+            workspace_name: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/src/vcs_cli.rs
+++ b/src/vcs_cli.rs
@@ -1,0 +1,397 @@
+//! Stable, VCS-neutral commands used by agtx's agent prompts.
+
+use crate::config::ProjectConfig;
+use crate::db::Database;
+use crate::git::{self, VcsKind};
+use anyhow::{bail, Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+struct TaskContext {
+    project: PathBuf,
+    checkout: PathBuf,
+    task: crate::db::Task,
+    kind: VcsKind,
+    base: String,
+}
+
+impl TaskContext {
+    fn discover() -> Result<Self> {
+        let project = std::env::var_os("AGTX_PROJECT_ROOT")
+            .map(PathBuf::from)
+            .context("not in an agtx task: AGTX_PROJECT_ROOT is not set")?
+            .canonicalize()
+            .context("AGTX_PROJECT_ROOT does not resolve")?;
+        let task_id = std::env::var("AGTX_TASK_ID")
+            .context("not in an agtx task: AGTX_TASK_ID is not set")?;
+        let checkout_env = std::env::var_os("AGTX_WORKTREE")
+            .map(PathBuf::from)
+            .context("not in an agtx task: AGTX_WORKTREE is not set")?;
+        let checkout = checkout_env
+            .canonicalize()
+            .context("AGTX_WORKTREE does not resolve")?;
+        let cwd = std::env::current_dir()?.canonicalize()?;
+        if !cwd.starts_with(&checkout) {
+            bail!(
+                "current directory '{}' is outside task checkout '{}'",
+                cwd.display(),
+                checkout.display()
+            );
+        }
+
+        let db = Database::open_project(&project)?;
+        let task = db
+            .get_task(&task_id)?
+            .with_context(|| format!("task '{task_id}' is not present in the project database"))?;
+        let recorded = task
+            .worktree_path
+            .as_deref()
+            .context("task has no recorded checkout")?;
+        if Path::new(recorded).canonicalize()? != checkout {
+            bail!("task database checkout does not match AGTX_WORKTREE");
+        }
+
+        // A missing value is always Git. Selection is never inferred from .jj.
+        let kind = task.vcs.unwrap_or_default();
+        if !git::is_repo_for(&checkout, kind) {
+            bail!(
+                "task records backend '{}', but '{}' is not a {} checkout",
+                kind,
+                checkout.display(),
+                kind
+            );
+        }
+        let configured_base = ProjectConfig::load(&project)?
+            .base_branch
+            .filter(|base| !base.trim().is_empty());
+        let base = task
+            .base_branch
+            .as_deref()
+            .map(str::trim)
+            .filter(|base| !base.is_empty())
+            .map(str::to_string)
+            .or(configured_base)
+            .map(Ok)
+            .unwrap_or_else(|| match kind {
+                VcsKind::Git => git::detect_main_branch(&project),
+                VcsKind::Jj => Ok("trunk()".to_string()),
+            })?;
+        Ok(Self {
+            project,
+            checkout,
+            task,
+            kind,
+            base,
+        })
+    }
+}
+
+fn output(command: &mut Command, label: &str) -> Result<Output> {
+    let result = command
+        .output()
+        .with_context(|| format!("failed to run {label}"))?;
+    if !result.status.success() {
+        bail!(
+            "{label} failed: {}",
+            String::from_utf8_lossy(&result.stderr).trim()
+        );
+    }
+    Ok(result)
+}
+
+fn print_output(result: Output) {
+    print!("{}", String::from_utf8_lossy(&result.stdout));
+    eprint!("{}", String::from_utf8_lossy(&result.stderr));
+}
+
+fn git_command(ctx: &TaskContext, args: &[&str]) -> Result<Output> {
+    output(
+        Command::new("git").current_dir(&ctx.checkout).args(args),
+        "git",
+    )
+}
+
+fn jj_command(ctx: &TaskContext, args: &[&str]) -> Result<Output> {
+    output(
+        Command::new("jj").current_dir(&ctx.checkout).args(args),
+        "jj",
+    )
+}
+
+fn git_ref_exists(ctx: &TaskContext, revision: &str) -> bool {
+    Command::new("git")
+        .current_dir(&ctx.checkout)
+        .args(["rev-parse", "--verify", "--quiet", revision])
+        .output()
+        .map(|result| result.status.success())
+        .unwrap_or(false)
+}
+
+/// Prefer a fetched remote-tracking revision when the configured Git base is
+/// a branch. Commit IDs and other revision expressions fall back unchanged.
+fn git_remote_base(ctx: &TaskContext) -> String {
+    let base = ctx.base.strip_prefix("refs/heads/").unwrap_or(&ctx.base);
+    let candidate = if let Some(remote) = base.strip_prefix("refs/remotes/") {
+        remote.to_string()
+    } else if base.starts_with("origin/") {
+        base.to_string()
+    } else {
+        format!("origin/{base}")
+    };
+    if git_ref_exists(ctx, &candidate) {
+        candidate
+    } else {
+        ctx.base.clone()
+    }
+}
+
+/// Avoid invoking `jj resolve --list` for a clean revision: jj uses exit 2 for
+/// that ordinary state. The revset check gives the command an unambiguous
+/// success path and reserves nonzero exits for actual failures.
+fn jj_conflicts(ctx: &TaskContext) -> Result<Vec<String>> {
+    let conflicted = jj_command(
+        ctx,
+        &[
+            "log",
+            "-r",
+            "@ & conflicts()",
+            "--no-graph",
+            "-T",
+            "commit_id",
+        ],
+    )?;
+    if conflicted.stdout.is_empty() {
+        return Ok(Vec::new());
+    }
+    let result = jj_command(ctx, &["resolve", "--list"])?;
+    Ok(String::from_utf8_lossy(&result.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+fn jj_has_revision(ctx: &TaskContext, revset: &str) -> Result<bool> {
+    let result = jj_command(ctx, &["log", "-r", revset, "--no-graph", "-T", "commit_id"])?;
+    Ok(!result.stdout.is_empty())
+}
+
+fn task_diff(ctx: &TaskContext, extra: &[String]) -> Result<()> {
+    let mut command = match ctx.kind {
+        VcsKind::Git => {
+            let mut cmd = Command::new("git");
+            cmd.current_dir(&ctx.checkout)
+                .args(["diff", &format!("{}...HEAD", ctx.base)]);
+            cmd
+        }
+        VcsKind::Jj => {
+            let mut cmd = Command::new("jj");
+            let fork = format!("fork_point(({}) | @)", ctx.base);
+            cmd.current_dir(&ctx.checkout)
+                .args(["diff", "--git", "--from", &fork, "--to", "@"]);
+            cmd
+        }
+    };
+    if extra.iter().any(|arg| arg == "--stat") {
+        command.arg("--stat");
+    }
+    if let Some(separator) = extra.iter().position(|arg| arg == "--") {
+        command.arg("--").args(&extra[separator + 1..]);
+    }
+    print_output(output(&mut command, "task diff")?);
+    Ok(())
+}
+
+fn task_log(ctx: &TaskContext) -> Result<()> {
+    let result = match ctx.kind {
+        VcsKind::Git => git_command(ctx, &["log", "--oneline", &format!("{}..HEAD", ctx.base)]),
+        VcsKind::Jj => jj_command(
+            ctx,
+            &[
+                "log",
+                "-r",
+                &format!("{}..@", ctx.base),
+                "-T",
+                "builtin_log_compact",
+            ],
+        ),
+    }?;
+    print_output(result);
+    Ok(())
+}
+
+fn checkpoint(ctx: &TaskContext, message: &str) -> Result<()> {
+    match ctx.kind {
+        VcsKind::Git => {
+            let dirty = git_command(ctx, &["status", "--porcelain"])?;
+            if dirty.stdout.is_empty() {
+                return Ok(());
+            }
+            git_command(ctx, &["add", "-A"])?;
+            git_command(ctx, &["commit", "-m", message])?;
+        }
+        VcsKind::Jj => {
+            let dirty = jj_command(ctx, &["diff", "--summary"])?;
+            if dirty.stdout.is_empty() {
+                return Ok(());
+            }
+            jj_command(ctx, &["describe", "-m", message])?;
+            jj_command(ctx, &["new"])?;
+        }
+    }
+    Ok(())
+}
+
+fn conflicts(ctx: &TaskContext) -> Result<()> {
+    match ctx.kind {
+        VcsKind::Git => {
+            let current = git_command(ctx, &["diff", "--name-only", "--diff-filter=U"])?;
+            if !current.stdout.is_empty() {
+                println!("conflicts: yes");
+                print!("{}", String::from_utf8_lossy(&current.stdout));
+                return Ok(());
+            }
+        }
+        VcsKind::Jj => {
+            let current = jj_conflicts(ctx)?;
+            if !current.is_empty() {
+                println!("conflicts: yes");
+                for path in current {
+                    println!("{path}");
+                }
+                return Ok(());
+            }
+        }
+    }
+    let (conflicted, files) = match ctx.kind {
+        VcsKind::Git => {
+            let branch = ctx.task.branch_name.as_deref().unwrap_or("HEAD");
+            git::check_merge_conflicts(&ctx.checkout, &git_remote_base(ctx), branch)?
+        }
+        VcsKind::Jj => git::jj_conflict_probe(&ctx.checkout, "@", &ctx.base)?,
+    };
+    if conflicted {
+        println!("conflicts: yes");
+        for file in files {
+            println!("{file}");
+        }
+    } else {
+        println!("conflicts: no");
+    }
+    Ok(())
+}
+
+fn integrate_base(ctx: &TaskContext, fetch: bool) -> Result<()> {
+    if fetch {
+        match ctx.kind {
+            VcsKind::Git => {
+                git_command(ctx, &["fetch", "origin"])?;
+            }
+            VcsKind::Jj => {
+                jj_command(ctx, &["git", "fetch", "--remote", "origin"])?;
+            }
+        }
+    }
+    match ctx.kind {
+        VcsKind::Git => {
+            let base = if fetch {
+                git_remote_base(ctx)
+            } else {
+                ctx.base.clone()
+            };
+            print_output(git_command(
+                ctx,
+                &["merge", "--no-ff", &base, "-m", &format!("Merge {base}")],
+            )?);
+        }
+        VcsKind::Jj => {
+            let base_is_ancestor = format!("({}) & ::@", ctx.base);
+            if jj_has_revision(ctx, &base_is_ancestor)? {
+                return Ok(());
+            }
+            print_output(jj_command(
+                ctx,
+                &["new", "@", &ctx.base, "-m", &format!("Merge {}", ctx.base)],
+            )?);
+        }
+    }
+    Ok(())
+}
+
+fn finish_integration(ctx: &TaskContext) -> Result<()> {
+    match ctx.kind {
+        VcsKind::Git => {
+            let unresolved = git_command(ctx, &["diff", "--name-only", "--diff-filter=U"])?;
+            if !unresolved.stdout.is_empty() {
+                bail!(
+                    "unresolved conflicts remain:\n{}",
+                    String::from_utf8_lossy(&unresolved.stdout)
+                );
+            }
+            // A clean Git merge commits immediately. Only finish a commit when
+            // an in-progress merge remains after conflict repair.
+            if git_ref_exists(ctx, "MERGE_HEAD") {
+                git_command(ctx, &["add", "-A"])?;
+                git_command(ctx, &["commit", "--no-edit"])?;
+            }
+        }
+        VcsKind::Jj => {
+            let unresolved = jj_conflicts(ctx)?;
+            if !unresolved.is_empty() {
+                bail!("unresolved conflicts remain:\n{}", unresolved.join("\n"));
+            }
+            jj_command(ctx, &["st"])?;
+        }
+    }
+    Ok(())
+}
+
+fn usage() -> &'static str {
+    "agtx vcs — VCS-neutral operations for an agtx task\n\n\
+USAGE\n  agtx vcs info\n  agtx vcs status\n  agtx vcs diff --task [--stat] [-- <paths>]\n  agtx vcs log --task\n  agtx vcs checkpoint -m <message>\n  agtx vcs conflicts\n  agtx vcs integrate-base [--fetch]\n  agtx vcs finish-integration"
+}
+
+pub fn run(args: &[String]) -> Result<()> {
+    let Some(command) = args.first().map(String::as_str) else {
+        println!("{}", usage());
+        return Ok(());
+    };
+    if matches!(command, "help" | "--help" | "-h") {
+        println!("{}", usage());
+        return Ok(());
+    }
+    let ctx = TaskContext::discover()?;
+    match command {
+        "info" => {
+            println!("task:       {}", ctx.task.id);
+            println!("backend:    {}", ctx.kind);
+            println!("project:    {}", ctx.project.display());
+            println!("workspace:  {}", ctx.checkout.display());
+            println!("base:       {}", ctx.base);
+            println!(
+                "publish:    {}",
+                ctx.task.branch_name.as_deref().unwrap_or("(unset)")
+            );
+        }
+        "status" => print_output(match ctx.kind {
+            VcsKind::Git => git_command(&ctx, &["status", "--short"]),
+            VcsKind::Jj => jj_command(&ctx, &["st"]),
+        }?),
+        "diff" => task_diff(&ctx, &args[1..])?,
+        "log" => task_log(&ctx)?,
+        "checkpoint" => {
+            let message = args
+                .windows(2)
+                .find(|pair| pair[0] == "-m" || pair[0] == "--message")
+                .map(|pair| pair[1].as_str())
+                .context("checkpoint requires -m <message>")?;
+            checkpoint(&ctx, message)?;
+        }
+        "conflicts" => conflicts(&ctx)?,
+        "integrate-base" => integrate_base(&ctx, args.iter().any(|arg| arg == "--fetch"))?,
+        "finish-integration" => finish_integration(&ctx)?,
+        other => bail!("unknown agtx vcs command '{other}'\n\n{}", usage()),
+    }
+    Ok(())
+}

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -112,8 +112,15 @@ pub async fn serve(opts: ServeOptions) -> Result<()> {
             let path = path
                 .canonicalize()
                 .with_context(|| format!("resolving {}", path.display()))?;
-            if !crate::git::is_git_repo(&path) {
-                bail!("serve requires a git project directory: {}", path.display());
+            let vcs = crate::config::ProjectConfig::load(&path)?
+                .vcs
+                .unwrap_or_default();
+            if !crate::git::is_repo_for(&path, vcs) {
+                bail!(
+                    "serve requires a configured {} project directory: {}",
+                    vcs,
+                    path.display()
+                );
             }
             ServeMode::Project(path)
         }

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -370,10 +370,26 @@ fn resolve_base(
     project: &std::path::Path,
     worktree: &std::path::Path,
     recorded: Option<&str>,
+    vcs: crate::git::VcsKind,
 ) -> Option<String> {
+    let configured = crate::config::ProjectConfig::load(project)
+        .ok()
+        .and_then(|config| config.base_branch)
+        .filter(|base| !base.trim().is_empty());
+    if vcs == crate::git::VcsKind::Jj {
+        let base = recorded
+            .filter(|base| !base.trim().is_empty())
+            .map(str::to_string)
+            .or(configured)
+            .unwrap_or_else(|| "trunk()".to_string());
+        return crate::git::resolve_jj_revision(worktree, &base)
+            .ok()
+            .map(|_| base);
+    }
     recorded
         .filter(|b| !b.is_empty() && crate::git::ref_exists(worktree, b))
         .map(str::to_string)
+        .or_else(|| configured.filter(|base| crate::git::ref_exists(worktree, base)))
         .or_else(|| {
             crate::git::detect_main_branch(project)
                 .ok()
@@ -388,8 +404,15 @@ fn conflict_for(project: &std::path::Path, task: &Task) -> Option<ConflictState>
     if !worktree.exists() {
         return None;
     }
+    let vcs = task.vcs.unwrap_or_default();
+    let base = resolve_base(project, &worktree, task.base_branch.as_deref(), vcs)?;
+
+    if vcs == crate::git::VcsKind::Jj {
+        return crate::git::jj_conflict_probe(&worktree, "@", &base)
+            .ok()
+            .map(|(conflicted, files)| ConflictState { conflicted, files });
+    }
     let branch = task.branch_name.clone()?;
-    let base = resolve_base(project, &worktree, task.base_branch.as_deref())?;
 
     match crate::git::check_merge_conflicts(&worktree, &base, &branch) {
         Ok((conflicted, files)) => Some(ConflictState { conflicted, files }),
@@ -517,21 +540,50 @@ async fn task_diff(
         )));
     }
 
-    let base = resolve_base(&project, &worktree, t.base_branch.as_deref()).ok_or_else(|| {
-        ApiError::NotFound(format!(
-            "no base branch to diff against: task {tid} records {:?}, and neither it nor a \
+    let vcs = t.vcs.unwrap_or_default();
+    let base =
+        resolve_base(&project, &worktree, t.base_branch.as_deref(), vcs).ok_or_else(|| {
+            ApiError::NotFound(format!(
+                "no base branch to diff against: task {tid} records {:?}, and neither it nor a \
                  detected default resolves in {}",
-            t.base_branch.as_deref().unwrap_or("none"),
-            worktree.display()
-        ))
-    })?;
+                t.base_branch.as_deref().unwrap_or("none"),
+                worktree.display()
+            ))
+        })?;
 
     // `HEAD` rather than the branch name: the branch is what the worktree has
     // checked out, and naming it would miss nothing but costs a lookup.
-    let stat = crate::git::diff_stat(&worktree, &base, "HEAD")
-        .map_err(|e| ApiError::Internal(format!("git diff --stat: {e}")))?;
-    let patch = crate::git::diff_full(&worktree, &base, "HEAD")
-        .map_err(|e| ApiError::Internal(format!("git diff: {e}")))?;
+    let (stat, patch) = match vcs {
+        crate::git::VcsKind::Git => (
+            crate::git::diff_stat(&worktree, &base, "HEAD")
+                .map_err(|e| ApiError::Internal(format!("git diff --stat: {e}")))?,
+            crate::git::diff_full(&worktree, &base, "HEAD")
+                .map_err(|e| ApiError::Internal(format!("git diff: {e}")))?,
+        ),
+        crate::git::VcsKind::Jj => {
+            let run = |stat: bool| -> Result<String, ApiError> {
+                let mut command = std::process::Command::new("jj");
+                command
+                    .current_dir(&worktree)
+                    .args(["diff", "--from", &base, "--to", "@"]);
+                if stat {
+                    command.arg("--stat");
+                } else {
+                    command.arg("--git");
+                }
+                let output = command
+                    .output()
+                    .map_err(|e| ApiError::Internal(e.to_string()))?;
+                if !output.status.success() {
+                    return Err(ApiError::Internal(
+                        String::from_utf8_lossy(&output.stderr).into_owned(),
+                    ));
+                }
+                Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+            };
+            (run(true)?, run(false)?)
+        }
+    };
 
     // Computed here rather than read from the cache: this is the screen the
     // decision gets made on, and one git call is worth an honest answer.

--- a/src/web/writes.rs
+++ b/src/web/writes.rs
@@ -75,12 +75,24 @@ pub async fn task_action(
     // The TUI checks again at execution time because the agent may keep writing.
     if body.action == "move_to_done" {
         if let Some(worktree) = task.worktree_path.clone() {
+            let vcs = task.vcs.unwrap_or_default();
             let dirty = tokio::task::spawn_blocking(move || {
-                let output = std::process::Command::new("git")
+                let mut command = match vcs {
+                    crate::git::VcsKind::Git => {
+                        let mut command = std::process::Command::new("git");
+                        command.args(["status", "--porcelain"]);
+                        command
+                    }
+                    crate::git::VcsKind::Jj => {
+                        let mut command = std::process::Command::new("jj");
+                        command.args(["diff", "--summary"]);
+                        command
+                    }
+                };
+                let output = command
                     .current_dir(&worktree)
-                    .args(["status", "--porcelain"])
                     .output()
-                    .map_err(|e| ApiError::Internal(format!("checking worktree: {e}")))?;
+                    .map_err(|e| ApiError::Internal(format!("checking workspace: {e}")))?;
                 if !output.status.success() {
                     return Err(ApiError::Conflict(
                         "Cannot verify that the worktree is clean; completion is blocked.".into(),
@@ -189,7 +201,7 @@ pub async fn create_task(
     // The project's own defaults, so a task created from a phone is the task
     // the desktop would have created — the agent in particular is what every
     // later phase reads.
-    let (agent, plugin) = defaults_for(&state, &pid);
+    let (agent, plugin, vcs) = defaults_for(&state, &pid)?;
     let project_name = project_name_for(&state, &pid);
 
     let mut task = Task::new(title, &agent, &project_name);
@@ -197,6 +209,7 @@ pub async fn create_task(
     task.plugin = body.plugin.or(plugin);
     task.referenced_tasks = body.referenced_tasks;
     task.base_branch = body.base_branch;
+    task.vcs = Some(vcs);
 
     db.create_task(&task)
         .map_err(|e| ApiError::Internal(format!("creating the task: {e}")))?;
@@ -342,16 +355,20 @@ fn validate_refs(db: &Database, refs: Option<&str>) -> ApiResult<()> {
 
 /// The project's configured default agent and plugin, merged over the global
 /// config exactly as the TUI does.
-fn defaults_for(state: &ServerState, pid: &str) -> (String, Option<String>) {
+fn defaults_for(
+    state: &ServerState,
+    pid: &str,
+) -> ApiResult<(String, Option<String>, crate::git::VcsKind)> {
     let global = crate::config::GlobalConfig::load().unwrap_or_default();
-    match state.project_path(pid) {
-        Ok(path) => {
-            let project = crate::config::ProjectConfig::load(&path).unwrap_or_default();
-            let merged = crate::config::MergedConfig::merge(&global, &project);
-            (merged.default_agent.clone(), merged.workflow_plugin.clone())
-        }
-        Err(_) => (global.default_agent.clone(), None),
-    }
+    let path = state.project_path(pid)?;
+    let project = crate::config::ProjectConfig::load(&path)
+        .map_err(|error| ApiError::Internal(format!("loading project config: {error}")))?;
+    let merged = crate::config::MergedConfig::merge(&global, &project);
+    Ok((
+        merged.default_agent.clone(),
+        merged.workflow_plugin.clone(),
+        merged.vcs,
+    ))
 }
 
 fn project_name_for(state: &ServerState, pid: &str) -> String {

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -74,6 +74,7 @@ fn test_worktree_config_default() {
 fn test_project_config_default() {
     let config = ProjectConfig::default();
 
+    assert!(config.vcs.is_none());
     assert!(config.default_agent.is_none());
     assert!(config.base_branch.is_none());
     assert!(config.github_url.is_none());
@@ -91,6 +92,7 @@ fn test_merged_config_uses_global_defaults() {
 
     let merged = MergedConfig::merge(&global, &project);
 
+    assert_eq!(merged.vcs, agtx::git::VcsKind::Git);
     assert_eq!(merged.default_agent, "claude");
     assert_eq!(merged.base_branch, "");
     assert!(merged.worktree_enabled);
@@ -101,9 +103,17 @@ fn test_merged_config_uses_global_defaults() {
 }
 
 #[test]
+fn project_config_rejects_unknown_vcs_instead_of_guessing() {
+    let dir = project_with_config("vcs = \"auto\"\n");
+    let error = ProjectConfig::load(dir.path()).unwrap_err().to_string();
+    assert!(error.contains("Failed to parse project config"), "{error}");
+}
+
+#[test]
 fn test_merged_config_project_overrides() {
     let global = GlobalConfig::default();
     let project = ProjectConfig {
+        vcs: Some(agtx::git::VcsKind::Jj),
         default_agent: Some("codex".to_string()),
         agents: None,
         base_branch: Some("develop".to_string()),
@@ -120,6 +130,7 @@ fn test_merged_config_project_overrides() {
     let merged = MergedConfig::merge(&global, &project);
 
     assert_eq!(merged.default_agent, "codex");
+    assert_eq!(merged.vcs, agtx::git::VcsKind::Jj);
     assert_eq!(merged.base_branch, "develop");
     assert_eq!(
         merged.github_url,
@@ -135,6 +146,20 @@ fn test_merged_config_project_overrides() {
         merged.cleanup_script,
         Some("scripts/cleanup.sh".to_string())
     );
+}
+
+#[test]
+fn jj_does_not_inherit_the_global_git_base() {
+    let mut global = GlobalConfig::default();
+    global.worktree.base_branch = "main".to_string();
+    let project = ProjectConfig {
+        vcs: Some(agtx::git::VcsKind::Jj),
+        ..Default::default()
+    };
+
+    let merged = MergedConfig::merge(&global, &project);
+    assert_eq!(merged.vcs, agtx::git::VcsKind::Jj);
+    assert!(merged.base_branch.is_empty());
 }
 
 #[test]

--- a/tests/db_tests.rs
+++ b/tests/db_tests.rs
@@ -62,6 +62,8 @@ fn test_task_new() {
     assert!(task.branch_name.is_none());
     assert!(task.pr_number.is_none());
     assert!(task.pr_url.is_none());
+    assert!(task.vcs.is_none());
+    assert!(task.workspace_name.is_none());
 }
 
 #[test]
@@ -166,6 +168,22 @@ fn test_in_memory_project_db_update_task() {
     let retrieved = db.get_task(&task.id).unwrap().unwrap();
     assert_eq!(retrieved.status, TaskStatus::Running);
     assert_eq!(retrieved.session_name.as_deref(), Some("session-1"));
+}
+
+#[test]
+#[cfg(feature = "test-mocks")]
+fn test_task_vcs_identity_round_trips() {
+    let db = Database::open_in_memory_project().unwrap();
+    let mut task = Task::new("JJ task", "codex", "proj-1");
+    task.vcs = Some(agtx::git::VcsKind::Jj);
+    task.workspace_name = Some("task-jj-task".to_string());
+    task.base_branch = Some("trunk()".to_string());
+    db.create_task(&task).unwrap();
+
+    let retrieved = db.get_task(&task.id).unwrap().unwrap();
+    assert_eq!(retrieved.vcs, Some(agtx::git::VcsKind::Jj));
+    assert_eq!(retrieved.workspace_name.as_deref(), Some("task-jj-task"));
+    assert_eq!(retrieved.base_branch.as_deref(), Some("trunk()"));
 }
 
 #[test]

--- a/tests/vcs_cli_tests.rs
+++ b/tests/vcs_cli_tests.rs
@@ -1,0 +1,308 @@
+use agtx::db::{Database, Task};
+use agtx::git::VcsKind;
+use std::process::{Command, Output};
+use std::sync::Mutex;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn git_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn run_ok(command: &mut Command) -> Output {
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn jj_available() -> bool {
+    Command::new("jj")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn vcs_cli_uses_task_identity_and_never_guesses_jj() {
+    let _env = ENV_LOCK.lock().unwrap();
+    if !jj_available() {
+        return;
+    }
+    let project = tempfile::tempdir().unwrap();
+    let project_path = project.path().canonicalize().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let init = Command::new("jj")
+        .args(["git", "init", "--no-colocate"])
+        .arg(project.path())
+        .output()
+        .unwrap();
+    assert!(init.status.success());
+    std::fs::create_dir_all(project_path.join(".agtx")).unwrap();
+    std::fs::write(
+        project_path.join(".agtx/config.toml"),
+        "vcs = \"jj\"\nbase_branch = \"root()\"\n",
+    )
+    .unwrap();
+
+    std::env::set_var("AGTX_DATA_DIR", data.path());
+    let db = Database::open_project(&project_path).unwrap();
+    let mut task = Task::new("CLI context", "codex", "test-project");
+    task.worktree_path = Some(project_path.to_string_lossy().into_owned());
+    db.create_task(&task).unwrap();
+    std::env::remove_var("AGTX_DATA_DIR");
+
+    let run = |args: &[&str]| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_agtx"));
+        command
+            .arg("vcs")
+            .args(args)
+            .current_dir(&project_path)
+            .env("AGTX_DATA_DIR", data.path())
+            .env("AGTX_CONFIG_DIR", data.path())
+            .env("AGTX_PROJECT_ROOT", &project_path)
+            .env("AGTX_WORKTREE", &project_path)
+            .env("AGTX_TASK_ID", &task.id);
+        command.output().unwrap()
+    };
+
+    let default_git = run(&["info"]);
+    assert!(!default_git.status.success());
+    assert!(
+        String::from_utf8_lossy(&default_git.stderr).contains("not a git checkout"),
+        "{}",
+        String::from_utf8_lossy(&default_git.stderr)
+    );
+
+    task.vcs = Some(VcsKind::Jj);
+    std::env::set_var("AGTX_DATA_DIR", data.path());
+    db.update_task(&task).unwrap();
+    std::env::remove_var("AGTX_DATA_DIR");
+
+    let explicit_jj = run(&["info"]);
+    assert!(
+        explicit_jj.status.success(),
+        "{}",
+        String::from_utf8_lossy(&explicit_jj.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&explicit_jj.stdout);
+    assert!(stdout.contains("backend:    jj"), "{stdout}");
+    assert!(stdout.contains("base:       root()"), "{stdout}");
+
+    let clean_conflicts = run(&["conflicts"]);
+    assert!(
+        clean_conflicts.status.success(),
+        "{}",
+        String::from_utf8_lossy(&clean_conflicts.stderr)
+    );
+    assert!(String::from_utf8_lossy(&clean_conflicts.stdout).contains("conflicts: no"));
+
+    let diff = run(&["diff", "--task"]);
+    assert!(
+        diff.status.success(),
+        "{}",
+        String::from_utf8_lossy(&diff.stderr)
+    );
+
+    let integrate = run(&["integrate-base"]);
+    assert!(
+        integrate.status.success(),
+        "{}",
+        String::from_utf8_lossy(&integrate.stderr)
+    );
+
+    let finish = run(&["finish-integration"]);
+    assert!(
+        finish.status.success(),
+        "{}",
+        String::from_utf8_lossy(&finish.stderr)
+    );
+}
+
+#[test]
+fn git_diff_uses_the_fork_point_and_fetch_integrates_the_remote_base() {
+    let _env = ENV_LOCK.lock().unwrap();
+    if !git_available() {
+        return;
+    }
+    let root = tempfile::tempdir().unwrap();
+    let remote = root.path().join("remote.git");
+    let project = root.path().join("project");
+    let upstream = root.path().join("upstream");
+    let data = tempfile::tempdir().unwrap();
+
+    run_ok(
+        Command::new("git")
+            .args(["init", "--bare", "-b", "main"])
+            .arg(&remote),
+    );
+    run_ok(
+        Command::new("git")
+            .args(["init", "-b", "main"])
+            .arg(&project),
+    );
+    run_ok(Command::new("git").current_dir(&project).args([
+        "config",
+        "user.email",
+        "agtx@example.invalid",
+    ]));
+    run_ok(
+        Command::new("git")
+            .current_dir(&project)
+            .args(["config", "user.name", "agtx test"]),
+    );
+
+    std::fs::write(project.join("base.txt"), "base\n").unwrap();
+    run_ok(
+        Command::new("git")
+            .current_dir(&project)
+            .args(["add", "base.txt"]),
+    );
+    run_ok(
+        Command::new("git")
+            .current_dir(&project)
+            .args(["commit", "-m", "base"]),
+    );
+    run_ok(
+        Command::new("git")
+            .current_dir(&project)
+            .args(["remote", "add", "origin"])
+            .arg(&remote),
+    );
+    run_ok(
+        Command::new("git")
+            .current_dir(&project)
+            .args(["push", "-u", "origin", "main"]),
+    );
+    run_ok(
+        Command::new("git")
+            .args(["clone"])
+            .arg(&remote)
+            .arg(&upstream),
+    );
+    run_ok(Command::new("git").current_dir(&upstream).args([
+        "config",
+        "user.email",
+        "agtx@example.invalid",
+    ]));
+    run_ok(
+        Command::new("git")
+            .current_dir(&upstream)
+            .args(["config", "user.name", "agtx test"]),
+    );
+    run_ok(
+        Command::new("git")
+            .current_dir(&project)
+            .args(["switch", "-c", "feature"]),
+    );
+    std::fs::write(project.join("feature.txt"), "feature\n").unwrap();
+    run_ok(
+        Command::new("git")
+            .current_dir(&project)
+            .args(["add", "feature.txt"]),
+    );
+    run_ok(
+        Command::new("git")
+            .current_dir(&project)
+            .args(["commit", "-m", "feature"]),
+    );
+
+    std::fs::write(upstream.join("upstream-one.txt"), "one\n").unwrap();
+    run_ok(
+        Command::new("git")
+            .current_dir(&upstream)
+            .args(["add", "."]),
+    );
+    run_ok(
+        Command::new("git")
+            .current_dir(&upstream)
+            .args(["commit", "-m", "upstream one"]),
+    );
+    run_ok(
+        Command::new("git")
+            .current_dir(&upstream)
+            .args(["push", "origin", "main"]),
+    );
+    run_ok(
+        Command::new("git")
+            .current_dir(&project)
+            .args(["fetch", "origin"]),
+    );
+    run_ok(
+        Command::new("git")
+            .current_dir(&project)
+            .args(["branch", "-f", "main", "origin/main"]),
+    );
+
+    let project_path = project.canonicalize().unwrap();
+    std::fs::create_dir_all(project_path.join(".agtx")).unwrap();
+    std::env::set_var("AGTX_DATA_DIR", data.path());
+    let db = Database::open_project(&project_path).unwrap();
+    let mut task = Task::new("Git CLI context", "codex", "test-project");
+    task.worktree_path = Some(project_path.to_string_lossy().into_owned());
+    task.branch_name = Some("feature".to_string());
+    task.base_branch = Some("main".to_string());
+    task.vcs = Some(VcsKind::Git);
+    db.create_task(&task).unwrap();
+    std::env::remove_var("AGTX_DATA_DIR");
+
+    let run = |args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_agtx"))
+            .arg("vcs")
+            .args(args)
+            .current_dir(&project_path)
+            .env("AGTX_DATA_DIR", data.path())
+            .env("AGTX_CONFIG_DIR", data.path())
+            .env("AGTX_PROJECT_ROOT", &project_path)
+            .env("AGTX_WORKTREE", &project_path)
+            .env("AGTX_TASK_ID", &task.id)
+            .output()
+            .unwrap()
+    };
+
+    let diff = run(&["diff", "--task"]);
+    assert!(diff.status.success());
+    let diff = String::from_utf8_lossy(&diff.stdout);
+    assert!(diff.contains("feature.txt"), "{diff}");
+    assert!(!diff.contains("upstream-one.txt"), "{diff}");
+
+    std::fs::write(upstream.join("upstream-two.txt"), "two\n").unwrap();
+    run_ok(
+        Command::new("git")
+            .current_dir(&upstream)
+            .args(["add", "."]),
+    );
+    run_ok(
+        Command::new("git")
+            .current_dir(&upstream)
+            .args(["commit", "-m", "upstream two"]),
+    );
+    run_ok(
+        Command::new("git")
+            .current_dir(&upstream)
+            .args(["push", "origin", "main"]),
+    );
+
+    let integrate = run(&["integrate-base", "--fetch"]);
+    assert!(
+        integrate.status.success(),
+        "{}",
+        String::from_utf8_lossy(&integrate.stderr)
+    );
+    assert!(project_path.join("upstream-two.txt").exists());
+
+    let finish = run(&["finish-integration"]);
+    assert!(
+        finish.status.success(),
+        "{}",
+        String::from_utf8_lossy(&finish.stderr)
+    );
+}

--- a/tests/web_tests.rs
+++ b/tests/web_tests.rs
@@ -876,6 +876,11 @@ async fn a_task_can_be_created_edited_and_deleted() {
     assert_eq!(created["title"], "From the phone");
     assert_eq!(created["status"], "backlog");
     let id = created["id"].as_str().unwrap().to_string();
+    let db = Database::open_project(&f.project_path).unwrap();
+    assert_eq!(
+        db.get_task(&id).unwrap().unwrap().vcs,
+        Some(agtx::git::VcsKind::Git)
+    );
 
     let (status, edited) = send(
         state_for(&f, ServeMode::Global),
@@ -896,7 +901,6 @@ async fn a_task_can_be_created_edited_and_deleted() {
     .await;
     assert_eq!(status, StatusCode::OK);
 
-    let db = Database::open_project(&f.project_path).unwrap();
     assert!(db.get_task(&id).unwrap().is_none());
 }
 


### PR DESCRIPTION
Replacement for #50

Status: draft. Still testing locally.

Changes:
- Configure projects with `vcs = "jj"`; no repository auto-detection.
- Always default to git Git when their stored VCS or configuration is absent.
- Persist each task’s VCS, workspace name, and base revision.
- Route TUI, web, MCP, review, conflict, diff, push, and PR workflows through the task’s recorded backend.
- Add `agtx vcs` commands so agent prompts remain VCS-neutral.
- Bake the absolute `agtx` executable path into deployed skills.
- Support colocated and non-colocated JJ repositories.
- Create and clean up task workspaces with `jj workspace`.
- Use isolated JJ operations for non-destructive conflict checks.
- Use fork-point diffs to exclude unrelated upstream changes.

Architecturally I like this a lot better. It should allow for more VCS options in the future (mercurial, sapling, deltadb, etc) with less overall churn.

## Safety

JJ workspace cleanup verifies that the recorded workspace name resolves to the expected path before deleting anything. The project workspace is always preserved.

Conflict probes use:

```text
jj new --no-edit --no-integrate-operation <task> <base>
```

This checks the hypothetical merge without moving or changing the active checkout.

## Configuration

```toml
# .agtx/config.toml
vcs = "jj"
base_branch = "trunk()"
```

Omitting `vcs` continues to mean Git.

## Testing

- `cargo test --features test-mocks`
  - 908 unit tests passed
  - All integration suites passed
- `cargo test --features 'test-mocks serve' --no-run`
- Added coverage for:
  - Explicit backend selection
  - Pure and colocated JJ repositories
  - Workspace creation and safe cleanup
  - Isolated conflict detection
  - Clean conflict-resolution paths
  - Fork-point task diffs
  - Remote-base Git integration
  - VCS-neutral prompt enforcement
  - Absolute binary paths in deployed skills